### PR TITLE
fix: restoring installPlan for network performance monitoring

### DIFF
--- a/install/network/npm/install.yml
+++ b/install/network/npm/install.yml
@@ -1,0 +1,13 @@
+id: network-performance-monitoring
+name: NPM
+title: Network Performance Monitoring
+description: |
+  Set up your network devices so they send network data to New Relic One.
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: link
+  destination:
+    url: https://docs.newrelic.com/docs/network-performance-monitoring/get-started/npm-introduction/


### PR DESCRIPTION
adding back the installPlan for the `network-data-ingest-and-cardinality` dashboard that was removed on [this change](https://github.com/newrelic/newrelic-quickstarts/commit/ca6a743953f488dd4e3ac15588f89d59045513c7#diff-258faaa56614e5fbf20729c13e0bf47fd42dfee8a8512bf6b3c702042139185a)