### PR TITLE
ignore install plan id does not exist errors

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
 
       - name: Install dependencies
         run: cd utils && yarn install

--- a/.github/workflows/validate_packs.yml
+++ b/.github/workflows/validate_packs.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
 
       - name: Install dependencies
         run: cd utils && yarn install
@@ -89,7 +89,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
 
       - name: Install dependencies
         run: cd utils && yarn install
@@ -179,7 +179,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
 
       - name: Install dependencies
         run: cd utils && yarn install
@@ -228,7 +228,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
 
       - name: Install dependencies
         run: cd utils && yarn install
@@ -277,7 +277,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
 
       - name: Install dependencies
         run: cd utils && yarn install

--- a/utils/__tests__/validate_pr_quickstarts.test.js
+++ b/utils/__tests__/validate_pr_quickstarts.test.js
@@ -9,8 +9,11 @@ const {
   buildMutationVariables,
   buildUniqueQuickstartSet,
   getGraphqlRequests,
+  countErrors,
 } = require('../validate_pr_quickstarts');
 const { readQuickstartFile } = require('../helpers');
+
+jest.mock('../nr-graphql-helpers');
 
 const mockDashboardRawConfigurationJSON = require('../mock_files/mock_dashboard_config.json');
 const mockDashboardRawConfiguration = JSON.stringify(
@@ -113,7 +116,8 @@ const expectedMockQuickstart2MutationInput = {
         description: 'Description about this doc reference',
       },
     ],
-    icon: 'https://raw.githubusercontent.com/newrelic/newrelic-quickstarts/main/utils/mock_files/mock-quickstart-2/logo.png',
+    icon:
+      'https://raw.githubusercontent.com/newrelic/newrelic-quickstarts/main/utils/mock_files/mock-quickstart-2/logo.png',
     keywords: ['list', 'of', 'searchable', 'keywords'],
     sourceUrl:
       'https://github.com/newrelic/newrelic-quickstarts/tree/main/utils/mock_files/mock-quickstart-2',
@@ -144,13 +148,16 @@ const expectedMockQuickstart2MutationInput = {
         rawConfiguration: mockDashboardRawConfiguration,
         screenshots: [
           {
-            url: 'https://raw.githubusercontent.com/newrelic/newrelic-quickstarts/main/utils/mock_files/mock-quickstart-2/dashboards/dotnet.png',
+            url:
+              'https://raw.githubusercontent.com/newrelic/newrelic-quickstarts/main/utils/mock_files/mock-quickstart-2/dashboards/dotnet.png',
           },
           {
-            url: 'https://raw.githubusercontent.com/newrelic/newrelic-quickstarts/main/utils/mock_files/mock-quickstart-2/dashboards/dotnet02.png',
+            url:
+              'https://raw.githubusercontent.com/newrelic/newrelic-quickstarts/main/utils/mock_files/mock-quickstart-2/dashboards/dotnet02.png',
           },
           {
-            url: 'https://raw.githubusercontent.com/newrelic/newrelic-quickstarts/main/utils/mock_files/mock-quickstart-2/dashboards/dotnet03.png',
+            url:
+              'https://raw.githubusercontent.com/newrelic/newrelic-quickstarts/main/utils/mock_files/mock-quickstart-2/dashboards/dotnet03.png',
           },
         ],
       },
