### PR TITLE
fix: sentence-case headers

### DIFF
--- a/quickstarts/apache/config.yml
+++ b/quickstarts/apache/config.yml
@@ -13,20 +13,20 @@ description: |+
 
   The Apache HTTP Server is a free and open-source, secure, efficient, and extensible HTTP web server for the Windows and UNIX operating systems.
 
-  ## What should you look for in an Apache HTTP Server Monitor?
+  ### What should you look for in an Apache HTTP Server Monitor?
   
   An Apache monitor offers developers critical information to help them paint a complete picture of a web server's performance. Such data includes error analytics, host-related resource metrics, throughput metrics, latency metrics, resource utilization metrics, and activity metrics.
 
-  ## What’s Included?
+  ### What’s included?
   
   Our Apache quickstart include out-of-the-box dashboards and alerts, including data such as:
   - Servers reporting
   - Total requests per second
   - Requests per second by server
 
-  ## What makes New Relic's quickstart unique?
+  ### What makes New Relic's quickstart unique?
   
-  Our monitor features an intuitive design that allows developers to look up their preferred performance-related data quickly, efficient issue resolution process, and combines practicality and usability.
+  Our monitoring features an intuitive design that allows developers to look up their preferred performance-related data quickly, efficient issue resolution process, and combines practicality and usability.
   
 summary: |
   Check out New Relic's Apache quickstart and gain a more comprehensive understanding of your servers' performance with customized dashboards including; total requests per second, servers reporting, worker status, and more.

--- a/quickstarts/dotnet/dotnet/config.yml
+++ b/quickstarts/dotnet/dotnet/config.yml
@@ -1,9 +1,7 @@
 id: 2dff13b6-0fac-43a6-abc6-57f0a3299639
 name: dotnet
 description: |
-  ## Comprehensive Monitoring Quickstart for .NET
-
-  ### What is .NET Framework?
+  ## Comprehensive monitoring quickstart for .NET
 
   .NET Framework is a software product developed by Microsoft. It is a platform used on the Microsoft Windows operating system to build desktop and web applications and supports many programming languages.
 
@@ -21,13 +19,13 @@ description: |
   - Granular error identification mechanism
   - Comprehensive .NET Framework, Common Language Runtime (CLR), and Internet Information Services (IIS) monitoring
 
-  ### What’s Included in this quickstart:
+  ### What’s included in this quickstart:
 
   - High-value alerts
   - Code-related insights that acquaint developers with the intricate details of their application’s health and status by providing detailed information on errors, database queries, and transaction traces
   - Alerts that proactively inform developers about the status of their applications
 
-  ### What Makes This quickstart Unique?
+  ### What makes this quickstart unique?
 
   With this quickstart, you can monitor health and status in one place, focus on the most important information, and enable preventative maintenance strategy.
 summary: |

--- a/quickstarts/haproxy/config.yml
+++ b/quickstarts/haproxy/config.yml
@@ -8,13 +8,13 @@ title: HAProxy
 
 # Description of the quickstart
 description: |
-  ## Complete Quickstart for HAProxy Monitoring
+  ## Complete quickstart for HAProxy monitoring
 
   HAProxy monitoring helps maintain system performance and provides the visibility you need to identify and resolve the cause of errors and latency. When you monitor HAProxy in real-time, you can see the entire service topology of your data pipeline and applications in an HAProxy dashboard.
 
   Keep track of TCP and HTTP-based applications powered by the highly available and stable TCP/HTTP load-balancing software and proxy solution. 
 
-  ### New Relic HAProxy Quickstart Highlights
+  ### New Relic HAProxy quickstart highlights
 
   New Relic's HAProxy monitoring agent tracks server capacity to ensure that it can handle all concurrent sessions. You can efficiently manage your resources and run applications optimally by keeping an eye on real-time HAProxy status and statistics.
 
@@ -22,7 +22,7 @@ description: |
   - Alerts (latency and errors) 
   - Dashboards (bytes sent and received per second, frontend statuses, request errors per second, sessions per second, and active servers - same dashboards for both front and backend)
 
