### PR TITLE
chore: adding default log install plan

### DIFF
--- a/install/logs/default/install.yml
+++ b/install/logs/default/install.yml
@@ -1,0 +1,13 @@
+id: logs-default
+name: New Relic Logs
+title: Manage log collection for New Relic
+description: |
+  Manage log collection for New Relic
+target:
+  type: unknown
+  destination: unknown
+
+install:
+  mode: link
+  destination:
+    url: https://docs.newrelic.com/docs/logs/forward-logs/enable-log-management-new-relic/

--- a/quickstarts/audit/log-ingestion-analysis/config.yml
+++ b/quickstarts/audit/log-ingestion-analysis/config.yml
@@ -30,7 +30,7 @@ keywords:
 # Reference to install plans located under /install directory
 # Allows us to construct reusable "install plans" and just use their ID in the quickstart config
 installPlans:
-  - telemetry-data-platform
+  - logs-default
 
 documentation:
   - name: Log Management


### PR DESCRIPTION
# Summary

Adding dedicated install plan for logs; links to default logs management documentation for the `Logs Analysis` dashboard. 