### PR TITLE
Update links in descriptions for cloud integrations

### DIFF
--- a/quickstarts/aws/amazon-athena/config.yml
+++ b/quickstarts/aws/amazon-athena/config.yml
@@ -27,8 +27,7 @@ title: Amazon Athena
 documentation:
   - name: Amazon Athena installation docs
     description: |
-      Serverless, interactive query service to query data and analyze big data
-      in Amazon S3 using standard SQL.
+      Monitor Amazon Athena by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-athena-monitoring-integration
 keywords:

--- a/quickstarts/aws/amazon-athena/config.yml
+++ b/quickstarts/aws/amazon-athena/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Amazon Athena. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-athena-monitoring-integration) to learn more about New Relic monitoring for Amazon Athena. 
 summary: |-
   Monitor Amazon Athena by connecting AWS to New Relic
 icon: icon.svg

--- a/quickstarts/aws/amazon-cloudwatch-metric-streams/config.yml
+++ b/quickstarts/aws/amazon-cloudwatch-metric-streams/config.yml
@@ -1,11 +1,15 @@
 id: 32688a77-f5c8-4a37-9b4b-6f83a66fa4a5
 name: amazon-cloudwatch-metric-streams
 description: |
-  Faster telemetry from Amazon CloudWatch for all AWS Services and custom
-  namespaces without API throttling.
+  ## Why Amazon CloudWatch Metric Streams?
+
+  With New Relic's AWS Metric Streams integration, you only need a single service, AWS CloudWatch, to gather all AWS metrics and custom namespaces and send them to New Relic.
+  
+  ## Get started!
+
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream) to learn more about New Relic monitoring for more than 50 AWS services. 
 summary: |
-  Faster telemetry from Amazon CloudWatch for all AWS Services and custom
-  namespaces without API throttling.
+  Use Amazon CloudWatch to monitor your AWS services with New Relic
 icon: icon.svg
 logo: logo.svg
 level: New Relic

--- a/quickstarts/aws/amazon-documentdb/config.yml
+++ b/quickstarts/aws/amazon-documentdb/config.yml
@@ -27,8 +27,7 @@ title: Amazon DocumentDB
 documentation:
   - name: Amazon DocumentDB installation docs
     description: |
-      Fast, scalable, highly available, and fully managed document database
-      service that supports MongoDB workloads.
+      Monitor Amazon DocumentDB by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-documentdb-monitoring-integration
 keywords:

--- a/quickstarts/aws/amazon-documentdb/config.yml
+++ b/quickstarts/aws/amazon-documentdb/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Amazon DocumentDB. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-documentdb-monitoring-integration) to learn more about New Relic monitoring for Amazon DocumentDB. 
 summary: |-
   Monitor Amazon DocumentDB by connecting AWS to New Relic
 icon: icon.svg

--- a/quickstarts/aws/amazon-linux/config.yml
+++ b/quickstarts/aws/amazon-linux/config.yml
@@ -1,11 +1,16 @@
 id: bede2fa6-1325-4e58-9885-811beecaccad
 name: amazon-linux
 description: |
+  ## What is Amazon Linux?
+  
   Amazon supported and maintained Linux image provided by Amazon Web Services
   for use on Amazon Elastic Compute Cloud.
+
+  ## Get started!
+
+  Choose this quickstart and follow New Relic's guided install process to monitor your Amazon Linux environment.
 summary: |
-  Amazon supported and maintained Linux image provided by Amazon Web Services
-  for use on Amazon Elastic Compute Cloud.
+  Use the New Relic Infrastructure agent to monitor Amazon Linux
 icon: icon.svg
 logo: logo.svg
 level: New Relic
@@ -15,8 +20,7 @@ title: Amazon Linux
 documentation:
   - name: Amazon Linux installation docs
     description: |
-      Amazon supported and maintained Linux image provided by Amazon Web
-      Services for use on Amazon Elastic Compute Cloud.
+      Use the New Relic Infrastructure agent to monitor Amazon Linux.
     url: >-
       https://docs.newrelic.com/docs/infrastructure/install-configure-manage-infrastructure/linux-installation/install-infrastructure-linux-using-package-manager
 keywords:

--- a/quickstarts/aws/amazon-msk/config.yml
+++ b/quickstarts/aws/amazon-msk/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Amazon MSK. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-managed-kafka-msk-integration) to learn more about New Relic monitoring for Amazon MSK. 
 summary: |-
   Monitor Amazon MSK by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Amazon MSK
 documentation:
   - name: Amazon MSK installation docs
     description: |
-      Fully managed service that makes it easy for you to build and run
-      applications that use Apache Kafka to process streaming data.
+      Monitor Amazon MSK by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-managed-kafka-msk-integration
 keywords:

--- a/quickstarts/aws/aws-api-gateway/config.yml
+++ b/quickstarts/aws/aws-api-gateway/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS API Gateway. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-api-gateway-monitoring-integration) to learn more about New Relic monitoring for AWS API Gateway. 
 summary: |-
   Monitor AWS API Gateway by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS API Gateway
 documentation:
   - name: AWS API Gateway installation docs
     description: |
-      Fully managed service for creating, publishing, maintaining, monitoring,
-      and securing APIs at any scale.
+      Monitor AWS API Gateway by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-api-gateway-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-appsync/config.yml
+++ b/quickstarts/aws/aws-appsync/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS AppSync. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-appsync-monitoring-integration) to learn more about New Relic monitoring for AWS AppSync. 
 summary: |-
   Monitor AWS AppSync by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS AppSync
 documentation:
   - name: AWS AppSync installation docs
     description: |
-      Fully managed serverless GraphQL service for real-time data queries,
-      synchronization, communications and offline programming features.
+      Monitor AWS AppSync by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-appsync-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-auto-scaling/config.yml
+++ b/quickstarts/aws/aws-auto-scaling/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS Auto Scaling. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-auto-scaling-monitoring-integration) to learn more about New Relic monitoring for AWS Auto Scaling. 
 summary: |-
   Monitor AWS Auto Scaling by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS Auto Scaling
 documentation:
   - name: AWS Auto Scaling installation docs
     description: |
-      Launch or terminate EC2 instances automatically, adapting capacity based
-      on user-defined policies, schedules, and health checks.
+      Monitor AWS Auto Scaling by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-auto-scaling-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-billing/config.yml
+++ b/quickstarts/aws/aws-billing/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS Billing. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-billing-monitoring-integration) to learn more about New Relic monitoring for AWS Billing. 
 summary: |-
   Monitor AWS Billing by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS Billing
 documentation:
   - name: AWS Billing installation docs
     description: |
-      Service that can be used to pay your AWS bill, monitor your usage, and
-      analyze and control your costs.
+      Monitor AWS Billing by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-billing-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-cloudformation/config.yml
+++ b/quickstarts/aws/aws-cloudformation/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS CloudFormation. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-cloudformation-integration) to learn more about New Relic monitoring for AWS CloudFormation. 
 summary: |-
   Monitor AWS CloudFormation by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS CloudFormation
 documentation:
   - name: AWS CloudFormation installation docs
     description: |
-      Use programming languages or text files to model resources for your
-      applications, then create and duplicate a collection of AWS resources.
+      Monitor AWS CloudFormation by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-cloudformation-integration
 keywords:

--- a/quickstarts/aws/aws-cloudfront/config.yml
+++ b/quickstarts/aws/aws-cloudfront/config.yml
@@ -1,6 +1,6 @@
 id: c6a0f98b-94f3-4f66-9217-83526d7c1afb
 name: aws-cloudfront
-description: "## What is AWS CloudFront?\n\nSpeeds up the distribution of web content served from Amazon Web Services.\n\n### Get started!\n\nStart monitoring AWS CloudFront by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS CloudFront documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS CloudFront. "
+description: "## What is AWS CloudFront?\n\nSpeeds up the distribution of web content served from Amazon Web Services.\n\n### Get started!\n\nStart monitoring AWS CloudFront by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS CloudFront documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-cloudfront-monitoring-integration) to learn more about New Relic monitoring for AWS CloudFront. "
 summary: Monitor AWS CloudFront by connecting AWS to New Relic
 icon: icon.svg
 logo: logo.svg
@@ -10,7 +10,7 @@ authors:
 title: AWS CloudFront
 documentation:
   - name: AWS CloudFront installation docs
-    description: Speeds up the distribution of web content served from Amazon Web Services.
+    description: Monitor AWS CloudFront by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-cloudfront-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-cloudtrail/config.yml
+++ b/quickstarts/aws/aws-cloudtrail/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS CloudTrail. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-cloudtrail-monitoring-integration) to learn more about New Relic monitoring for AWS CloudTrail. 
 summary: |-
   Monitor AWS CloudTrail by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS CloudTrail
 documentation:
   - name: AWS CloudTrail installation docs
     description: |
-      Capture and record AWS account activity and API requests for security or
-      governance purposes.
+      Monitor AWS CloudTrail by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-cloudtrail-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-cognito/config.yml
+++ b/quickstarts/aws/aws-cognito/config.yml
@@ -1,6 +1,6 @@
 id: 70c5611b-51e8-41ca-8659-abc6b0d5c795
 name: aws-cognito
-description: "## What is AWS Cognito?\n\nAdd user account management functionality to your web or mobile application.\n\n### Get started!\n\nStart monitoring AWS Cognito by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS Cognito documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS Cognito. "
+description: "## What is AWS Cognito?\n\nAdd user account management functionality to your web or mobile application.\n\n### Get started!\n\nStart monitoring AWS Cognito by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS Cognito documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/amazon-cognito-monitoring-integration) to learn more about New Relic monitoring for AWS Cognito. "
 summary: Monitor AWS Cognito by connecting AWS to New Relic
 icon: icon.svg
 logo: logo.svg
@@ -11,8 +11,7 @@ title: AWS Cognito
 documentation:
   - name: AWS Cognito installation docs
     description: |
-      Add user account management functionality to your web or mobile
-      application.
+      Monitor AWS Cognito by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/amazon-cognito-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-connect/config.yml
+++ b/quickstarts/aws/aws-connect/config.yml
@@ -1,6 +1,6 @@
 id: ddf0d06c-12c7-4951-9335-ab2c10dbd1c5
 name: aws-connect