-  ### New Relic - The Complete HAProxy Dashboard Tool
+  ### New Relic - The complete HAProxy dashboard tool
 
   New Relic's instant observability quickstart provides a complete view of server health, capacity, and potential latency issues in a single HAProxy dashboard. Track frontend request rates in real-time, gauge the peaks and the drops, and better manage traffic spikes. Get a comprehensive view of the entire infrastructure to remediate errors before impact on user experiences by correlating frontend and backend metrics.
 

--- a/quickstarts/infrastructure/config.yml
+++ b/quickstarts/infrastructure/config.yml
@@ -8,7 +8,7 @@ title: Infrastructure
 
 # Description of the quickstart
 description: |
-  ### Infrastructure Monitoring Quickstart
+  ## Infrastructure monitoring quickstart
 
   Infrastructure monitoring provides deep visibility into performance, available resources, and your entire estate at a glance. Remote infrastructure monitoring tools collect and display data and related attributes represented by various metrics and metadata.
 
@@ -17,7 +17,7 @@ description: |
   New Relic's infrastructure quickstart provides visibility across the entire stack and enables greater scale and efficiency. It's a monitoring solution for multifaceted hybrid environments including pre-built dashboards and alerts.
 
 
-  ### Quickstart Highlights
+  ### Quickstart highlights
 
   New Relic's infrastructure monitoring tool provides instant observability out-of-the-box. 
 
@@ -29,14 +29,14 @@ description: |
   - Process breakdown, and more
 
 
-  #### New Relic Infrastructure Monitoring
+  ### New Relic infrastructure monitoring
 
   Instant observability with New Relic quickstarts minimizes the complexity in efficiently managing enterprise infrastructure. You can see everything at a glance with New Relic's infrastructure dashboard. Quickly see the status of key infrastructure components with our pre-built dashboards. 
 
   New Relic's instant observability quickstart helps DevOps engineers reduce complexity and enhance efficiency through unmatched visibility in an infrastructure dashboard. 
 
 
-  ### What Makes New Relic Unique?
+  ### New Relic capabilities
 
   On top of the benefits from this quickstart, New Relic infrastructure monitoring provides advanced features, including:
   - Custom views

--- a/quickstarts/java/java/config.yml
+++ b/quickstarts/java/java/config.yml
@@ -1,18 +1,18 @@
 id: 3ebfb315-d0a6-4b27-9f89-b16a9a1ada5f
 name: java
 description: |
-  ### Why Monitoring Java is So Important
+  ## Why monitoring Java is so important
 
   Java is a compiled language, with the potential to be very fast. However, there are a a lot of Java-specific quirks that make the average program slow such as high default memory usage and lags in the startup time of the JVM. 
 
   In order to get the most performance out of your Java applications, it’s important to continuously monitor them with tools such as the New Relic Java agent. 
 
-  ### New Relic Java Quickstart Features
+  ### New Relic Java quickstart features
 
   - Dashboards showing average CPU utilization, memory heap used, garbage collection CPU time, top 5 slowest transactions, and more.
   - Alerts for various metrics including high cpu utilization and transaction errors
 
-  ### New Relic - The Perfect Java Observability Tool
+  ### New Relic - the perfect java observability tool
 
   Proactive Java monitoring yields reductions in site latency and improves the user experience. Our Java agent monitors app servers, databases, and message queuing systems, giving insight into all the key components which allow a web app to run. Custom instrumentation is also available for the add-on Java frameworks and libraries which may be used. 
 

--- a/quickstarts/java/java/config.yml
+++ b/quickstarts/java/java/config.yml
@@ -12,7 +12,7 @@ description: |
   - Dashboards showing average CPU utilization, memory heap used, garbage collection CPU time, top 5 slowest transactions, and more.
   - Alerts for various metrics including high cpu utilization and transaction errors
 
