### PR TITLE
chore: Show OHIs in infrastructure category

### DIFF
--- a/quickstarts/audit/infrastructure-integrations-data-analysis/config.yml
+++ b/quickstarts/audit/infrastructure-integrations-data-analysis/config.yml
@@ -25,6 +25,7 @@ authors:
 keywords:
   - audit
   - data ingest
+  - infrastructure
   - k8s
   - kubernetes
   - on-host integration

--- a/quickstarts/aws/aws-ecs-ecr/config.yml
+++ b/quickstarts/aws/aws-ecs-ecr/config.yml
@@ -33,3 +33,4 @@ keywords:
   - aws
   - amazon web services
   - containers
+  - infrastructure

--- a/quickstarts/collectd/config.yml
+++ b/quickstarts/collectd/config.yml
@@ -24,4 +24,5 @@ documentation:
     url: >-
       https://docs.newrelic.com/docs/integrations/host-integrations/open-source-host-integrations-list/collectd-open-source-integration
 keywords:
+  - infrastructure
   - open source monitoring

--- a/quickstarts/jmx/config.yml
+++ b/quickstarts/jmx/config.yml
@@ -32,3 +32,6 @@ installPlans:
   - infra-agent-targeted
   - jmx-integration-docs
 
+keywords:
+  - infrastructure
+  - java

--- a/quickstarts/mssql/config.yml
+++ b/quickstarts/mssql/config.yml
@@ -10,7 +10,7 @@ logo: logo.svg
 level: New Relic
 authors:
   - New Relic
-title: MSSQL
+title: Microsoft SQL Server
 documentation:
   - name: MSSQL installation docs
     description: |

--- a/quickstarts/perfmon/config.yml
+++ b/quickstarts/perfmon/config.yml
@@ -18,4 +18,5 @@ documentation:
       data and analytics.
     url: https://docs.newrelic.com/docs/perfmon-open-source-integration
 keywords:
+  - infrastructure
   - windows

--- a/quickstarts/postgresql/config.yml
+++ b/quickstarts/postgresql/config.yml
@@ -31,3 +31,6 @@ documentation:
 installPlans:
   - postgresql-integration
 
+keywords:
+  - database
+  - infrastructure

--- a/quickstarts/statsd/config.yml
+++ b/quickstarts/statsd/config.yml
@@ -24,4 +24,5 @@ documentation:
     url: >-
       https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/statsd-monitoring-integration-version-2
 keywords:
+  - infrastructure
   - open source monitoring


### PR DESCRIPTION
- Adding keywords so OHIs show up in "infrastructure" category
- Change title of MSSQL to match name in docs https://docs.newrelic.com/docs/infrastructure/host-integrations/get-started/introduction-host-integrations/

# Summary

This [docs page](https://docs.newrelic.com/docs/infrastructure/host-integrations/get-started/introduction-host-integrations/) links to I/O with the infrastructure category selected, but many OHIs weren't showing up (or in the case of MSSQL, the title didn't match the expected OHI name.

This commit adds the infrastructure keyword to existing keyword lists, and adds keyword lists to quickstarts that were missing them. It also changes the title of MSSQL.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [ ] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?

### Screenshots

Attach images of any visual changes, such as a dashboard here.