-description: "## What is AWS Connect?\n\nBuild cloud-based omnichannel support centers to serve customers dynamically.\n\n### Get started!\n\nStart monitoring AWS Connect by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS Connect documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS Connect. "
+description: "## What is AWS Connect?\n\nBuild cloud-based omnichannel support centers to serve customers dynamically.\n\n### Get started!\n\nStart monitoring AWS Connect by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS Connect documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-connect-monitoring-integration) to learn more about New Relic monitoring for AWS Connect. "
 summary: Monitor AWS Connect by connecting AWS to New Relic
 icon: icon.svg
 logo: logo.svg
@@ -11,8 +11,7 @@ title: AWS Connect
 documentation:
   - name: AWS Connect installation docs
     description: |
-      Build cloud-based omnichannel support centers to serve customers
-      dynamically.
+      Monitor AWS Connect by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-connect-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-direct-connect/config.yml
+++ b/quickstarts/aws/aws-direct-connect/config.yml
@@ -1,6 +1,6 @@
 id: 913f6003-d559-4538-a6b2-9c19a7cc7d46
 name: aws-direct-connect
-description: "## What is AWS Direct Connect?\n\nEstablish a private, secure connection to AWS that runs outside of your ISP.\n\n### Get started!\n\nStart monitoring AWS Direct Connect by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS Direct Connect documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS Direct Connect. "
+description: "## What is AWS Direct Connect?\n\nEstablish a private, secure connection to AWS that runs outside of your ISP.\n\n### Get started!\n\nStart monitoring AWS Direct Connect by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS Direct Connect documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-direct-connect-monitoring-integration) to learn more about New Relic monitoring for AWS Direct Connect. "
 summary: Monitor AWS Direct Connect by connecting AWS to New Relic
 icon: icon.svg
 logo: logo.svg
@@ -11,8 +11,7 @@ title: AWS Direct Connect
 documentation:
   - name: AWS Direct Connect installation docs
     description: |
-      Establish a private, secure connection to AWS that runs outside of your
-      ISP.
+      Monitor AWS Direct Connect by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-direct-connect-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-dynamodb/config.yml
+++ b/quickstarts/aws/aws-dynamodb/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS DynamoDB. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-dynamodb-monitoring-integration) to learn more about New Relic monitoring for AWS DynamoDB. 
 summary: |-
   Monitor AWS DynamoDB by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS DynamoDB
 documentation:
   - name: AWS DynamoDB installation docs
     description: |
-      Fully managed NoSQL cloud database that supports both document and
-      key-value store models.
+      Monitor AWS DynamoDB by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-dynamodb-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-ebs/config.yml
+++ b/quickstarts/aws/aws-ebs/config.yml
@@ -1,6 +1,6 @@
 id: e9aeb0ad-18d2-4e0f-b68b-356ef5788da4
 name: aws-ebs
-description: "## What is AWS EBS?\n\nBlock level storage volumes for Amazon EC2 instances.\n\n### Get started!\n\nStart monitoring AWS EBS by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS EBS documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS EBS. "
+description: "## What is AWS EBS?\n\nBlock level storage volumes for Amazon EC2 instances.\n\n### Get started!\n\nStart monitoring AWS EBS by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS EBS documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-ebs-monitoring-integration) to learn more about New Relic monitoring for AWS EBS. "
 summary: Monitor AWS EBS by connecting AWS to New Relic
 icon: icon.svg
 logo: logo.svg
@@ -10,7 +10,7 @@ authors:
 title: AWS EBS
 documentation:
   - name: AWS EBS installation docs
-    description: Block level storage volumes for Amazon EC2 instances.
+    description: Monitor AWS EBS by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-ebs-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-ec2/config.yml
+++ b/quickstarts/aws/aws-ec2/config.yml
@@ -1,6 +1,6 @@
 id: 4e11966f-04c2-49ca-8815-9e7de8645b1b
 name: aws-ec2
-description: "## What is AWS EC2?\n\nBuild scalable and flexible applications on top of AWS container services.\n\n### Get started!\n\nStart monitoring AWS EC2 by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS EC2 documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS EC2. "
+description: "## What is AWS EC2?\n\nBuild scalable and flexible applications on top of AWS container services.\n\n### Get started!\n\nStart monitoring AWS EC2 by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS EC2 documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-ec2-monitoring-integration) to learn more about New Relic monitoring for AWS EC2. "
 summary: Monitor AWS EC2 by connecting AWS to New Relic
 icon: icon.svg
 logo: logo.svg
@@ -10,7 +10,7 @@ authors:
 title: AWS EC2
 documentation:
   - name: AWS EC2 installation docs
-    description: Build scalable and flexible applications on top of AWS container services.
+    description: Monitor AWS EC2 by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-ec2-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-ecs-ecr/config.yml
+++ b/quickstarts/aws/aws-ecs-ecr/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS ECS/ECR. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-ecsecr-monitoring-integration) to learn more about New Relic monitoring for AWS ECS/ECR. 
 summary: |-
   Monitor AWS ECS/ECR by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS ECS/ECR
 documentation:
   - name: AWS ECS/ECR installation docs
     description: |
-      Fully managed container orchestration service built on AWS with a focus on
-      security, reliability, and scalability.
+      Monitor AWS ECS/ECR by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-ecsecr-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-efs/config.yml
+++ b/quickstarts/aws/aws-efs/config.yml
@@ -1,6 +1,6 @@
 id: 29b8f0ce-b573-48e3-98ab-52e4231d2225
 name: aws-efs
-description: "## What is AWS EFS?\n\nFull managed NFS with support for both AWS and on-prem resources.\n\n### Get started!\n\nStart monitoring AWS EFS by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS EFS documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS EFS. "
+description: "## What is AWS EFS?\n\nFull managed NFS with support for both AWS and on-prem resources.\n\n### Get started!\n\nStart monitoring AWS EFS by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS EFS documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-efs-monitoring-integration) to learn more about New Relic monitoring for AWS EFS. "
 summary: Monitor AWS EFS by connecting AWS to New Relic
 icon: icon.svg
 logo: logo.svg
@@ -10,7 +10,7 @@ authors:
 title: AWS EFS
 documentation:
   - name: AWS EFS installation docs
-    description: Full managed NFS with support for both AWS and on-prem resources.
+    description: Monitor AWS EFS by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-efs-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-elastic-beanstalk/config.yml
+++ b/quickstarts/aws/aws-elastic-beanstalk/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS Elastic Beanstalk. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-elastic-beanstalk-monitoring-integration) to learn more about New Relic monitoring for AWS Elastic Beanstalk. 
 summary: |-
   Monitor AWS Elastic Beanstalk by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS Elastic Beanstalk
 documentation:
   - name: AWS Elastic Beanstalk installation docs
     description: |
-      Dynamic service that allows easy deployment and scalability for your
-      applications on AWS.
+      Monitor AWS Elastic Beanstalk by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-elastic-beanstalk-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-elasticache/config.yml
+++ b/quickstarts/aws/aws-elasticache/config.yml
@@ -1,6 +1,6 @@
 id: 5c1e7b31-df21-4acb-b72c-0a8786b88301
 name: aws-elasticache
-description: "## What is AWS ElastiCache?\n\nDeploy, operate, and scale an in-memory data store or cache in the cloud.\n\n### Get started!\n\nStart monitoring AWS ElastiCache by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS ElastiCache documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS ElastiCache. "
+description: "## What is AWS ElastiCache?\n\nDeploy, operate, and scale an in-memory data store or cache in the cloud.\n\n### Get started!\n\nStart monitoring AWS ElastiCache by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS ElastiCache documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-elasticache-monitoring-integration) to learn more about New Relic monitoring for AWS ElastiCache. "
 summary: Monitor AWS ElastiCache by connecting AWS to New Relic
 icon: icon.svg
 logo: logo.svg
@@ -10,7 +10,7 @@ authors:
 title: AWS ElastiCache
 documentation:
   - name: AWS ElastiCache installation docs
-    description: Deploy, operate, and scale an in-memory data store or cache in the cloud.
+    description: Monitor AWS ElastiCache by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-elasticache-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-elasticsearch/config.yml
+++ b/quickstarts/aws/aws-elasticsearch/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS Elasticsearch. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/elasticsearch-monitoring-integration) to learn more about New Relic monitoring for AWS Elasticsearch. 
 summary: |-
   Monitor AWS Elasticsearch by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS Elasticsearch
 documentation:
   - name: AWS Elasticsearch installation docs
     description: |
-      Fully managed services for deploying and managing Elasticsearch
-      implementations on AWS.
+      Monitor AWS Elasticsearch by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/elasticsearch-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-elb/config.yml
+++ b/quickstarts/aws/aws-elb/config.yml
@@ -1,6 +1,6 @@
 id: ceb7f12e-fc9c-48c8-8fa8-a6d353c5f751
 name: aws-elb
-description: "## What is AWS ELB?\n\nAutomatically redirect incoming web traffic to balance load when demand rises.\n\n### Get started!\n\nStart monitoring AWS ELB by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS ELB documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS ELB. "
+description: "## What is AWS ELB?\n\nAutomatically redirect incoming web traffic to balance load when demand rises.\n\n### Get started!\n\nStart monitoring AWS ELB by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS ELB documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-elb-classic-monitoring-integration) to learn more about New Relic monitoring for AWS ELB. "
 summary: Monitor AWS ELB by connecting AWS to New Relic
 icon: icon.svg
 logo: logo.svg
@@ -11,8 +11,7 @@ title: AWS ELB
 documentation:
   - name: AWS ELB installation docs
     description: |
-      Automatically redirect incoming web traffic to balance load when demand
-      rises.
+      Monitor AWS ELB by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-elb-classic-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-elemental-mediapackage-vod/config.yml
+++ b/quickstarts/aws/aws-elemental-mediapackage-vod/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS Elemental MediaPackage VOD. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-elemental-mediapackage-vod-monitoring-integration) to learn more about New Relic monitoring for AWS Elemental MediaPackage VOD. 
 summary: |-
   Monitor AWS Elemental MediaPackage VOD by connecting AWS to New Relic
 icon: ''
@@ -27,8 +27,7 @@ title: AWS Elemental MediaPackage VOD
 documentation:
   - name: AWS Elemental MediaPackage VOD installation docs
     description: |
-      Collect AWS MediaPackage VOD data for PackagingConfiguration. Maintained
-      by Amazon.
+      Monitor AWS Elemental MediaPackage VOD by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-elemental-mediapackage-vod-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-emr/config.yml
+++ b/quickstarts/aws/aws-emr/config.yml
@@ -1,6 +1,6 @@
 id: d84051ba-365f-4542-8db9-0829384ea55a
 name: aws-emr
