### PR TITLE
fix:  change name and title to CodeStream

### DIFF
--- a/quickstarts/codestream/config.yml
+++ b/quickstarts/codestream/config.yml
@@ -1,5 +1,5 @@
 id: 29bd9a4a-1c19-4219-9694-0942f6411ce7
-name: new-relic-codestream
+name: codestream
 
 description: |
   ## What is New Relic CodeStream?
@@ -29,7 +29,7 @@ logo: logo.svg
 level: New Relic
 authors:
   - New Relic
-title: New Relic CodeStream
+title: CodeStream
 documentation:
   - name: Installation Docs
     description: View production telemetry and troubleshoot errors from your IDE


### PR DESCRIPTION
# Summary

Changing the name of the CodeStream quickstart to remove the "New Relic" that was prefixed.  This brings it in-line with the other names.

## Pre merge checklist

- [n/a ] Did you check you NRQL syntax? - Does it work?
- [n/a ] Did you check your dashboard image quality? -  Do they look good?
- [n/a ] Did you check that your alerts actually work?
- [n/a ] Did you include an InstallPlan and Documentation reference?
- [n/a ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [n/a ] Did you attach images of your dashboards to the PR so we can see them working?

### Screenshots

Attach images of any visual changes, such as a dashboard here.