@@ -268,4 +275,130 @@ test('getGraphqlRequests constructs requests with a filepath and variables struc
   expect(graphqlRequests[0].filePath).toEqual(
     'quickstarts/python/aiohttp/config.yml'
   );
+});
+
+describe('countErrors', () => {
+  test('no errors returns error count of 0', () => {
+    const graphqlResponses = [
+      {
+        errors: [],
+        filePath: 'fake_file_path',
+      },
+    ];
+
+    const errorCount = countErrors(graphqlResponses);
+
+    expect(errorCount).toBe(0);
+  });
+
+  test(`only 'install plan does not exist' errors returns error count of 0`, () => {
+    const graphqlResponses = [
+      {
+        errors: [
+          {
+            extensions: {
+              argumentPath: ['quickstartMetadata', 'installPlanStepIds'],
+            },
+            message:
+              "`installPlanStepIds` contains an install plan step that does not exist: 'fake_install_plan'",
+          },
+        ],
+        filePath: 'fake_file_path',
+      },
+    ];
+
+    const errorCount = countErrors(graphqlResponses);
+
+    expect(errorCount).toBe(0);
+  });
+
+  test(`for a single file with multiple errors, 'install plan does not exist' errors are not counted`, () => {
+    const graphqlResponses = [
+      {
+        errors: [
+          {
+            extensions: {
+              argumentPath: ['quickstartMetadata', 'installPlanStepIds'],
+            },
+            message:
+              "`installPlanStepIds` contains an install plan step that does not exist: 'fake_install_plan'",
+          },
+          {
+            extensions: {
+              argumentPath: ['quickstartMetadata', 'description'],
+            },
+            message: "`description` can't be blank",
+          },
+          {
+            extensions: {
+              argumentPath: ['quickstartMetadata', 'summary'],
+            },
+            message: "`summary` can't be blank",
+          },
+        ],
+        filePath: 'fake_file_path',
+      },
+    ];
+
+    const errorCount = countErrors(graphqlResponses);
+
+    expect(errorCount).toBe(2);
+  });
+
+  test('for multiple files with multiple errors each, error count is summed correctly', () => {
+    const graphqlResponses = [
+      {
+        errors: [
+          {
+            extensions: {
+              argumentPath: ['quickstartMetadata', 'installPlanStepIds'],
+            },
+            message:
+              "`installPlanStepIds` contains an install plan step that does not exist: 'fake_install_plan'",
+          },
+          {
+            extensions: {
+              argumentPath: ['quickstartMetadata', 'description'],
+            },
+            message: "`description` can't be blank",
+          },
+          {
+            extensions: {
+              argumentPath: ['quickstartMetadata', 'summary'],
+            },
+            message: "`summary` can't be blank",
+          },
+        ],
+        filePath: 'fake_file_path',
+      },
+      {
+        errors: [
+          {
+            extensions: {
+              argumentPath: ['quickstartMetadata', 'installPlanStepIds'],
+            },
+            message:
+              "`installPlanStepIds` contains an install plan step that does not exist: 'fake_install_plan'",
+          },
+          {
+            extensions: {
+              argumentPath: ['quickstartMetadata', 'description'],
+            },
+            message: "`description` can't be blank",
+          },
+          {
+            extensions: {
+              argumentPath: ['quickstartMetadata', 'summary'],
+            },
+            message: "`summary` can't be blank",
+          },
+        ],
+        filePath: 'fake_file_path_2',
+      },
+    ];
+
+    const errorCount = countErrors(graphqlResponses);
+
+    expect(errorCount).toBe(4);
+  });
 });

--- a/utils/validate_pr_quickstarts.js
+++ b/utils/validate_pr_quickstarts.js
@@ -359,8 +359,10 @@ const countErrors = (graphqlResponses) => {
         )
     );
 
-    if (remainingErrors.length > 0) {
-      errorCount += remainingErrors.length;
+    errorCount += remainingErrors.length;
+
+    // we want to print out all errors, including install plan id does not exist
+    if (errors.length > 0) {
       translateMutationErrors(remainingErrors, filePath);
     }
   });

--- a/utils/validate_pr_quickstarts.js
+++ b/utils/validate_pr_quickstarts.js
@@ -237,8 +237,9 @@ const adaptQuickstartDashboardInput = (dashboardConfigPaths) =>
   dashboardConfigPaths.map((dashboardConfigPath) => {
     const parsedConfig = readQuickstartFile(dashboardConfigPath);
     const { description, name } = parsedConfig.contents[0];
-    const screenshotPaths =
-      getQuickstartDashboardScreenshotPaths(dashboardConfigPath);
+    const screenshotPaths = getQuickstartDashboardScreenshotPaths(
+      dashboardConfigPath
+    );
     return {
       description: description && description.trim(),
       displayName: name && name.trim(),
@@ -336,16 +337,35 @@ const validateQuickstarts = async (files) => {
     })
   );
 
-  let hasFailed = false;
+  return Boolean(countErrors(graphqlResponses));
+};
+
+/**
+ * @param {Object[]} graphqlResponses[]
+ * @param {Object[]} graphqlResponses[].errors
+ * @param {string[]} graphqlResponses[].filePath
+ * @returns {number}
+ */
+const countErrors = (graphqlResponses) => {
+  let errorCount = 0;
 
   graphqlResponses.forEach(({ errors, filePath }) => {
-    if (errors.length > 0) {
-      hasFailed = true;
-      translateMutationErrors(errors, filePath);
+    // filter out errors where install plan id does not exist
+    const remainingErrors = errors.filter(
+      (error) =>
+        !error?.extensions?.argumentPath?.includes('installPlanStepIds') ||
+        !error?.message?.includes(
+          'contains an install plan step that does not exist'
+        )
+    );
+
+    if (remainingErrors.length > 0) {
+      errorCount += remainingErrors.length;
+      translateMutationErrors(remainingErrors, filePath);
     }
   });
 
-  return hasFailed;
+  return errorCount;
 };
 
 const main = async () => {
@@ -376,4 +396,5 @@ module.exports = {
   buildMutationVariables,
   buildUniqueQuickstartSet,
   getGraphqlRequests,
+  countErrors,
 };


### PR DESCRIPTION
## Summary

The functionality we ultimately want to see is that errors relating to install plan id's not existing coming from the api are ignored and don't fail the workflow.

In that effort, I moved handling the graphqlResponses & the handling of this new error case we want into a new method call countErrors(). This method returns the number of errors found, which the caller can still Booleanify to be consumed as before. In the case where we see that error mentioned above, the count is not incremented & the error is effectively ignored. We still print out all errors as before.

Also added in some unit tests.

## Links
Resolves: #702