### PR TITLE
fix: change typo in quickstart name

### DIFF
--- a/quickstarts/account-data-ingestion/config.yml
+++ b/quickstarts/account-data-ingestion/config.yml
@@ -1,6 +1,6 @@
 id: 51e66f0d-153c-493c-a75c-a386c3f170ce
 # Name of the quickstart (required)
-name: acccount-data-ingestion
+name: account-data-ingestion
 
 # Displayed in the UI (required)
 title: Data Ingestion Breakdown


### PR DESCRIPTION
# Summary

Just noticed this while querying the API. 

CAUTION: No idea if this YAML change is breaking! Just highlighting the typo really. :D  Feel free to close this PR and address in another way as appropriate
