### PR TITLE
Use https prefix on Fastly docs link

### DIFF
--- a/quickstarts/fastly/config.yml
+++ b/quickstarts/fastly/config.yml
@@ -37,7 +37,7 @@ installPlans:
 
 documentation:
   - name: Installation Docs
-    url: docs.fastly.com/en/guides/log-streaming-newrelic-logs
+    url: https://docs.fastly.com/en/guides/log-streaming-newrelic-logs
     description: Configure Fastly streaming logs to New Relic
 
 # Content / Design


### PR DESCRIPTION
# Summary

The Fastly quickstart is a featured quickstart, but its docs link is broken. This PR prepends the `https://` prefix to ensure the doc link opens up as expected.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [ ] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?
