### PR TITLE
style(macOS): Change `Mac OS` to `macOS`

### DIFF
--- a/quickstarts/macos/config.yml
+++ b/quickstarts/macos/config.yml
@@ -3,12 +3,12 @@ id: 2acd265d-427d-4064-ab71-915e3c2824fe
 name: macos
 
 # Displayed in the UI
-title: Apple Mac OS (Beta)
+title: Apple macOS (Beta)
 
 # Long-form description of the quickstart (required)
 description: |
-  ## Apple Mac OS?
-  With New Relic's infrastructure monitoring agent for Mac OS, you can monitor individual desktops or servers to analyze how your applications are performing as a whole. The Mac OS agent can run on your own hardware or in cloud systems such as AWS.
+  ## Apple macOS?
+  With New Relic's infrastructure monitoring agent for macOS, you can monitor individual desktops or servers to analyze how your applications are performing as a whole. The macOS agent can run on your own hardware or in cloud systems such as AWS.
 
   ## Supported versions
   - macOS 10.14 (Mohave), 10.15 (Catalina), 11 (Big Sur)
@@ -16,7 +16,7 @@ description: |
 
 # Displayed in search results and recommendations. Summarizes a quickstarts functionality.
 summary: |
-  Monitor your Mac OS Desktop or Server
+  Monitor your macOS Desktop or Server
 
 # Support level: New Relic | Verified | Community (required)
 level: New Relic


### PR DESCRIPTION
Apple's official style is `macOS`, not `Mac OS` 

* Our usage guidelines: https://docs.newrelic.com/docs/style-guide/quick-reference/usage-dictionary/#macos
* Example in use on Apple's site: https://www.apple.com/macos/monterey/