-description: "## What is AWS EMR?\n\nProcess and manage big data inputs from popular frameworks.\n\n### Get started!\n\nStart monitoring AWS EMR by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS EMR documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS EMR. "
+description: "## What is AWS EMR?\n\nProcess and manage big data inputs from popular frameworks.\n\n### Get started!\n\nStart monitoring AWS EMR by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS EMR documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-emr-monitoring-integration) to learn more about New Relic monitoring for AWS EMR. "
 summary: Monitor AWS EMR by connecting AWS to New Relic
 icon: icon.svg
 logo: logo.svg
@@ -10,7 +10,7 @@ authors:
 title: AWS EMR
 documentation:
   - name: AWS EMR installation docs
-    description: Process and manage big data inputs from popular frameworks.
+    description: Monitor AWS EMR by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-emr-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-fsx/config.yml
+++ b/quickstarts/aws/aws-fsx/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS FSx. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-fsx-monitoring-integration) to learn more about New Relic monitoring for AWS FSx. 
 summary: |-
   Monitor AWS FSx by connecting AWS to New Relic
 icon: ''
@@ -27,8 +27,7 @@ title: AWS FSx
 documentation:
   - name: AWS FSx installation docs
     description: |
-      Collect AWS FSx data for WindowsFileServer; change polling frequency and
-      filter data using configuration options. Maintained by Amazon.
+      Monitor AWS FSx by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-fsx-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-glue/config.yml
+++ b/quickstarts/aws/aws-glue/config.yml
@@ -1,6 +1,6 @@
 id: 6f4ca9e9-5b33-4073-b609-948bd59da406
 name: aws-glue
-description: "## What is AWS Glue?\n\nFully managed service for data analytics and ETF operations.\n\n### Get started!\n\nStart monitoring AWS Glue by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS Glue documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS Glue. "
+description: "## What is AWS Glue?\n\nFully managed service for data analytics and ETF operations.\n\n### Get started!\n\nStart monitoring AWS Glue by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS Glue documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-glue-monitoring-integration) to learn more about New Relic monitoring for AWS Glue. "
 summary: Monitor AWS Glue by connecting AWS to New Relic
 icon: icon.svg
 logo: logo.svg
@@ -10,7 +10,7 @@ authors:
 title: AWS Glue
 documentation:
   - name: AWS Glue installation docs
-    description: Fully managed service for data analytics and ETF operations.
+    description: Monitor AWS Glue by connecting AWS to New Relic
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-glue-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-health/config.yml
+++ b/quickstarts/aws/aws-health/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS Health. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-health-monitoring-integration) to learn more about New Relic monitoring for AWS Health. 
 summary: |-
   Monitor AWS Health by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS Health
 documentation:
   - name: AWS Health installation docs
     description: |
-      Oversight and alerts for how AWS outages and maintenance may affect your
-      services.
+      Monitor AWS Health by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-health-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-iam/config.yml
+++ b/quickstarts/aws/aws-iam/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS IAM. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-iam-monitoring-integration) to learn more about New Relic monitoring for AWS IAM. 
 summary: |-
   Monitor AWS IAM by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS IAM
 documentation:
   - name: AWS IAM installation docs
     description: |
-      Securely control access to AWS services and resources, create and manage
-      users, groups, and permissions.
+      Monitor AWS IAM by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-iam-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-iot/config.yml
+++ b/quickstarts/aws/aws-iot/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS IoT. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-iot-monitoring-integration) to learn more about New Relic monitoring for AWS IoT. 
 summary: |-
   Monitor AWS IoT by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS IoT
 documentation:
   - name: AWS IoT installation docs
     description: |
-      Provides communication and collects telemetry data between
-      Internet-connected devices and the AWS Cloud.
+      Monitor AWS IoT by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-iot-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-kinesis-data-firehose/config.yml
+++ b/quickstarts/aws/aws-kinesis-data-firehose/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS Kinesis Data Firehose. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-kinesis-data-firehose-monitoring-integration) to learn more about New Relic monitoring for AWS Kinesis Data Firehose. 
 summary: |-
   Monitor AWS Kinesis Data Firehose by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS Kinesis Data Firehose
 documentation:
   - name: AWS Kinesis Data Firehose installation docs
     description: |
-      Capture, transform, and load streaming data into various Amazon Web
-      Services, enabling near real-time analytics.
+      Monitor AWS Kinesis Data Firehose by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-kinesis-data-firehose-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-kinesis-data-streams/config.yml
+++ b/quickstarts/aws/aws-kinesis-data-streams/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS Kinesis Data Streams. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-kinesis-data-streams-monitoring-integration) to learn more about New Relic monitoring for AWS Kinesis Data Streams. 
 summary: |-
   Monitor AWS Kinesis Data Streams by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS Kinesis Data Streams
 documentation:
   - name: AWS Kinesis Data Streams installation docs
     description: |
-      Platform for streaming data on AWS, making it easy to load and analyze
-      data in real time and build applications for specialized needs.
+      Monitor AWS Kinesis Data Streams by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-kinesis-data-streams-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-lambda/config.yml
+++ b/quickstarts/aws/aws-lambda/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS Lambda. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-lambda-monitoring-integration) to learn more about New Relic monitoring for AWS Lambda. 
 summary: |-
   Monitor AWS Lambda by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS Lambda
 documentation:
   - name: AWS Lambda installation docs
     description: |
-      Zero-administration compute platform for back-end web developers that runs
-      your code for you in AWS cloud.
+      Monitor AWS Lambda by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-lambda-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-mq/config.yml
+++ b/quickstarts/aws/aws-mq/config.yml
@@ -1,6 +1,6 @@
 id: 73de5982-8f59-4d2d-a90a-4838414d3304
 name: aws-mq
-description: "## What is AWS MQ?\n\nMessage brokering service for Apache ActiveMQ managed by AWS.\n\n### Get started!\n\nStart monitoring AWS MQ by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS MQ documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS MQ. "
+description: "## What is AWS MQ?\n\nMessage brokering service for Apache ActiveMQ managed by AWS.\n\n### Get started!\n\nStart monitoring AWS MQ by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS MQ documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-mq-integration) to learn more about New Relic monitoring for AWS MQ. "
 summary: Monitor AWS MQ by connecting AWS to New Relic
 icon: icon.svg
 logo: logo.svg
@@ -10,7 +10,7 @@ authors:
 title: AWS MQ
 documentation:
   - name: AWS MQ installation docs
-    description: Message brokering service for Apache ActiveMQ managed by AWS.
+    description: Monitor AWS MQ by connecting AWS to New Relic
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-mq-integration
 keywords:

--- a/quickstarts/aws/aws-neptunedb/config.yml
+++ b/quickstarts/aws/aws-neptunedb/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS NeptuneDB. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-neptune-monitoring-integration) to learn more about New Relic monitoring for AWS NeptuneDB. 
 summary: |-
   Monitor AWS NeptuneDB by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS NeptuneDB
 documentation:
   - name: AWS NeptuneDB installation docs
     description: |
-      Develop applications on top of interconnected datasets with this AWS graph
-      database service.
+      Monitor AWS NeptuneDB by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-neptune-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-nlb-alb/config.yml
+++ b/quickstarts/aws/aws-nlb-alb/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS NLB/ALB. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-albnlb-monitoring-integration) to learn more about New Relic monitoring for AWS NLB/ALB. 
 summary: |-
   Monitor AWS NLB/ALB by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS NLB/ALB
 documentation:
   - name: AWS NLB/ALB installation docs
     description: |
-      Distributes incoming application traffic across multiple targets, such as
-      EC2 instances, in multiple availability zones.
+      Monitor AWS NLB/ALB by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-albnlb-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-outposts/config.yml
+++ b/quickstarts/aws/aws-outposts/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS Outposts. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/get-started/introduction-aws-integrations) to learn more about New Relic monitoring for AWS Outposts. 
 summary: |-
   Monitor AWS Outposts by connecting AWS to New Relic
 icon: ''
@@ -27,8 +27,7 @@ title: AWS Outposts
 documentation:
   - name: AWS Outposts installation docs
     description: |
-      An introduction to AWS integrations on New Relic One. Use the Amazon
-      CloudWatch API to obtain metrics from the AWS services you monitor.
+      Monitor AWS Outposts by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/get-started/introduction-aws-integrations
 keywords:

--- a/quickstarts/aws/aws-qldb/config.yml
+++ b/quickstarts/aws/aws-qldb/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS QLDB. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-qldb-monitoring-integration) to learn more about New Relic monitoring for AWS QLDB. 
 summary: |-
   Monitor AWS QLDB by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS QLDB
 documentation:
   - name: AWS QLDB installation docs
     description: |
-      Create a cryptographically verifiable ledger database that's managed by
-      one group.
+      Monitor AWS QLDB by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-qldb-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-rds-enhanced/config.yml
+++ b/quickstarts/aws/aws-rds-enhanced/config.yml
@@ -1,6 +1,6 @@
 id: 998141b4-32dd-4c6b-a550-4e0d74faacf3
 name: aws-rds-enhanced
-description: "## What is AWS RDS Enhanced?\n\nSupplement your RDS monitoring with real-time metrics about the OS.\n\n### Get started!\n\nStart monitoring AWS RDS Enhanced by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS RDS Enhanced documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS RDS Enhanced. "
+description: "## What is AWS RDS Enhanced?\n\nSupplement your RDS monitoring with real-time metrics about the OS.\n\n### Get started!\n\nStart monitoring AWS RDS Enhanced by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS RDS Enhanced documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-rds-enhanced-monitoring-integration) to learn more about New Relic monitoring for AWS RDS Enhanced. "
 summary: Monitor AWS RDS Enhanced by connecting AWS to New Relic
 icon: icon.svg
 logo: logo.svg
@@ -10,7 +10,7 @@ authors:
 title: AWS RDS Enhanced
 documentation:
   - name: AWS RDS Enhanced installation docs
-    description: Supplement your RDS monitoring with real-time metrics about the OS.
+    description: Monitor AWS RDS Enhanced by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-rds-enhanced-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-rds/config.yml
+++ b/quickstarts/aws/aws-rds/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS RDS. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-rds-monitoring-integration) to learn more about New Relic monitoring for AWS RDS. 
 summary: |-
   Monitor AWS RDS by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS RDS
 documentation:
   - name: AWS RDS installation docs
     description: |
