### PR TITLE
chore: update script to reword footer

### DIFF
--- a/utils/schema-doc-generator/script.py
+++ b/utils/schema-doc-generator/script.py
@@ -11,7 +11,7 @@ def reword_footer(file_path):
         for line in f:
             search_string = "Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans)"
             if search_string in line:
-                # this line strips off the timestamp, so the file doesn't all change and get picked up by git
+                # this strips off the timestamp part of the line. this should result in less doc commits since the file should be changing less frequently -- as opposed to every time the action runs.
                 line = "Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans)"
             sys.stdout.write(line)
 

--- a/utils/schema-doc-generator/script.py
+++ b/utils/schema-doc-generator/script.py
@@ -1,8 +1,19 @@
+import fileinput
 import glob
 from pathlib import Path
+import sys
 
 from json_schema_for_humans.generation_configuration import GenerationConfiguration
 from json_schema_for_humans.generate import generate_from_filename
+
+def reword_footer(file_path):
+    with fileinput.input(files=(file_path), inplace=True) as f:
+        for line in f:
+            search_string = "Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans)"
+            if search_string in line:
+                # this line strips off the timestamp, so the file doesn't all change and get picked up by git
+                line = "Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans)"
+            sys.stdout.write(line)
 
 config = GenerationConfiguration(template_name="md", show_toc=False)
 
@@ -13,3 +24,4 @@ for path in schema_paths:
     stem = Path(path).stem
     print(f'generating doc for: {path}')
     generate_from_filename(path, f'docs/{stem}.md', config=config)
+    reword_footer(f'docs/{stem}.md')

--- a/utils/schema-doc-generator/script.py
+++ b/utils/schema-doc-generator/script.py
@@ -11,8 +11,8 @@ def reword_footer(file_path):
         for line in f:
             search_string = "Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans)"
             if search_string in line:
-                # this strips off the timestamp part of the line. this should result in less doc commits since the file should be changing less frequently -- as opposed to every time the action runs.
-                line = "Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans)"
+                # this strips off the timestamp part of the line and should result in less doc commits since the file should be changing less frequently -- as opposed to every time the action runs.
+                line = search_string
             sys.stdout.write(line)
 
 config = GenerationConfiguration(template_name="md", show_toc=False)


### PR DESCRIPTION
## Summary

* previously, generated footer also included a timestamp, which would
indicate to git the file was always changing, despite no meaningful
changes to the schema. Stripped the timestamp off the footer to try
and avoid this. Now, git should only see & commit changes if the schema
changes in some meaningful way.