### PR TITLE
chore: explicit checkout for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
+          ref: 'main'
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v2
@@ -105,6 +107,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
+          ref: 'main'
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v2


### PR DESCRIPTION
# Summary

Update the release workflow jobs to explicitly pull down git history on the main branch.

Closes #419 