### PR TITLE
feat: removed OHIs targeted installs with low success rate

### DIFF
--- a/install/on-host-integration/cassandra/install.yml
+++ b/install/on-host-integration/cassandra/install.yml
@@ -11,11 +11,6 @@ target:
   destination: host
 
 install:
-  mode: targetedInstall
-  destination:
-    recipeName: cassandra-open-source-integration
-
-fallback:
   mode: link
   destination:
-    url: https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/cassandra-monitoring-integration/
+    url: https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/cassandra-monitoring-integration/#install

--- a/install/on-host-integration/elasticsearch/install.yml
+++ b/install/on-host-integration/elasticsearch/install.yml
@@ -11,11 +11,6 @@ target:
   destination: host
 
 install:
-  mode: targetedInstall
-  destination:
-    recipeName: elasticsearch-open-source-integration
-
-fallback:
   mode: link
   destination:
-    url: https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/elasticsearch-monitoring-integration/
+    url: https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/elasticsearch-monitoring-integration/#install

--- a/install/on-host-integration/haproxy/install.yml
+++ b/install/on-host-integration/haproxy/install.yml
@@ -11,11 +11,6 @@ target:
   destination: host
 
 install:
-  mode: targetedInstall
-  destination:
-    recipeName: haproxy-open-source-integration
-
-fallback:
   mode: link
   destination:
-    url: https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/haproxy-monitoring-integration/
+    url: https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/haproxy-monitoring-integration/#install

--- a/install/on-host-integration/hashicorp-consul/install.yml
+++ b/install/on-host-integration/hashicorp-consul/install.yml
@@ -11,11 +11,6 @@ target:
   destination: host
 
 install:
-  mode: targetedInstall
-  destination:
-    recipeName: hashicorp-consul-open-source-integration
-
-fallback:
   mode: link
   destination:
-    url: https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/hashicorp-consul-monitoring-integration/
+    url: https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/hashicorp-consul-monitoring-integration/#install

--- a/install/on-host-integration/mongodb/install.yml
+++ b/install/on-host-integration/mongodb/install.yml
@@ -11,11 +11,6 @@ target:
   destination: host
 
 install:
-  mode: targetedInstall
-  destination:
-    recipeName: mongodb-open-source-integration
-
-fallback:
   mode: link
   destination:
-    url: https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/mongodb-monitoring-integration/
+    url: https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/mongodb-monitoring-integration/#install

--- a/install/on-host-integration/nagios/install.yml
+++ b/install/on-host-integration/nagios/install.yml
@@ -11,11 +11,6 @@ target:
   destination: host
 
 install:
-  mode: targetedInstall
-  destination:
-    recipeName: nagios-open-source-integration
-
-fallback:
   mode: link
   destination:
-    url: https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/nagios-monitoring-integration/
+    url: https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/nagios-monitoring-integration/#install

--- a/install/on-host-integration/postgres/install.yml
+++ b/install/on-host-integration/postgres/install.yml
@@ -11,11 +11,6 @@ target:
   destination: host
 
 install:
-  mode: targetedInstall
-  destination:
-    recipeName: postgres-open-source-integration
-
-fallback:
   mode: link
   destination:
-    url: https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/postgresql-monitoring-integration/
+    url: https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/postgresql-monitoring-integration/#install

--- a/install/on-host-integration/rabbitmq/install.yml
+++ b/install/on-host-integration/rabbitmq/install.yml
@@ -11,11 +11,6 @@ target:
   destination: host
 
 install:
-  mode: targetedInstall
-  destination:
-    recipeName: rabbitmq-open-source-integration
-
-fallback:
   mode: link
   destination:
-    url: https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/rabbitmq-monitoring-integration/
+    url: https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/rabbitmq-monitoring-integration/#install

--- a/install/on-host-integration/varnish/install.yml
+++ b/install/on-host-integration/varnish/install.yml
@@ -11,11 +11,6 @@ target:
   destination: host
 
 install:
-  mode: targetedInstall
-  destination:
-    recipeName: varnish-cache-open-source-integration
-
-fallback:
   mode: link
   destination:
-    url: https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/varnish-cache-monitoring-integration/
+    url: https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/varnish-cache-monitoring-integration/#install


### PR DESCRIPTION
# Summary

This is removing the targeted installation for OHIs with a high weekly failure rate per this dashboard:

https://staging.onenr.io/0dBj3p0nxQX

Additionally, the documentation links used have been updated to point to the installation instructions section of the given OHI, as the start of the documentation also references the targeted installation command.