### PR TITLE
fix (logAnalysis): changed installPlan

### DIFF
--- a/quickstarts/audit/log-ingestion-analysis/config.yml
+++ b/quickstarts/audit/log-ingestion-analysis/config.yml
@@ -30,7 +30,7 @@ keywords:
 # Reference to install plans located under /install directory
 # Allows us to construct reusable "install plans" and just use their ID in the quickstart config
 installPlans:
-  - guided-install
+  - telemetry-data-platform
 
 documentation:
   - name: Log Management


### PR DESCRIPTION
# Summary
Fixing the installPlan from guided-install to telemetry-data-platform, because the guided-install does not give the option to skip the installation process.

