### PR TITLE
fix: small name change to make it clear it's the apache webserver

### DIFF
--- a/quickstarts/apache/config.yml
+++ b/quickstarts/apache/config.yml
@@ -11,7 +11,7 @@ title: Apache httpd
 description: |+
   ## Understanding Apache httpd
 
-  The Apache HTTP Server is a free and open-source, secure, efficient, and extensible HTTP web server for the Windows and UNIX operating systems.
+The Apache HTTP Server is a free and open-source, secure, efficient, and extensible HTTP web server for the Windows and UNIX operating systems.
 
   ### What should you look for in an Apache HTTP Server Monitor?
 

--- a/quickstarts/apache/config.yml
+++ b/quickstarts/apache/config.yml
@@ -4,12 +4,12 @@ id: ad5affab-545a-4355-ad48-cfd66e2fbf00
 name: apache
 
 # Title of the quickstart
-title: Apache
+title: Apache httpd
 
 # Description of the quickstart
 
 description: |+
-  ## Understanding Apache
+  ## Understanding Apache httpd
 
   The Apache HTTP Server is a free and open-source, secure, efficient, and extensible HTTP web server for the Windows and UNIX operating systems.
 

--- a/quickstarts/apache/config.yml
+++ b/quickstarts/apache/config.yml
@@ -11,7 +11,7 @@ title: Apache httpd
 description: |+
   ## Understanding Apache httpd
 
-The Apache HTTP Server is a free and open-source, secure, efficient, and extensible HTTP web server for the Windows and UNIX operating systems.
+  The Apache HTTP Server is a free and open-source, secure, efficient, and extensible HTTP web server for the Windows and UNIX operating systems.
 
   ### What should you look for in an Apache HTTP Server Monitor?
 


### PR DESCRIPTION
Small fix to avoid confusion. Apache is an organization with many different projects, which all have the “Apache” prefix in them. For instance, it’s not “kafka” but “Apache Kafka”, it’s not Cassandra but “Apache Cassandra”.