-      Set up and manage a relational database in the cloud by providing
-      resizable capacity and managing common database administration tasks.
+      Monitor AWS RDS by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-rds-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-redshift/config.yml
+++ b/quickstarts/aws/aws-redshift/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS Redshift. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-redshift-integration) to learn more about New Relic monitoring for AWS Redshift. 
 summary: |-
   Monitor AWS Redshift by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS Redshift
 documentation:
   - name: AWS Redshift installation docs
     description: |
-      Fully managed data warehouse used to analyze all your data using standard
-      SQL and your existing Amazon Business Intelligence tools.
+      Monitor AWS Redshift by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-redshift-integration
 keywords:

--- a/quickstarts/aws/aws-route-53/config.yml
+++ b/quickstarts/aws/aws-route-53/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS Route 53. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-route-53-monitoring-integration) to learn more about New Relic monitoring for AWS Route 53. 
 summary: |-
   Monitor AWS Route 53 by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS Route 53
 documentation:
   - name: AWS Route 53 installation docs
     description: |
-      Register domain names, route Internet traffic to the appropriate
-      resources, and check the health of your web app’s resources.
+      Monitor AWS Route 53 by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-route-53-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-route53-resolver/config.yml
+++ b/quickstarts/aws/aws-route53-resolver/config.yml
@@ -1,6 +1,6 @@
 id: 91a052fe-cb0f-4b98-ae79-56d61abef5ec
 name: aws-route53-resolver
-description: "## What is AWS Route53 Resolver?\n\nCreate and configure endpoints in AWS Route 53.\n\n### Get started!\n\nStart monitoring AWS Route53 Resolver by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS Route53 Resolver documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS Route53 Resolver. "
+description: "## What is AWS Route53 Resolver?\n\nCreate and configure endpoints in AWS Route 53.\n\n### Get started!\n\nStart monitoring AWS Route53 Resolver by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS Route53 Resolver documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-route53-resolver-monitoring-integration) to learn more about New Relic monitoring for AWS Route53 Resolver. "
 summary: Monitor AWS Route53 Resolver by connecting AWS to New Relic
 icon: icon.svg
 logo: logo.svg
@@ -10,7 +10,7 @@ authors:
 title: AWS Route53 Resolver
 documentation:
   - name: AWS Route53 Resolver installation docs
-    description: Create and configure endpoints in AWS Route 53.
+    description: Monitor AWS Route53 Resolver by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-route53-resolver-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-s3/config.yml
+++ b/quickstarts/aws/aws-s3/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS S3. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-s3-monitoring-integration) to learn more about New Relic monitoring for AWS S3. 
 summary: |-
   Monitor AWS S3 by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS S3
 documentation:
   - name: AWS S3 installation docs
     description: |
-      Provides developers and IT teams with secure, durable, highly-scalable
-      cloud storage.
+      Monitor AWS S3 by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-s3-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-ses/config.yml
+++ b/quickstarts/aws/aws-ses/config.yml
@@ -1,6 +1,6 @@
 id: 4d72d691-d338-4b53-9dbf-97c5030db09e
 name: aws-ses
-description: "## What is AWS SES?\n\nCloud-based service for sending and receiving email.\n\n### Get started!\n\nStart monitoring AWS SES by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS SES documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS SES. "
+description: "## What is AWS SES?\n\nCloud-based service for sending and receiving email.\n\n### Get started!\n\nStart monitoring AWS SES by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS SES documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-simple-email-service-ses-monitoring-integration) to learn more about New Relic monitoring for AWS SES. "
 summary: Monitor AWS SES by connecting AWS to New Relic
 icon: icon.svg
 logo: logo.svg

--- a/quickstarts/aws/aws-sns/config.yml
+++ b/quickstarts/aws/aws-sns/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS SNS. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-sns-monitoring-integration) to learn more about New Relic monitoring for AWS SNS. 
 summary: |-
   Monitor AWS SNS by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS SNS
 documentation:
   - name: AWS SNS installation docs
     description: |
-      Fully managed push notification service compatible with pub/sub, SMS,
-      email, and mobile.
+      Monitor AWS SNS by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-sns-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-sqs/config.yml
+++ b/quickstarts/aws/aws-sqs/config.yml
@@ -1,6 +1,6 @@
 id: ef58d468-bcee-4a66-a641-8ff5453b5363
 name: aws-sqs
-description: "## What is AWS SQS?\n\nProvides fully managed, hosted queues for storing messages in transit.\n\n### Get started!\n\nStart monitoring AWS SQS by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS SQS documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS SQS. "
+description: "## What is AWS SQS?\n\nProvides fully managed, hosted queues for storing messages in transit.\n\n### Get started!\n\nStart monitoring AWS SQS by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS SQS documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-sqs-monitoring-integration) to learn more about New Relic monitoring for AWS SQS. "
 summary: Monitor AWS SQS by connecting AWS to New Relic
 icon: icon.svg
 logo: logo.svg
@@ -10,7 +10,7 @@ authors:
 title: AWS SQS
 documentation:
   - name: AWS SQS installation docs
-    description: Provides fully managed, hosted queues for storing messages in transit.
+    description: Monitor AWS SQS by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-sqs-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-step-functions/config.yml
+++ b/quickstarts/aws/aws-step-functions/config.yml
@@ -1,6 +1,6 @@
 id: 7a864c4a-5005-4419-a729-3da92426b49a
 name: aws-step-functions
-description: "## What is AWS Step Functions?\n\nOrchestrate serverless functions in Amazon Web Services, including Lambda.\n\n### Get started!\n\nStart monitoring AWS Step Functions by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS Step Functions documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS Step Functions. "
+description: "## What is AWS Step Functions?\n\nOrchestrate serverless functions in Amazon Web Services, including Lambda.\n\n### Get started!\n\nStart monitoring AWS Step Functions by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS Step Functions documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-step-functions-monitoring-integration) to learn more about New Relic monitoring for AWS Step Functions. "
 summary: Monitor AWS Step Functions by connecting AWS to New Relic
 icon: icon.svg
 logo: logo.svg
@@ -10,7 +10,7 @@ authors:
 title: AWS Step Functions
 documentation:
   - name: AWS Step Functions installation docs
-    description: Orchestrate serverless functions in Amazon Web Services, including Lambda.
+    description: Monitor AWS Step Functions by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-step-functions-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-transitgateway/config.yml
+++ b/quickstarts/aws/aws-transitgateway/config.yml
@@ -1,6 +1,6 @@
 id: a77fc65d-c2a3-4025-94b6-4af11ec82739
 name: aws-transitgateway
-description: "## What is AWS TransitGateway?\n\nCollate VPC and on-premises resources through a central gateway.\n\n### Get started!\n\nStart monitoring AWS TransitGateway by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS TransitGateway documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS TransitGateway. "
+description: "## What is AWS TransitGateway?\n\nCollate VPC and on-premises resources through a central gateway.\n\n### Get started!\n\nStart monitoring AWS TransitGateway by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS TransitGateway documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/amazon-transit-gateway-monitoring-integration) to learn more about New Relic monitoring for AWS TransitGateway. "
 summary: Monitor AWS TransitGateway by connecting AWS to New Relic
 icon: icon.svg
 logo: logo.svg
@@ -10,7 +10,7 @@ authors:
 title: AWS TransitGateway
 documentation:
   - name: AWS TransitGateway installation docs
-    description: Collate VPC and on-premises resources through a central gateway.
+    description: Monitor AWS TransitGateway by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/amazon-transit-gateway-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-trusted-advisor/config.yml
+++ b/quickstarts/aws/aws-trusted-advisor/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS Trusted Advisor. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-trusted-advisor-integration) to learn more about New Relic monitoring for AWS Trusted Advisor. 
 summary: |-
   Monitor AWS Trusted Advisor by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS Trusted Advisor
 documentation:
   - name: AWS Trusted Advisor installation docs
     description: |
-      Online tool that provides real-time guidance to help you follow AWS best
-      practices for provisioning your resources.
+      Monitor AWS Trusted Advisor by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-trusted-advisor-integration
 keywords:

--- a/quickstarts/aws/aws-vpc-flow-logs/config.yml
+++ b/quickstarts/aws/aws-vpc-flow-logs/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS VPC Flow Logs. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-vpc-flow-logs-monitoring-integration) to learn more about New Relic monitoring for AWS VPC Flow Logs. 
 summary: |-
   Monitor AWS VPC Flow Logs by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS VPC Flow Logs
 documentation:
   - name: AWS VPC Flow Logs installation docs
     description: |
-      Enables you to capture information about the IP traffic going to and from
-      network interfaces in your AWS VPC.
+      Monitor AWS VPC Flow Logs by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-vpc-flow-logs-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-vpc/config.yml
+++ b/quickstarts/aws/aws-vpc/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS VPC. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-vpc-monitoring-integration) to learn more about New Relic monitoring for AWS VPC. 
 summary: |-
   Monitor AWS VPC by connecting AWS to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: AWS VPC
 documentation:
   - name: AWS VPC installation docs
     description: |
-      Virtual network that leverages AWS to gain visibility into configuration
-      event changes that are overlaid across your Amazon services.
+      Monitor AWS VPC by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-vpc-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-waf/config.yml
+++ b/quickstarts/aws/aws-waf/config.yml
@@ -1,6 +1,6 @@
 id: 8aa3f09f-63ad-416f-b505-b377ad88ff06
 name: aws-waf
-description: "## What is AWS WAF?\n\nSecure web traffic with a firewall built on top of Amazon Web Services.\n\n### Get started!\n\nStart monitoring AWS WAF by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS WAF documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS WAF. "
+description: "## What is AWS WAF?\n\nSecure web traffic with a firewall built on top of Amazon Web Services.\n\n### Get started!\n\nStart monitoring AWS WAF by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS WAF documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-waf-monitoring-integration) to learn more about New Relic monitoring for AWS WAF. "
 summary: Monitor AWS WAF by connecting AWS to New Relic
 icon: icon.svg
 logo: logo.svg
@@ -10,7 +10,7 @@ authors:
 title: AWS WAF
 documentation:
   - name: AWS WAF installation docs
-    description: Secure web traffic with a firewall built on top of Amazon Web Services.
+    description: Monitor AWS WAF by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-waf-monitoring-integration
 keywords:

--- a/quickstarts/aws/aws-x-ray/config.yml
+++ b/quickstarts/aws/aws-x-ray/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for AWS X-Ray. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-x-ray-monitoring-integration) to learn more about New Relic monitoring for AWS X-Ray. 
 summary: |-
   Monitor AWS X-Ray by connecting AWS to New Relic
 icon: ''