-  ### New Relic - the perfect java observability tool
+  ### New Relic - the perfect Java observability tool
 
   Proactive Java monitoring yields reductions in site latency and improves the user experience. Our Java agent monitors app servers, databases, and message queuing systems, giving insight into all the key components which allow a web app to run. Custom instrumentation is also available for the add-on Java frameworks and libraries which may be used. 
 

--- a/quickstarts/kafka/config.yml
+++ b/quickstarts/kafka/config.yml
@@ -8,27 +8,29 @@ title: Kafka
 
 # Description of the quickstart
 description: |
-  ## Quickstart for Kafka Monitoring
+  ## Quickstart for Kafka monitoring
 
   Kafka monitoring is important to track services running on multiple Kafka servers in real-time. Observe key metrics like CPU usage, memory, and consumer lag at a glance in a Kafka dashboard. 
  
-  ### Why Monitoring Kafka Is so Important
+  ### Why monitoring kafka is so important
 
   Apache Kafka is a fault-tolerant, scalable messaging system used to build real-time data pipelines. Kafka also supports replications natively, and you can build streaming applications that run inside production environments.
 
   Leveraging a Kafka monitoring tool to monitor data replication, retention, and issues like consumer lag is important. New Relic’s Kafka quickstart lets you look at performance metrics and inventory data, create your own custom charts and queries, and create alert policies. 
 
-  ### New Relic Kafka quickstart Features
+  ### New Relic Kafka quickstart features
 
   New Relic’s Kafka monitoring tracks space and time retention, leverages replication alerts to uncover potential issues, and uses queries and a Kafka dashboard to explore them.
 
-  ### New Relic + Kafka Quickstart - New Relic’s performance monitoring provides instant observability out-of-the-box. This quickstart includes:
+  ### New Relic + Kafka quickstart 
+
+  New Relic’s performance monitoring provides instant observability out-of-the-box. This quickstart includes:
 
   - Monitoring Kafka topics
   - Dashboards tracking brokers, messages per sec, broker bytes in and out per sec, consumer lag, and more
   - Monitoring of producers and consumers coded in Java
 
-  ### New Relic - Complete Kafka Performance Monitoring
+  ### New Relic - complete kafka monitoring
 
   Provide total visibility into key performance metrics like the number of client requests and bytes served per second with New Relic’s Kafka monitoring and also track inventory data and metadata in real-time.
 

--- a/quickstarts/kafka/config.yml
+++ b/quickstarts/kafka/config.yml
@@ -30,7 +30,7 @@ description: |
   - Dashboards tracking brokers, messages per sec, broker bytes in and out per sec, consumer lag, and more
   - Monitoring of producers and consumers coded in Java
 
-  ### New Relic - complete kafka monitoring
+  ### New Relic - complete Kafka monitoring
 
   Provide total visibility into key performance metrics like the number of client requests and bytes served per second with New Relic’s Kafka monitoring and also track inventory data and metadata in real-time.
 

--- a/quickstarts/mysql/config.yml
+++ b/quickstarts/mysql/config.yml
@@ -7,28 +7,28 @@ title: MySQL
 
 # Description of the quickstart
 description: |+
-  ## MySQL Performance Monitoring
+  ## MySQL monitoring quickstart
 
   Applications powered by relational database management systems demand the user to understand how the application uses it. Quickly identify and resolve the source server issues with MySQL performance monitoring tools. 
 
   Identify query optimization metrics and more within a single New Relic MySQL dashboard and ensure the highest application performance with this approach. 
 
-  ## MySQL Monitoring
+  ### MySQL monitoring
 
   Optimize your infrastructure by collecting inventory and metrics from your database. Analyze the data to ascertain server health and identify the source of potential problems.
 
-  ## New Relic + MySQL - Your Ideal Tool for Better Monitoring
+  ### New Relic + MySQL - your ideal tool for better monitoring
 
   Install this quickstart to access preconfigured observability solutions. Unlike other performance monitoring tools, New Relic is a powerful proactive remote monitoring solution that provides a comprehensive view from a single MySQL dashboard. 
 
