### PR TITLE
fix: added install plan for aws metric streams dashboards

### DIFF
--- a/install/aws/aws-cloudwatch-metric-streams/install.yml
+++ b/install/aws/aws-cloudwatch-metric-streams/install.yml
@@ -1,0 +1,13 @@
+id: aws-cloudwatch-metric-streams
+name: AWS-CloudWatch-Metric-Streams
+title: AWS Metric Streams
+description: |
+  AWS CloudWatch Metric Streams integration enables streaming of metrics from any AWS service (including custom namespaces) to New Relic. 
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: link
+  destination:
+    url: https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream/

--- a/install/aws/aws-cloudwatch-metric-streams/install.yml
+++ b/install/aws/aws-cloudwatch-metric-streams/install.yml
@@ -10,4 +10,5 @@ target:
 install:
   mode: link
   destination:
-    url: https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream/
+    url: >-
+      https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream/

--- a/quickstarts/aws/aws-nlb-alb/config.yml
+++ b/quickstarts/aws/aws-nlb-alb/config.yml
@@ -34,3 +34,5 @@ keywords:
   - aws
   - amazon web services
   - networking
+installPlans:
+  - aws-cloudwatch-metric-streams


### PR DESCRIPTION
# Summary
Adding a link-based install plan for AWS dashboards based on CloudWatch metric streams pointing to AWS CloudWatch metric streams setup instructions (no guided install at the moment). 
Starting with ALB dashboard only, we'll migrate others once this is validated. 

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [x] Did you include an InstallPlan and Documentation reference?
- [x] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?

### Screenshots

Attach images of any visual changes, such as a dashboard here.
