### PR TITLE
fix: explicitly check `main` during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,6 +192,7 @@ jobs:
         uses: actions/checkout@v2
         # Ensure we have the most recent commit to `main`
         with:
+          ref: 'main'
           fetch-depth: 0
 
       - name: Setup Node.js


### PR DESCRIPTION
## Summary
Ensure we are always on the latest commit of the `main` branch when generating a release