-  ## What’s Included?
+  ### What’s included?
 
   The MySQL quickstart include out-of-the-box dashboards and alerts, including:
 
   - Alerts (pending reads and writes, max connection errors/second, questions/second, and slow queries/second)
   - Dashboards (operations/second, slow queries per minute by node, active connections by node, and more)
 
-  ## Value of MySQL Quickstart
+  ### Value of MySQL quickstart
 
   New Relic’s instant observability quickstart helps developers accelerate time to value. You can use this approach to help reduce administrative overheads. Implement this robust performance and infrastructure monitoring tool within minutes.
   

--- a/quickstarts/nginx/config.yml
+++ b/quickstarts/nginx/config.yml
@@ -8,17 +8,17 @@ title: Nginx
 
 # Description of the quickstart
 description: |
-  ### Why Monitoring Nginx is so Important
+  ### Why monitoring Nginx is so important
 
   NGINX is one of the fastest‑growing open-source web servers in the world. However, in some cases, NGINX may not serve requests as quickly as expected due to problems in an application or architecture. Monitoring NGINX performance is essential to ensure that your web application and server environment are healthy. The key to effective NGINX monitoring is the New Relic NGINX quickstart.
 
-  ### New Relic Nginx Quickstart Features
+  ### New Relic Nginx quickstart features
 
   - Dashboards: NGINX dashboards proactively monitor NGINX metrics like requests per second, active connections, connections accepted per second, connections dropped per second, etc.
   - Automatic On-host integrations instrumentation
   - Compatible with both NGINX Open Source and NGINX Plus
 
-  ### New Relic - The Complete Nginx Performance Monitoring Tool
+  ### New Relic - the complete Nginx performance monitoring tool
 
   Monitor key NGINX with the New Relic NGINX Performance monitoring integration with metrics like requests per second, connections accepted per second, connections dropped per second, etc. Specifically, our NGINX integration collects and sends inventory and metrics from your NGINX server to the New Relic platform, where you can see valuable insights. From that platform, you can also query data, understand integration data in detail, and create alert conditions.
 

--- a/quickstarts/node-js/node-js/config.yml
+++ b/quickstarts/node-js/node-js/config.yml
@@ -2,23 +2,23 @@ id: 01fdea36-5a15-44b4-a864-c4c99866735b
 name: node-js
 
 description: |
-  ## The Comprehensive Node.js Monitoring System
+  ## The comprehensive Node.js monitoring system
 
   Node.js is an open-source platform built on Chrome's JavaScript runtime used to develop fast and scalable applications quickly with an event-driven, non-blocking input/output architecture. 
  
   However, these attributes can be inconvenient because verifying the correctness of an application with asynchronous nested callbacks is complex. So, it’s important to watch executing Node.js systems closely. Monitoring your Node.js applications ensures optimal performance, allows the maximization of system availability, and ensures that a system’s health is well maintained.
  
-  ## What should you look for in a Node.js dashboard? 
+  ### What should you look for in a Node.js dashboard? 
 
   A reliable Node.js network monitor must provide enough information to identify the problem sources. Some crucial information includes process ID, log management, request rate, application availability, resource usage, uptime, downtime, system health, error rates and handling, number of connections, load average, and latency. 
  
-  ## What’s Included in the Node.js quickstart?
+  ### What’s included in the Node.js quickstart?
 
   Install this quickstart to install preconfigured observability solutions: 
   - Multiple high-value alerts, including Apdex score and CPU utilization
   - Informative dashboards (Slowest transactions, throughput comparisons, and more)
  
-  ## The Value of New Relic’s Node.js quickstart
+  ### The value of New Relic’s Node.js quickstart
 
   Our tool also provides other essential productivity and efficiency-enhancing innovations. Service Maps acquaints developers with their system's architecture providing vital insights to identify issues quickly. Error Analytics granularly pinpoints offending lines of code, relieving developers of a potentially arduous task so that they can concentrate on resolving issues. Our solution offers historical data that could prove essential in process improvement in addition to real-time information. 
 

