### PR TITLE
fix: reduce nginx quickstart description length

### DIFF
--- a/quickstarts/nginx/config.yml
+++ b/quickstarts/nginx/config.yml
@@ -14,8 +14,6 @@ description: |
 
   ### New Relic Nginx Quickstart Features
 
-  The New Relic NGINX quickstart has the following features:
-
   - Dashboards: NGINX dashboards proactively monitor NGINX metrics like requests per second, active connections, connections accepted per second, connections dropped per second, etc.
   - Automatic On-host integrations instrumentation
   - Compatible with both NGINX Open Source and NGINX Plus


### PR DESCRIPTION
## Summary

Removed a line of the Nginx quickstart description to fit within the length requirements. The copy was restating the header above it, so I figured that would be fine to remove. 