### PR TITLE
fix: change name of key

### DIFF
--- a/quickstarts/speedscale/config.yml
+++ b/quickstarts/speedscale/config.yml
@@ -40,7 +40,7 @@ installPlans:
 documentation:
   - name: Speedscale Installation Docs
     url: https://docs.speedscale.com/reference/integrations/new-relic
-    description: The only prerequisite is to obtain your New Relic account id and insights insert key.
+    description: The only prerequisite is to obtain your New Relic account id and license key.
 
 # Content / Design
 logo: logo.svg


### PR DESCRIPTION
We no longer use insights insert key, but instead use license keys. Quick copy fix. 