@@ -27,8 +27,7 @@ title: AWS X-Ray
 documentation:
   - name: AWS X-Ray installation docs
     description: |
-      Capture data and debug protection for applications built on distributed
-      frameworks.
+      Monitor AWS X-Ray by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-x-ray-monitoring-integration
 keywords:

--- a/quickstarts/azure/azure-api-management/config.yml
+++ b/quickstarts/azure/azure-api-management/config.yml
@@ -1,6 +1,6 @@
 id: 86047b47-5628-4c80-8202-03ebd3133357
 name: azure-api-management
-description: "## What is Azure API Management?\n\nComplete API management platform built for multi-cloud environments.\n\n### Get started!\n\nStart monitoring Azure API Management by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure API Management documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Azure API Management. "
+description: "## What is Azure API Management?\n\nComplete API management platform built for multi-cloud environments.\n\n### Get started!\n\nStart monitoring Azure API Management by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure API Management documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-api-management-monitoring-integration) to learn more about New Relic monitoring for Azure API Management. "
 summary: Monitor Azure API Management by connecting Azure to New Relic
 icon: icon.svg
 logo: logo.svg
@@ -10,7 +10,7 @@ authors:
 title: Azure API Management
 documentation:
   - name: Azure API Management installation docs
-    description: Complete API management platform built for multi-cloud environments.
+    description: Monitor Azure API Management by connecting Azure to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-api-management-monitoring-integration
 keywords:

--- a/quickstarts/azure/azure-app-service/config.yml
+++ b/quickstarts/azure/azure-app-service/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Azure App Service. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-app-service-monitoring-integration) to learn more about New Relic monitoring for Azure App Service. 
 summary: |-
   Monitor Azure App Service by connecting Azure to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Azure App Service
 documentation:
   - name: Azure App Service installation docs
     description: |
-      Service for hosting and running web applications, REST APIs, and mobile
-      back ends in a fully managed platform.
+      Monitor Azure App Service by connecting Azure to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-app-service-monitoring-integration
 keywords:

--- a/quickstarts/azure/azure-containers/config.yml
+++ b/quickstarts/azure/azure-containers/config.yml
@@ -1,6 +1,6 @@
 id: fde01772-978b-40c4-9339-51f57c6f60a8
 name: azure-containers
-description: "## What is Azure Containers?\n\nFramework for building and running microservice applications on Azure.\n\n### Get started!\n\nStart monitoring Azure Containers by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure Containers documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Azure Containers. "
+description: "## What is Azure Containers?\n\nFramework for building and running microservice applications on Azure.\n\n### Get started!\n\nStart monitoring Azure Containers by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure Containers documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-containers-monitoring-integration) to learn more about New Relic monitoring for Azure Containers. "
 summary: Monitor Azure Containers by connecting Azure to New Relic
 icon: icon.svg
 logo: logo.svg
@@ -10,7 +10,7 @@ authors:
 title: Azure Containers
 documentation:
   - name: Azure Containers installation docs
-    description: Framework for building and running microservice applications on Azure.
+    description: Monitor Azure Containers by connecting Azure to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-containers-monitoring-integration
 keywords:

--- a/quickstarts/azure/azure-cosmos-db/config.yml
+++ b/quickstarts/azure/azure-cosmos-db/config.yml
@@ -1,6 +1,6 @@
 id: 81c38d53-5931-4fbc-9288-57c2c84cb1fd
 name: azure-cosmos-db
-description: "## What is Azure Cosmos DB?\n\nQuickly and easily scale your database traffic across multiple Azure regions.\n\n### Get started!\n\nStart monitoring Azure Cosmos DB by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure Cosmos DB documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Azure Cosmos DB. "
+description: "## What is Azure Cosmos DB?\n\nQuickly and easily scale your database traffic across multiple Azure regions.\n\n### Get started!\n\nStart monitoring Azure Cosmos DB by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure Cosmos DB documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-cosmos-db-document-db-monitoring-integration) to learn more about New Relic monitoring for Azure Cosmos DB. "
 summary: Monitor Azure Cosmos DB by connecting Azure to New Relic
 icon: icon.svg
 logo: logo.svg
@@ -11,8 +11,7 @@ title: Azure Cosmos DB
 documentation:
   - name: Azure Cosmos DB installation docs
     description: |
-      Quickly and easily scale your database traffic across multiple Azure
-      regions.
+      Monitor Azure Cosmos DB by connecting Azure to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-cosmos-db-document-db-monitoring-integration
 keywords:

--- a/quickstarts/azure/azure-cost-management/config.yml
+++ b/quickstarts/azure/azure-cost-management/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Azure Cost Management. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-cost-management-monitoring-integration) to learn more about New Relic monitoring for Azure Cost Management. 
 summary: |-
   Monitor Azure Cost Management by connecting Azure to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Azure Cost Management
 documentation:
   - name: Azure Cost Management installation docs
     description: |
-      Monitor billing, manage subscriptions, and optimize spending across your
-      Azure services.
+      Monitor Azure Cost Management by connecting Azure to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-cost-management-monitoring-integration
 keywords:

--- a/quickstarts/azure/azure-datafactories/config.yml
+++ b/quickstarts/azure/azure-datafactories/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Azure DataFactories. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-data-factory-integration) to learn more about New Relic monitoring for Azure DataFactories. 
 summary: |-
   Monitor Azure DataFactories by connecting Azure to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Azure DataFactories
 documentation:
   - name: Azure DataFactories installation docs
     description: |
-      Visual environment for creating and processing ETL operations from
-      multiple data sources.
+      Monitor Azure DataFactories by connecting Azure to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-data-factory-integration
 keywords:

--- a/quickstarts/azure/azure-event-hubs/config.yml
+++ b/quickstarts/azure/azure-event-hubs/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Azure Event Hubs. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-event-hub-monitoring-integration) to learn more about New Relic monitoring for Azure Event Hubs. 
 summary: |-
   Monitor Azure Event Hubs by connecting Azure to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Azure Event Hubs
 documentation:
   - name: Azure Event Hubs installation docs
     description: |
-      Collect and centralize real-time streaming data into a central cloud-based
-      pipeline.
+      Monitor Azure Event Hubs by connecting Azure to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-event-hub-monitoring-integration
 keywords:

--- a/quickstarts/azure/azure-express-route/config.yml
+++ b/quickstarts/azure/azure-express-route/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Azure Express Route. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-express-route-monitoring-integration) to learn more about New Relic monitoring for Azure Express Route. 
 summary: |-
   Monitor Azure Express Route by connecting Azure to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Azure Express Route
 documentation:
   - name: Azure Express Route installation docs
     description: |
-      Create a dedicated connection between your on-prem infrastructure and
-      Azure's services.
+      Monitor Azure Express Route by connecting Azure to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-express-route-monitoring-integration
 keywords:

--- a/quickstarts/azure/azure-front-door/config.yml
+++ b/quickstarts/azure/azure-front-door/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Azure Front Door. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-front-door-monitoring-integration) to learn more about New Relic monitoring for Azure Front Door. 
 summary: |-
   Monitor Azure Front Door by connecting Azure to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Azure Front Door
 documentation:
   - name: Azure Front Door installation docs
     description: |
-      Azure service for creating rules and redirecting your incoming web
-      traffic’s global routing.
+      Monitor Azure Front Door by connecting Azure to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-front-door-monitoring-integration
 keywords:

--- a/quickstarts/azure/azure-functions/config.yml
+++ b/quickstarts/azure/azure-functions/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Azure Functions. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-functions-monitoring-integration) to learn more about New Relic monitoring for Azure Functions. 
 summary: |-
   Monitor Azure Functions by connecting Azure to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Azure Functions
 documentation:
   - name: Azure Functions installation docs
     description: |
-      Event-driven serverless compute platform that enables you to build locally
-      and deploy on the cloud.
+      Monitor Azure Functions by connecting Azure to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-functions-monitoring-integration
 keywords:

--- a/quickstarts/azure/azure-load-balancer/config.yml
+++ b/quickstarts/azure/azure-load-balancer/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Azure Load Balancer. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-load-balancer-monitoring-integration) to learn more about New Relic monitoring for Azure Load Balancer. 
 summary: |-
   Monitor Azure Load Balancer by connecting Azure to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Azure Load Balancer
 documentation:
   - name: Azure Load Balancer installation docs
     description: |
-      Watches incoming TCP and UDP traffic from different services, and uses
-      health to distribute those requests across different instances.
+      Monitor Azure Load Balancer by connecting Azure to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-load-balancer-monitoring-integration
 keywords:

--- a/quickstarts/azure/azure-logic-apps/config.yml
+++ b/quickstarts/azure/azure-logic-apps/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Azure Logic Apps. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-logic-apps-monitoring-integration) to learn more about New Relic monitoring for Azure Logic Apps. 
 summary: |-
   Monitor Azure Logic Apps by connecting Azure to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Azure Logic Apps
 documentation:
   - name: Azure Logic Apps installation docs
     description: |
-      Scalable workflows, business processes, and enterprise orchestrations for
-      apps and data across cloud services and on-prem systems.
+      Monitor Azure Logic Apps by connecting Azure to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-logic-apps-monitoring-integration
 keywords:

--- a/quickstarts/azure/azure-machine-learning-services/config.yml
+++ b/quickstarts/azure/azure-machine-learning-services/config.yml
@@ -1,6 +1,6 @@
 id: 4022bc8b-c395-424e-9073-7d4174910da7
 name: azure-machine-learning-services
-description: "## What is Azure Machine Learning Services?\n\nBuild and manage machine-learning applications on Azure.\n\n### Get started!\n\nStart monitoring Azure Machine Learning Services by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure Machine Learning Services documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Azure Machine Learning Services. "
+description: "## What is Azure Machine Learning Services?\n\nBuild and manage machine-learning applications on Azure.\n\n### Get started!\n\nStart monitoring Azure Machine Learning Services by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure Machine Learning Services documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-machine-learning-integration) to learn more about New Relic monitoring for Azure Machine Learning Services. "
 summary: Monitor Azure Machine Learning Services by connecting Azure to New Relic
 icon: icon.svg
 logo: logo.svg
@@ -10,7 +10,7 @@ authors:
 title: Azure Machine Learning Services
 documentation:
   - name: Azure Machine Learning Services installation docs