--- a/quickstarts/php/php/config.yml
+++ b/quickstarts/php/php/config.yml
@@ -8,23 +8,23 @@ title: PHP
 
 # Description of the quickstart
 description: |
-  ## Complete Solution to PHP Monitoring
+  ## Complete solution to PHP monitoring
 
   Use a PHP server monitor agent and let developers see a high-level summary of their app performance in a comprehensive PHP dashboard. Help teams monitor the app's Apdex, build architectural maps, and find and resolve errors quickly.
 
   A PHP server monitor collects and analyzes application data that drive data-driven decisions. Organize data, query data using NRQL, and visualize data (in customizable interactive dashboards) that directly impact customer experiences. 
 
-  ## How to Speed Up PHP with New Relic
+  ### How to speed ip PHP with New Relic
 
   Identify slow AJAX request performance issues at a glance through our PHP dashboard that boasts broader visibility. Proactively monitor where you should concentrate your efforts and address potential errors quickly.
 
-  ## What’s Included?
+  ### What’s included?
 
   Our PHP quickstart include out-of-the-box dashboards and alerts, including:
   - Alerts including error rates, duration, and throughput
   - Multiple ready-to-use dashboards including throughput, error rate %, transaction time in ms, and latest transactions
 
-  ## Value of .PHP Quickstarts
+  ### Value of .PHP quickstarts
 
   New Relic's instant observability quickstart helps developers leverage broader visibility in a PHP dashboard to resolve errors and speed up processes that enhance customer experiences.
   

--- a/quickstarts/prometheus/config.yml
+++ b/quickstarts/prometheus/config.yml
@@ -1,11 +1,11 @@
 id: 0dcf38e5-0e99-499b-94ca-2d515a9b1df1
 name: prometheus
 description: |
-  ### Prometheus Monitoring 
+  ## Prometheus monitoring 
 
   Prometheus is an open-source monitoring and alerting toolkit. Setting up Prometheus is straightforward, but scaling up and managing is not. That’s where New Relic steps in.
 
-  ### New Relic's Prometheus Quickstart
+  ### New Relic's Prometheus quickstart
 
   New Relic offers two Prometheus integration schemes, Remote Write and OpenMetrics. 
 
@@ -15,7 +15,7 @@ description: |
 
   New Relic's Prometheus Integration stores various kinds of telemetry data - whether open-source, vendor-specific, or vendor-agnostic. 
 
-  ### Value of the Prometheus Quickstart 
+  ### Value of the Prometheus quickstart 
 
   New Relic’s quickstart makes DevOps easier. Although there are many ways to use Prometheus data in New Relic, we’ll break these down into OpenMetrics and Remote Write to help you decide on the best option for you:
 

--- a/quickstarts/python/python/config.yml
+++ b/quickstarts/python/python/config.yml
@@ -1,19 +1,19 @@
 id: 986df593-98db-485b-8e8c-dd866fa28813
 name: python
 description: |
-  ### Complete Quickstart for Python Monitoring
+  ## Complete quickstart for Python monitoring
 
   Python monitoring provides visibility into all your applications to help identify and resolve performance issues. Track key transactions, monitor a dashboard for critical metrics, and trigger alerts whenever an error or problem is detected before it impacts users.
 
   The Python quickstart enables development teams to dive deep into performance metrics to inspect database query traces, code-level transaction traces, and error traces.
 
-  ### Why Monitoring Python Is so Important
+  ### Why monitoring Python is so important
 
   Python monitoring agents enable developers to troubleshoot application and endpoint issues, identify specific dependencies, and meet service level agreements. 
 
   Development teams can view detailed stack traces of sampled threads and extend performance monitoring to collect and analyze business data in a dashboard. This approach helps teams make data-driven decisions and enhance user experiences.
 
