### PR TITLE
fix(heroku): reverted to docs only install as nerdlet is out of scope for launch

### DIFF
--- a/install/logs/heroku/install.yml
+++ b/install/logs/heroku/install.yml
@@ -8,11 +8,6 @@ target:
   destination: cloud
 
 install:
-  mode: nerdlet
-  destination:
-    nerdletId: instrument-everything-logs.setup-heroku
-
-fallback:
   mode: link
   destination:
     url: https://docs.newrelic.com/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/heroku-log-forwarding/


### PR DESCRIPTION
Reverted Heroku to docs link as we haven't modified the nerdlet yet. 