### PR TITLE
chore: adding docs to config for network data ingest

### DIFF
--- a/quickstarts/network-data-ingest-and-cardinality/config.yml
+++ b/quickstarts/network-data-ingest-and-cardinality/config.yml
@@ -33,6 +33,12 @@ keywords:
   - featured
   - infrastructure
 
+documentation:
+  - name: Network Performance Monitoring docs
+    url: https://docs.newrelic.com/docs/network-performance-monitoring/get-started/npm-introduction/
+    description: |
+      Get started with Network Performance Monitoring (NPM).
+
 # Content / Design
 icon: icon.png
 logo: logo.png


### PR DESCRIPTION
# Summary

Addressing notes for `Network - Data Ingest and Cardinality` quickstart from Issue #367 by adding a `documentation` section to `config.yml`