### PR TITLE
Marked Istio adapter as deprecated

### DIFF
--- a/quickstarts/istio/config.yml
+++ b/quickstarts/istio/config.yml
@@ -1,12 +1,10 @@
 id: 36aa41e3-2d2a-41d7-844a-083f00c5d65e
-name: istio (Deprecated)
+name: istio
 description: |
   Open source service mesh that allows you to connect various services and
   platforms together in a single point.
 summary: >-
-  Use New Relic's Istio adapter to export telemetry data from your Istio instance to your New Relic account.
-
-  NOTE: This adapter requires the Istio Mixer component which was deprecated after Istio v1.7
+  Use New Relic's Istio adapter to export telemetry data from your Istio instance to your New Relic account. NOTE: This adapter requires the Istio Mixer component which was deprecated after Istio v1.7
 
 icon: icon.svg
 logo: logo.svg

--- a/quickstarts/istio/config.yml
+++ b/quickstarts/istio/config.yml
@@ -1,10 +1,13 @@
 id: 36aa41e3-2d2a-41d7-844a-083f00c5d65e
-name: istio
+name: istio (Deprecated)
 description: |
   Open source service mesh that allows you to connect various services and
   platforms together in a single point.
 summary: >-
   Use New Relic's Istio adapter to export telemetry data from your Istio instance to your New Relic account.
+
+  NOTE: This adapter requires the Istio Mixer component which was deprecated after Istio v1.7
+
 icon: icon.svg
 logo: logo.svg
 level: New Relic


### PR DESCRIPTION
# Summary

The Istio adapter linked in Quickstarts is no longer supported and the repo has essentially been abandoned.  Newer versions of Istio do not utilize the Istio Mixer and that component has been deprecated as of Istio v1.7.  Istio is currently at v1.11.3.

## Pre merge checklist

N/A

- [x] Did you check your descriptive content for voice, tone, spelling and grammar errors?

### Screenshots

Attach images of any visual changes, such as a dashboard here.

N/A