-    description: Build and manage machine-learning applications on Azure.
+    description: Monitor Azure Machine Learning Services by connecting Azure to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-machine-learning-integration
 keywords:

--- a/quickstarts/azure/azure-mariadb/config.yml
+++ b/quickstarts/azure/azure-mariadb/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Azure MariaDB. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-database-mariadb-monitoring-integration) to learn more about New Relic monitoring for Azure MariaDB. 
 summary: |-
   Monitor Azure MariaDB by connecting Azure to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Azure MariaDB
 documentation:
   - name: Azure MariaDB installation docs
     description: |
-      Fully managed database as a service with predictable performance and
-      scalability for applications using open-source tools and platforms.
+      Monitor Azure MariaDB by connecting Azure to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-database-mariadb-monitoring-integration
 keywords:

--- a/quickstarts/azure/azure-mysql/config.yml
+++ b/quickstarts/azure/azure-mysql/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Azure MySQL. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-database-mysql-monitoring-integration) to learn more about New Relic monitoring for Azure MySQL. 
 summary: |-
   Monitor Azure MySQL by connecting Azure to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Azure MySQL
 documentation:
   - name: Azure MySQL installation docs
     description: |
-      Fully managed MySQL Community database as a service with high
-      availability, elastic scaling, automatic backups, and data protection.
+      Monitor Azure MySQL by connecting Azure to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-database-mysql-monitoring-integration
 keywords:

--- a/quickstarts/azure/azure-postgresql/config.yml
+++ b/quickstarts/azure/azure-postgresql/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Azure PostgreSQL. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-database-postgresql-monitoring-integration) to learn more about New Relic monitoring for Azure PostgreSQL. 
 summary: |-
   Monitor Azure PostgreSQL by connecting Azure to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Azure PostgreSQL
 documentation:
   - name: Azure PostgreSQL installation docs
     description: |
-      Fully managed PostgreSQL Community database as a service with high
-      availability, elastic scaling, automatic backups, and data protection.
+      Monitor Azure PostgreSQL by connecting Azure to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-database-postgresql-monitoring-integration
 keywords:

--- a/quickstarts/azure/azure-power-bi-dedicated-capacities/config.yml
+++ b/quickstarts/azure/azure-power-bi-dedicated-capacities/config.yml
@@ -1,6 +1,6 @@
 id: 258a1a34-165c-4911-bcd4-80bb60597b24
 name: azure-power-bi-dedicated-capacities
-description: "## What is Azure Power BI Dedicated capacities?\n\nCollect Azure Power BI Dedicated data for Capacity. Maintained by Microsoft.\n\n### Get started!\n\nStart monitoring Azure Power BI Dedicated capacities by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure Power BI Dedicated capacities documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Azure Power BI Dedicated capacities. "
+description: "## What is Azure Power BI Dedicated capacities?\n\nCollect Azure Power BI Dedicated data for Capacity. Maintained by Microsoft.\n\n### Get started!\n\nStart monitoring Azure Power BI Dedicated capacities by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure Power BI Dedicated capacities documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-power-bi-dedicated-capacities-monitoring-integration) to learn more about New Relic monitoring for Azure Power BI Dedicated capacities. "
 summary: Monitor Azure Power BI Dedicated capacities by connecting Azure to New Relic
 icon: ''
 logo: ''
@@ -11,8 +11,7 @@ title: Azure Power BI Dedicated capacities
 documentation:
   - name: Azure Power BI Dedicated capacities installation docs
     description: |
-      Collect Azure Power BI Dedicated data for Capacity. Maintained by
-      Microsoft.
+      Monitor Azure Power BI Dedicated capacities by connecting Azure to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-power-bi-dedicated-capacities-monitoring-integration
 keywords:

--- a/quickstarts/azure/azure-redis-cache/config.yml
+++ b/quickstarts/azure/azure-redis-cache/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Azure Redis Cache. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-redis-cache-monitoring-integration) to learn more about New Relic monitoring for Azure Redis Cache. 
 summary: |-
   Monitor Azure Redis Cache by connecting Azure to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Azure Redis Cache
 documentation:
   - name: Azure Redis Cache installation docs
     description: |
-      Fully managed in-memory data store built for quickly scaling application
-      performance.
+      Monitor Azure Redis Cache by connecting Azure to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-redis-cache-monitoring-integration
 keywords:

--- a/quickstarts/azure/azure-service-bus/config.yml
+++ b/quickstarts/azure/azure-service-bus/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Azure Service Bus. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-service-bus-monitoring-integration) to learn more about New Relic monitoring for Azure Service Bus. 
 summary: |-
   Monitor Azure Service Bus by connecting Azure to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Azure Service Bus
 documentation:
   - name: Azure Service Bus installation docs
     description: |
-      Fully managed message broker designed to bridge the gaps between
-      applications and services.
+      Monitor Azure Service Bus by connecting Azure to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-service-bus-monitoring-integration
 keywords:

--- a/quickstarts/azure/azure-sql-database/config.yml
+++ b/quickstarts/azure/azure-sql-database/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Azure SQL Database. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-sql-database-monitoring-integration) to learn more about New Relic monitoring for Azure SQL Database. 
 summary: |-
   Monitor Azure SQL Database by connecting Azure to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Azure SQL Database
 documentation:
   - name: Azure SQL Database installation docs
     description: |
-      Azure SQL provides single databases with their own set of resources, and
-      elastic pools that share a set of resources.
+      Monitor Azure SQL Database by connecting Azure to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-sql-database-monitoring-integration
 keywords:

--- a/quickstarts/azure/azure-sql-managed-instances/config.yml
+++ b/quickstarts/azure/azure-sql-managed-instances/config.yml
@@ -1,6 +1,6 @@
 id: 16516e34-a906-4e5a-a173-1ce57a96339e
 name: azure-sql-managed-instances
-description: "## What is Azure SQL Managed Instances?\n\nCloud-based database service based on the SQL framework.\n\n### Get started!\n\nStart monitoring Azure SQL Managed Instances by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure SQL Managed Instances documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Azure SQL Managed Instances. "
+description: "## What is Azure SQL Managed Instances?\n\nCloud-based database service based on the SQL framework.\n\n### Get started!\n\nStart monitoring Azure SQL Managed Instances by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure SQL Managed Instances documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-sql-managed-instances-monitoring-integration) to learn more about New Relic monitoring for Azure SQL Managed Instances. "
 summary: Monitor Azure SQL Managed Instances by connecting Azure to New Relic
 icon: icon.svg
 logo: logo.svg
@@ -10,7 +10,7 @@ authors:
 title: Azure SQL Managed Instances
 documentation:
   - name: Azure SQL Managed Instances installation docs
-    description: Cloud-based database service based on the SQL framework.
+    description: Monitor Azure SQL Managed Instances by connecting Azure to New Relic
     url: >-
       https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-sql-managed-instances-monitoring-integration
 keywords:

--- a/quickstarts/azure/azure-storage/config.yml
+++ b/quickstarts/azure/azure-storage/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Azure Storage. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-storage-monitoring-integration) to learn more about New Relic monitoring for Azure Storage. 
 summary: |-
   Monitor Azure Storage by connecting Azure to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Azure Storage
 documentation:
   - name: Azure Storage installation docs
     description: |
-      Managed cloud service that provides highly available, secure, durable,
-      scalable, and redundant storage.
+      Monitor Azure Storage by connecting Azure to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-storage-monitoring-integration
 keywords:

--- a/quickstarts/azure/azure-virtual-machine-scale-sets/config.yml
+++ b/quickstarts/azure/azure-virtual-machine-scale-sets/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Azure Virtual Machine Scale Sets. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-virtual-machine-scale-sets-monitoring-integration) to learn more about New Relic monitoring for Azure Virtual Machine Scale Sets. 
 summary: |-
   Monitor Azure Virtual Machine Scale Sets by connecting Azure to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Azure Virtual Machine Scale Sets
 documentation:
   - name: Azure Virtual Machine Scale Sets installation docs
     description: |
-      Automatically scale application load across a series of heterogeneous,
-      load-balanced virtual machines.
+      Monitor Azure Virtual Machine Scale Sets by connecting Azure to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-virtual-machine-scale-sets-monitoring-integration
 keywords:

--- a/quickstarts/azure/azure-virtual-network/config.yml
+++ b/quickstarts/azure/azure-virtual-network/config.yml
@@ -1,6 +1,6 @@
 id: f812a124-5443-4451-94d3-32b54c109555
 name: azure-virtual-network
-description: "## What is Azure Virtual Network?\n\nNetwork for connecting on-prem, Azure, and external sources.\n\n### Get started!\n\nStart monitoring Azure Virtual Network by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure Virtual Network documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Azure Virtual Network. "
+description: "## What is Azure Virtual Network?\n\nNetwork for connecting on-prem, Azure, and external sources.\n\n### Get started!\n\nStart monitoring Azure Virtual Network by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure Virtual Network documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-virtual-network-monitoring-integration) to learn more about New Relic monitoring for Azure Virtual Network. "
 summary: Monitor Azure Virtual Network by connecting Azure to New Relic
 icon: icon.svg
 logo: logo.svg
@@ -10,7 +10,7 @@ authors:
 title: Azure Virtual Network
 documentation:
   - name: Azure Virtual Network installation docs
-    description: Network for connecting on-prem, Azure, and external sources.
+    description: Monitor Azure Virtual Network by connecting Azure to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-virtual-network-monitoring-integration
 keywords:

--- a/quickstarts/azure/azure-vms/config.yml
+++ b/quickstarts/azure/azure-vms/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Azure VMs. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-vms-monitoring-integration) to learn more about New Relic monitoring for Azure VMs. 
 summary: |-
   Monitor Azure VMs by connecting Azure to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Azure VMs
 documentation:
   - name: Azure VMs installation docs
     description: |
-      Provides on-demand cloud infrastructure in a variety of server sizes,
-      regions, and operating systems.
+      Monitor Azure VMs by connecting Azure to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-vms-monitoring-integration
 keywords:

--- a/quickstarts/azure/azure-vpn-gateways/config.yml
+++ b/quickstarts/azure/azure-vpn-gateways/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Azure VPN Gateways. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-vpn-gateway-integration) to learn more about New Relic monitoring for Azure VPN Gateways. 
 summary: |-
   Monitor Azure VPN Gateways by connecting Azure to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Azure VPN Gateways
 documentation:
   - name: Azure VPN Gateways installation docs
     description: |
