### PR TITLE
chore: ups limits

### DIFF
--- a/utils/schemas/main_config.json
+++ b/utils/schemas/main_config.json
@@ -59,7 +59,7 @@
       "title": "The description schema",
       "description": "A long form description for this quickstart",
       "minLength": 0,
-      "maxLength": 2000,
+      "maxLength": 4000,
       "default": "",
       "examples": [
         "The template quickstart allows you to get visibilility into the performance and available of your example service and dependencies. Use this quickstart together with the mock up integrations."
@@ -140,7 +140,7 @@
       "title": "The summary schema",
       "description": "# Displayed in search results and recommendations. Summarizes a quickstarts functionality.",
       "minLength": 0,
-      "maxLength": 250,
+      "maxLength": 500,
       "default": "",
       "examples": ["Short description of quickstart"]
     },


### PR DESCRIPTION
this PR ups the limits on description and summary to account for the counting of spaces in the cotent blocks.