-  ### What's Included in this Quickstart?
+  ### What's included in this quickstart?
 
   New Relic's Python monitoring quickstart boasts instant full-stack observability out-of-the-box:
   - Alerts (Adpex score, CPU utilization, transaction error)
@@ -21,7 +21,7 @@ description: |
   - Monitor scripts and functions
   - Monitor WSGI web transactions
 
-  ### New Relic - Complete Python Performance Monitoring Tool
+  ### New Relic - complete Python performance monitoring tool
 
   New Relic's Python agent helps developers measure time-based values like connections per minute. It allows teams to capture discrete events with key-value attributes attached to them and analyze and query data.
 

--- a/quickstarts/redis/config.yml
+++ b/quickstarts/redis/config.yml
@@ -20,7 +20,7 @@ description: |+
 
   New Relic's Redis monitor provides actionable insights into the health of a Redis system. It supports custom charts, custom queries, and pre-built dashboards are available for those who don’t need custom configurations. All critical performance and health metrics are monitored.
 
-  ### New Relic rRedis quickstart features
+  ### New Relic Redis quickstart features
   
   Our Redis quickstart include out-of-the-box dashboards and alerts, including data such as:
   - Overview Snapshot (# masters, # slaves) + charts with commands/sec and commands/sec by node

--- a/quickstarts/redis/config.yml
+++ b/quickstarts/redis/config.yml
@@ -8,26 +8,26 @@ title: Redis
 
 # Description of the quickstart
 description: |+
-  ## A Complete Redis Monitoring System
+  ## A complete Redis monitoring system
   
   Redis operates in-memory and achieves I/O faster than traditional database systems. It includes several data structures which make it ready to use right out of the box.
 
   New Relic provides a Redis quickstart which allows you to monitor your Redis instances out-of-the-box.
 
-  ## New Relic - A Perfect Tool to Monitor Redis
+  ### New Relic - a perfect tool to monitor Redis
   
   Redis is known for its speed, so ensuring that it stays operating at peak performance is paramount. Slowdowns can lead to a compromised user experience or even a complete application failure.
 
   New Relic's Redis monitor provides actionable insights into the health of a Redis system. It supports custom charts, custom queries, and pre-built dashboards are available for those who don’t need custom configurations. All critical performance and health metrics are monitored.
 
-  ## New Relic Redis Quickstart Features
+  ### New Relic rRedis quickstart features
   
   Our Redis quickstart include out-of-the-box dashboards and alerts, including data such as:
   - Overview Snapshot (# masters, # slaves) + charts with commands/sec and commands/sec by node
   - Charts showing connected clients, connected clients by node, changes since last save by node, expired keys/second by node, memory used by node, and blocked clients.
   - Charts showing keyspace hit ratio by node, evicted keys/second by node, input bytes/second by node, network I/O per second, and output bytes / second by node.
 
-  ## Value of the Redis quickstart
+  ### Value of the Redis quickstart
   
   The Redis Quickstart provides a visual snapshot of all the key health information related to your Redis nodes and clusters. Monitoring is made easy via the clear, color-coded dashboard which showcases memory usage, network I/O, node health, and much more.
   

--- a/quickstarts/varnish/config.yml
+++ b/quickstarts/varnish/config.yml
@@ -8,7 +8,7 @@ title: Varnish
 
 # Description of the quickstart
 description: |
-  ## Varnish Cache - What is it and why should you monitor it?
+  ## Varnish Cache and why should you monitor it?
   
   Varnish is a web cache used for content delivery and website acceleration. Media delivery over the internet can often experience lags and slow downs related to heavy user traffic and high throughput volumes. Varnish helps to address these issues by offering CDNs, streaming servers, caches, and HTTP/API reverse proxies that speed up the user experience. Caches such as Varnish are sensitive to things like insertion hits and misses and backend interactions, so it’s important to monitor such metrics to ensure Varnish runs smoothly.
   


### PR DESCRIPTION
We had some inconsistent capitalization in our description headers. This PR makes them all sentence case, and also makes a few small changes to the sizing of headers (made some h2s -> h3s.)