-      Used to send encrypted data between on-premises infrastructure and Azure
-      services.
+      Monitor Azure VPN Gateways by connecting Azure to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-vpn-gateway-integration
 keywords:

--- a/quickstarts/centos/config.yml
+++ b/quickstarts/centos/config.yml
@@ -1,7 +1,16 @@
 id: b3d951d1-82f3-4dc3-82bc-d7ecd56a749d
 name: centos
-description: Free Linux distribution built to be compatible with Red Hat Enterprise.
-summary: Free Linux distribution built to be compatible with Red Hat Enterprise.
+description: |
+  ## What is CentOS?
+  
+  Free Linux distribution built to be compatible with Red Hat Enterprise.
+
+  ## Get started!
+
+  Choose this quickstart and follow New Relic's guided install process to monitor your CentOS environment.
+  
+summary: |
+  Use the New Relic Infrastructure agent to monitor CentOS
 icon: icon.svg
 logo: logo.svg
 level: New Relic
@@ -10,7 +19,7 @@ authors:
 title: CentOS
 documentation:
   - name: CentOS installation docs
-    description: Free Linux distribution built to be compatible with Red Hat Enterprise.
+    description: Use the New Relic Infrastructure agent to monitor CentOS.
     url: >-
       https://docs.newrelic.com/docs/infrastructure/install-configure-manage-infrastructure/linux-installation/install-infrastructure-linux-using-package-manager
 keywords:

--- a/quickstarts/debian/config.yml
+++ b/quickstarts/debian/config.yml
@@ -1,11 +1,17 @@
 id: 1961cd44-68b3-4a59-8d48-45a881c0e3c0
 name: debian
 description: |
+  ## What is Debian?
+  
   Debian, also known as Debian GNU/Linux, is a Linux distribution composed of
   free and open-source software.
+
+  ## Get started!
+
+  Choose this quickstart and follow New Relic's guided install process to monitor your Debian environment.
+  
 summary: |
-  Debian, also known as Debian GNU/Linux, is a Linux distribution composed of
-  free and open-source software.
+  Use the New Relic Infrastructure agent to monitor Debian
 icon: icon.svg
 logo: logo.svg
 level: New Relic
@@ -15,8 +21,7 @@ title: Debian
 documentation:
   - name: Debian installation docs
     description: |
-      Debian, also known as Debian GNU/Linux, is a Linux distribution composed
-      of free and open-source software.
+      Use the New Relic Infrastructure agent to monitor Debian.
     url: >-
       https://docs.newrelic.com/docs/infrastructure/install-configure-manage-infrastructure/linux-installation/install-infrastructure-linux-using-package-manager
 keywords:

--- a/quickstarts/gcp/gcp-cloud-run/config.yml
+++ b/quickstarts/gcp/gcp-cloud-run/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for GCP Cloud Run. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-run-monitoring-integration) to learn more about New Relic monitoring for GCP Cloud Run. 
 summary: |-
   Monitor GCP Cloud Run by connecting GCP to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: GCP Cloud Run
 documentation:
   - name: GCP Cloud Run installation docs
     description: |
-      Fully managed platform for taking locally developed applications and
-      deploying them on containers for simple scaling.
+      Monitor GCP Cloud Run by connecting GCP to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-run-monitoring-integration
 keywords:

--- a/quickstarts/gcp/gcp-dataflow/config.yml
+++ b/quickstarts/gcp/gcp-dataflow/config.yml
@@ -1,6 +1,6 @@
 id: dec05983-5c59-4fdd-9446-211d5bd7e20d
 name: gcp-dataflow
-description: "## What is GCP Dataflow?\n\nExecute Apache Beam pipelines in a fully managed google cloud environment.\n\n### Get started!\n\nStart monitoring GCP Dataflow by connecting Google Cloud Platform (GCP) to New Relic!\n\nCheck out our GCP Dataflow documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for GCP Dataflow. "
+description: "## What is GCP Dataflow?\n\nExecute Apache Beam pipelines in a fully managed google cloud environment.\n\n### Get started!\n\nStart monitoring GCP Dataflow by connecting Google Cloud Platform (GCP) to New Relic!\n\nCheck out our GCP Dataflow documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-dataflow-monitoring-integration) to learn more about New Relic monitoring for GCP Dataflow. "
 summary: Monitor GCP Dataflow by connecting GCP to New Relic
 icon: icon.svg
 logo: logo.svg
@@ -10,7 +10,7 @@ authors:
 title: GCP Dataflow
 documentation:
   - name: GCP Dataflow installation docs
-    description: Execute Apache Beam pipelines in a fully managed google cloud environment.
+    description: Monitor GCP Dataflow by connecting GCP to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-dataflow-monitoring-integration
 keywords:

--- a/quickstarts/gcp/gcp-dataproc/config.yml
+++ b/quickstarts/gcp/gcp-dataproc/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for GCP Dataproc. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-dataproc-monitoring-integration) to learn more about New Relic monitoring for GCP Dataproc. 
 summary: |-
   Monitor GCP Dataproc by connecting GCP to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: GCP Dataproc
 documentation:
   - name: GCP Dataproc installation docs
     description: |
-      Run Apache Spark and Hadoop clusters in a fully managed Google Cloud
-      environment.
+      Monitor GCP Dataproc by connecting GCP to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-dataproc-monitoring-integration
 keywords:

--- a/quickstarts/gcp/gcp-datastore/config.yml
+++ b/quickstarts/gcp/gcp-datastore/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for GCP Datastore. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-datastore-monitoring-integration) to learn more about New Relic monitoring for GCP Datastore. 
 summary: |-
   Monitor GCP Datastore by connecting GCP to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: GCP Datastore
 documentation:
   - name: GCP Datastore installation docs
     description: |
-      A highly scalable, fully managed NoSQL database service offered by Google
-      on the Google Cloud Platform.
+      Monitor GCP Datastore by connecting GCP to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-datastore-monitoring-integration
 keywords:

--- a/quickstarts/gcp/gcp-dedicated-interconnect/config.yml
+++ b/quickstarts/gcp/gcp-dedicated-interconnect/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for GCP Dedicated Interconnect. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-direct-interconnect-monitoring-integration) to learn more about New Relic monitoring for GCP Dedicated Interconnect. 
 summary: |-
   Monitor GCP Dedicated Interconnect by connecting GCP to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: GCP Dedicated Interconnect
 documentation:
   - name: GCP Dedicated Interconnect installation docs
     description: |
-      Provides direct physical connections between your on-premises network and
-      Google's network.
+      Monitor GCP Dedicated Interconnect by connecting GCP to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-direct-interconnect-monitoring-integration
 keywords:

--- a/quickstarts/gcp/gcp-firebase-database/config.yml
+++ b/quickstarts/gcp/gcp-firebase-database/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for GCP Firebase Database. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-database-monitoring-integration) to learn more about New Relic monitoring for GCP Firebase Database. 
 summary: |-
   Monitor GCP Firebase Database by connecting GCP to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: GCP Firebase Database
 documentation:
   - name: GCP Firebase Database installation docs
     description: |
-      An efficient, low-latency solution for mobile apps that require synced
-      states across clients in real time.
+      Monitor GCP Firebase Database by connecting GCP to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-database-monitoring-integration
 keywords:

--- a/quickstarts/gcp/gcp-firebase-hosting/config.yml
+++ b/quickstarts/gcp/gcp-firebase-hosting/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for GCP Firebase Hosting. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-hosting-monitoring-integration) to learn more about New Relic monitoring for GCP Firebase Hosting. 
 summary: |-
   Monitor GCP Firebase Hosting by connecting GCP to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: GCP Firebase Hosting
 documentation:
   - name: GCP Firebase Hosting installation docs
     description: |
-      Provides fast and secure hosting for your web app, static and dynamic
-      content, and microservices.
+      Monitor GCP Firebase Hosting by connecting GCP to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-hosting-monitoring-integration
 keywords:

--- a/quickstarts/gcp/gcp-firebase-storage/config.yml
+++ b/quickstarts/gcp/gcp-firebase-storage/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for GCP Firebase Storage. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-storage-monitoring-integration) to learn more about New Relic monitoring for GCP Firebase Storage. 
 summary: |-
   Monitor GCP Firebase Storage by connecting GCP to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: GCP Firebase Storage
 documentation:
   - name: GCP Firebase Storage installation docs
     description: |
-      Service built for app developers that need to store and serve
-      user-generated content, such as photos or videos.
+      Monitor GCP Firebase Storage by connecting GCP to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-storage-monitoring-integration
 keywords:

--- a/quickstarts/gcp/gcp-firestore/config.yml
+++ b/quickstarts/gcp/gcp-firestore/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for GCP Firestore. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firestore-monitoring-integration) to learn more about New Relic monitoring for GCP Firestore. 
 summary: |-
   Monitor GCP Firestore by connecting GCP to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: GCP Firestore
 documentation:
   - name: GCP Firestore installation docs
     description: |
-      A NoSQL document database that lets you easily store, sync, and query data
-      for your mobile and web apps - at global scale.
+      Monitor GCP Firestore by connecting GCP to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firestore-monitoring-integration
 keywords:

--- a/quickstarts/gcp/gcp-router/config.yml
+++ b/quickstarts/gcp/gcp-router/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for GCP Router. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-router-monitoring-integration) to learn more about New Relic monitoring for GCP Router. 
 summary: |-
   Monitor GCP Router by connecting GCP to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: GCP Router
 documentation:
   - name: GCP Router installation docs
     description: |
-      Service that exchanges routes between Virtual Private Clouds (VPC) and
-      on-premises networks by using Border Gateway Protocol (BGP).
+      Monitor GCP Router by connecting GCP to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-router-monitoring-integration
 keywords:

--- a/quickstarts/gcp/gcp-vpc/config.yml
+++ b/quickstarts/gcp/gcp-vpc/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for GCP VPC. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-serverless-vpc-access-monitoring-integration) to learn more about New Relic monitoring for GCP VPC. 
 summary: |-
   Monitor GCP VPC by connecting GCP to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: GCP VPC
 documentation:
   - name: GCP VPC installation docs
     description: |
-      Provides networking for Google Compute instances, Google Kubernetes Engine
-      (GKE) clusters, and the App Engine flexible environment.
+      Monitor GCP VPC by connecting GCP to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-serverless-vpc-access-monitoring-integration
 keywords:

--- a/quickstarts/gcp/google-app-engine/config.yml
+++ b/quickstarts/gcp/google-app-engine/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Google App Engine. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-app-engine-monitoring-integration) to learn more about New Relic monitoring for Google App Engine. 
 summary: |-
   Monitor Google App Engine by connecting GCP to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Google App Engine
 documentation:
   - name: Google App Engine installation docs
     description: |
-      GCP service that abstracts away underlying infrastructure for your mobile
-      and web applications, allowing you to focus on their development.
+      Monitor Google App Engine by connecting GCP to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-app-engine-monitoring-integration
 keywords:

--- a/quickstarts/gcp/google-bigquery/config.yml
+++ b/quickstarts/gcp/google-bigquery/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Google BigQuery. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-bigquery-monitoring-integration) to learn more about New Relic monitoring for Google BigQuery. 
 summary: |-
   Monitor Google BigQuery by connecting GCP to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Google BigQuery
 documentation:
   - name: Google BigQuery installation docs
     description: |
-      Fully managed data warehouse with options for user-defined or automated
-      data schemes and exploration via SQL queries.
+      Monitor Google BigQuery by connecting GCP to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-bigquery-monitoring-integration
 keywords:

--- a/quickstarts/gcp/google-cloud-functions/config.yml
+++ b/quickstarts/gcp/google-cloud-functions/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Google Cloud Functions. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-functions-monitoring-integration) to learn more about New Relic monitoring for Google Cloud Functions. 
 summary: |-
   Monitor Google Cloud Functions by connecting GCP to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Google Cloud Functions
 documentation:
   - name: Google Cloud Functions installation docs
     description: |
-      Create short pieces of code that respond to cloud events without the need
-      to manage an application server or runtime environment.
+      Monitor Google Cloud Functions by connecting GCP to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-functions-monitoring-integration
 keywords:

--- a/quickstarts/gcp/google-cloud-spanner/config.yml
+++ b/quickstarts/gcp/google-cloud-spanner/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Google Cloud Spanner. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-spanner-monitoring-integration) to learn more about New Relic monitoring for Google Cloud Spanner. 
 summary: |-
   Monitor Google Cloud Spanner by connecting GCP to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Google Cloud Spanner
 documentation:
   - name: Google Cloud Spanner installation docs
     description: |
-      Globally-distributed relational database service built for the cloud. Add
-      schemas, write and modify data, and run queries.
+      Monitor Google Cloud Spanner by connecting GCP to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-spanner-monitoring-integration
 keywords:

--- a/quickstarts/gcp/google-cloud-sql/config.yml
+++ b/quickstarts/gcp/google-cloud-sql/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Google Cloud SQL. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-sql-monitoring-integration) to learn more about New Relic monitoring for Google Cloud SQL. 
 summary: |-
   Monitor Google Cloud SQL by connecting GCP to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Google Cloud SQL
 documentation:
   - name: Google Cloud SQL installation docs
     description: |
-      Set up, maintain, manage, and administer MySQL and PostgreSQL databases in
-      the cloud.
+      Monitor Google Cloud SQL by connecting GCP to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-sql-monitoring-integration
 keywords:

--- a/quickstarts/gcp/google-cloud-storage/config.yml
+++ b/quickstarts/gcp/google-cloud-storage/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Google Cloud Storage. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-storage-monitoring-integration) to learn more about New Relic monitoring for Google Cloud Storage. 
 summary: |-
   Monitor Google Cloud Storage by connecting GCP to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Google Cloud Storage
 documentation:
   - name: Google Cloud Storage installation docs
     description: |
-      Serve website content, store data for archival and disaster recovery, and
-      distribute data objects via direct download.
+      Monitor Google Cloud Storage by connecting GCP to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-storage-monitoring-integration
 keywords:

--- a/quickstarts/gcp/google-compute-engine/config.yml
+++ b/quickstarts/gcp/google-compute-engine/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Google Compute Engine. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-compute-engine-monitoring-integration/) to learn more about New Relic monitoring for Google Compute Engine. 
 summary: |-
   Monitor Google Compute Engine by connecting GCP to New Relic
 icon: icon.svg
@@ -27,9 +27,8 @@ title: Google Compute Engine
 documentation:
   - name: Google Compute Engine installation docs
     description: |
-      Provides on-demand cloud infrastructure for general purpose applications
-      with a variety of server sizes, regions, and operating systems.
-    url: https://newrelic.com/integrations/gcp-compute-engine-integration
+      Monitor Google Compute Engine by connecting GCP to New Relic.
+    url: https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-compute-engine-monitoring-integration/
 keywords:
   - gcp
   - google cloud platform

--- a/quickstarts/gcp/google-load-balancing/config.yml
+++ b/quickstarts/gcp/google-load-balancing/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Google Load Balancing. 
+  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-load-balancing-monitoring-integration) to learn more about New Relic monitoring for Google Load Balancing. 
 summary: |-
   Monitor Google Load Balancing by connecting GCP to New Relic
 icon: icon.svg
@@ -27,8 +27,7 @@ title: Google Load Balancing
 documentation:
   - name: Google Load Balancing installation docs
     description: |
-      Managed service for distributing traffic in a single or multiple regions
-      with seamless, immediate autoscaling and wide protocol support.
+      Monitor Google Load Balancing by connecting GCP to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-load-balancing-monitoring-integration
 keywords:

--- a/quickstarts/gcp/google-pub-sub/config.yml
+++ b/quickstarts/gcp/google-pub-sub/config.yml
@@ -1,6 +1,6 @@
 id: 7ee5466d-31ec-4b91-a7ca-18dc91b43424
 name: google-pub-sub
-description: "## What is Google Pub/Sub?\n\nIngests and delivers event streams for quick data processing and analysis.\n\n### Get started!\n\nStart monitoring Google Pub/Sub by connecting Google Cloud Platform (GCP) to New Relic!\n\nCheck out our Google Pub/Sub documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/) to learn more about New Relic monitoring for Google Pub/Sub. "
+description: "## What is Google Pub/Sub?\n\nIngests and delivers event streams for quick data processing and analysis.\n\n### Get started!\n\nStart monitoring Google Pub/Sub by connecting Google Cloud Platform (GCP) to New Relic!\n\nCheck out our Google Pub/Sub documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-pubsub-monitoring-integration) to learn more about New Relic monitoring for Google Pub/Sub. "
 summary: Monitor Google Pub/Sub by connecting GCP to New Relic
 icon: icon.svg
 logo: logo.svg
@@ -10,7 +10,7 @@ authors:
 title: Google Pub/Sub
 documentation:
   - name: Google Pub/Sub installation docs
-    description: Ingests and delivers event streams for quick data processing and analysis.
+    description: Monitor Google Pub/Sub by connecting GCP to New Relic.
     url: >-
       https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-pubsub-monitoring-integration
 keywords:

--- a/quickstarts/linux/config.yml
+++ b/quickstarts/linux/config.yml
@@ -1,11 +1,17 @@
 id: 5b420314-fbfb-4c62-85ed-42200d76cf9a
 name: linux
 description: |
+  ## What is Linux?
+  
   Linux is a family of open-source Unix-like operating systems, typically
   packaged in a distribution.
+
+  ## Get started!
+
+  Choose this quickstart and follow New Relic's guided install process to monitor your Linux environment.
+
 summary: |
-  Linux is a family of open-source Unix-like operating systems, typically
-  packaged in a distribution.
+  Use the New Relic Infrastructure agent to monitor Linux
 icon: icon.svg
 logo: logo.svg
 level: New Relic
@@ -15,8 +21,7 @@ title: Linux
 documentation:
   - name: Linux installation docs
     description: |
-      Linux is a family of open-source Unix-like operating systems, typically
-      packaged in a distribution.
+      Use the New Relic Infrastructure agent to monitor Linux.
     url: >-
       https://docs.newrelic.com/docs/infrastructure/install-configure-manage-infrastructure/linux-installation/install-infrastructure-linux-using-package-manager
 keywords:

--- a/quickstarts/suse-linux-enterprise-server/config.yml
+++ b/quickstarts/suse-linux-enterprise-server/config.yml
@@ -1,11 +1,17 @@
 id: 902c5c2f-41db-44ed-8381-f3cb9b8a4b9e
 name: suse-linux-enterprise-server
 description: |
+  ## What is SUSE?
+  
   Linux-based operating system developed by SUSE designed for servers,
   mainframes, and workstations.
+
+  ## Get started!
+
+  Choose this quickstart and follow New Relic's guided install process to monitor your SUSE environment.
+  
 summary: |
-  Linux-based operating system developed by SUSE designed for servers,
-  mainframes, and workstations.
+  Use the New Relic Infrastructure agent to monitor SUSE
 icon: icon.svg
 logo: logo.svg
 level: New Relic
@@ -15,8 +21,7 @@ title: SUSE Linux Enterprise Server
 documentation:
   - name: SUSE Linux Enterprise Server installation docs
     description: |
-      Linux-based operating system developed by SUSE designed for servers,
-      mainframes, and workstations.
+      Use the New Relic Infrastructure agent to monitor SUSE.
     url: >-
       https://docs.newrelic.com/docs/infrastructure/install-configure-manage-infrastructure/linux-installation/install-infrastructure-linux-using-package-manager
 keywords:

--- a/quickstarts/ubuntu/config.yml
+++ b/quickstarts/ubuntu/config.yml
@@ -1,11 +1,17 @@
 id: bb4a3bc6-b595-45d5-b65d-f375c428f31a
 name: ubuntu
-description: |
+description:  |
+  ## What is Ubuntu?
+  
   Open source Linux distribution for both personal and enterprise use, based on
   Debian.
+
+  ## Get started!
+
+  Choose this quickstart and follow New Relic's guided install process to monitor your Ubuntu environment.
+  
 summary: |
-  Open source Linux distribution for both personal and enterprise use, based on
-  Debian.
+  Use the New Relic Infrastructure agent to monitor Ubuntu
 icon: icon.svg
 logo: logo.svg
 level: New Relic
@@ -15,8 +21,7 @@ title: Ubuntu
 documentation:
   - name: Ubuntu installation docs
     description: |
-      Open source Linux distribution for both personal and enterprise use, based
-      on Debian.
+      Use the New Relic Infrastructure agent to monitor Ubuntu.
     url: >-
       https://docs.newrelic.com/docs/infrastructure/install-configure-manage-infrastructure/linux-installation/install-infrastructure-linux-using-package-manager
 keywords:


### PR DESCRIPTION
There was a wrong generic link, updating
