### PR TITLE
Feat/add cloud install plans

### DIFF
--- a/docs/install_config.md
+++ b/docs/install_config.md
@@ -40,6 +40,9 @@
         "destination": {
             "recipeName": "infrastructure-agent-installer",
             "nerdletId": "setup-nerdlets.setup-python-integration",
+            "nerdletState": {
+                "integration": "python"
+            },
             "url": "https://docs.newrelic.com/docs/agents/python-agent/installation/standard-python-agent-install/#install"
         }
     },
@@ -48,6 +51,9 @@
         "destination": {
             "recipeName": "infrastructure-agent-installer",
             "nerdletId": "setup-nerdlets.setup-python-integration",
+            "nerdletState": {
+                "name": "value"
+            },
             "url": "https://docs.newrelic.com/docs/agents/python-agent/installation/standard-python-agent-install/#install"
         }
     }
@@ -311,6 +317,9 @@ Must be one of:
     "destination": {
         "recipeName": "infrastructure-agent-installer",
         "nerdletId": "setup-nerdlets.setup-python-integration",
+        "nerdletState": {
+            "integration": "python"
+        },
         "url": "https://docs.newrelic.com/docs/agents/python-agent/installation/standard-python-agent-install/#install"
     }
 }
@@ -352,12 +361,13 @@ Must be one of:
 
 **Description:** An explanation about the purpose of this instance.
 
-| Property                                         | Pattern | Type   | Deprecated | Definition | Title/Description     |
-| ------------------------------------------------ | ------- | ------ | ---------- | ---------- | --------------------- |
-| - [recipeName](#install_destination_recipeName ) | No      | string | No         | -          | The recipeName schema |
-| - [nerdletId](#install_destination_nerdletId )   | No      | string | No         | -          | The nerdletId schema  |
-| - [url](#install_destination_url )               | No      | string | No         | -          | The url schema        |
-|                                                  |         |        |            |            |                       |
+| Property                                             | Pattern | Type   | Deprecated | Definition | Title/Description       |
+| ---------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------------- |
+| - [recipeName](#install_destination_recipeName )     | No      | string | No         | -          | The recipeName schema   |
+| - [nerdletId](#install_destination_nerdletId )       | No      | string | No         | -          | The nerdletId schema    |
+| - [nerdletState](#install_destination_nerdletState ) | No      | object | No         | -          | The nerdletState schema |
+| - [url](#install_destination_url )                   | No      | string | No         | -          | The url schema          |
+|                                                      |         |        |            |            |                         |
 
 **Example:** 
 
@@ -365,6 +375,9 @@ Must be one of:
 {
     "recipeName": "infrastructure-agent-installer",
     "nerdletId": "setup-nerdlets.setup-python-integration",
+    "nerdletState": {
+        "integration": "python"
+    },
     "url": "https://docs.newrelic.com/docs/agents/python-agent/installation/standard-python-agent-install/#install"
 }
 ```
@@ -403,6 +416,26 @@ Must be one of:
 
 ```json
 "setup-nerdlets.setup-python-integration"
+```
+
+#### <a name="install_destination_nerdletState"></a>5.2.2. [Optional] Property `root > install > destination > nerdletState`
+
+**Title:** The urlState to be passed to the nerdlet
+
+| Type                      | `object`                                                                  |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Additional properties** | [[Any type: allowed]](# "Additional Properties of any type are allowed.") |
+| **Default**               | `{}`                                                                      |
+|                           |                                                                           |
+
+**Description:** State object to be provided to the nerdlet's urlState.
+
+**Example:** 
+
+```json
+{
+    "integration": "python"
+}
 ```
 
 #### <a name="install_destination_url"></a>5.2.3. [Optional] Property `root > install > destination > url`
@@ -449,6 +482,9 @@ Must be one of:
     "destination": {
         "recipeName": "infrastructure-agent-installer",
         "nerdletId": "setup-nerdlets.setup-python-integration",
+        "nerdletState": {
+            "name": "value"
+        },
         "url": "https://docs.newrelic.com/docs/agents/python-agent/installation/standard-python-agent-install/#install"
     }
 }
@@ -490,12 +526,13 @@ Must be one of:
 
 **Description:** An explanation about the purpose of this instance.
 
-| Property                                          | Pattern | Type   | Deprecated | Definition | Title/Description     |
-| ------------------------------------------------- | ------- | ------ | ---------- | ---------- | --------------------- |
-| - [recipeName](#fallback_destination_recipeName ) | No      | string | No         | -          | The recipeName schema |
-| - [nerdletId](#fallback_destination_nerdletId )   | No      | string | No         | -          | The nerdletId schema  |
-| - [url](#fallback_destination_url )               | No      | string | No         | -          | The url schema        |
-|                                                   |         |        |            |            |                       |
+| Property                                              | Pattern | Type   | Deprecated | Definition | Title/Description       |
+| ----------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------------- |
+| - [recipeName](#fallback_destination_recipeName )     | No      | string | No         | -          | The recipeName schema   |
+| - [nerdletId](#fallback_destination_nerdletId )       | No      | string | No         | -          | The nerdletId schema    |
+| - [nerdletState](#fallback_destination_nerdletState ) | No      | object | No         | -          | The nerdletState schema |
+| - [url](#fallback_destination_url )                   | No      | string | No         | -          | The url schema          |
+|                                                       |         |        |            |            |                         |
 
 **Example:** 
 
@@ -503,6 +540,9 @@ Must be one of:
 {
     "recipeName": "infrastructure-agent-installer",
     "nerdletId": "setup-nerdlets.setup-python-integration",
+    "nerdletState": {
+        "name": "value"
+    }
     "url": "https://docs.newrelic.com/docs/agents/python-agent/installation/standard-python-agent-install/#install"
 }
 ```
@@ -541,6 +581,26 @@ Must be one of:
 
 ```json
 "setup-nerdlets.setup-python-integration"
+```
+
+#### <a name="fallback_destination_nerdletState"></a>6.2.2. [Optional] Property `root > fallback > destination > nerdletState`
+
+**Title:** The urlState to be passed to the nerdlet
+
+| Type                      | `object`                                                                  |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Additional properties** | [[Any type: allowed]](# "Additional Properties of any type are allowed.") |
+| **Default**               | `{}`                                                                      |
+|                           |                                                                           |
+
+**Description:** State object to be provided to the nerdlet's urlState.
+
+**Example:** 
+
+```json
+{
+    "name": "value"
+}
 ```
 
 #### <a name="fallback_destination_url"></a>6.2.3. [Optional] Property `root > fallback > destination > url`

--- a/install/aws/aws-cloudwatch-metric-streams/install.yml
+++ b/install/aws/aws-cloudwatch-metric-streams/install.yml
@@ -8,6 +8,15 @@ target:
   destination: cloud
 
 install:
+  mode: nerdlet
+  destination:
+    nerdletId: infra.aws
+    nerdletState:
+      providerName: aws
+      feature: accountWizardSetup
+      dataSource: 1
+
+fallback:
   mode: link
   destination:
     url: >-

--- a/install/aws/aws-infrastructure-monitoring/install.yml
+++ b/install/aws/aws-infrastructure-monitoring/install.yml
@@ -1,0 +1,21 @@
+id: aws-infrastructure-monitoring
+name: AWS-Infrastructure-Monitoring
+title: AWS Infrastructure Monitoring
+description: |
+  AWS Infrastructure Monitoring allows monitoring of various AWS services. 
+target:
+  type: cloud
+  destination: cloud
+
+install:
+  mode: nerdlet
+  destination:
+    nerdletId: infra.aws
+    nerdletState:
+      providerName: aws
+      
+fallback:
+  mode: link
+  destination:
+    url: >-
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/get-started/connect-aws-new-relic-infrastructure-monitoring/

--- a/install/azure/azure-infrastructure-monitoring/install.yml
+++ b/install/azure/azure-infrastructure-monitoring/install.yml
@@ -1,0 +1,21 @@
+id: azure-infrastructure-monitoring
+name: Azure-Infrastructure-Monitoring
+title: Azure Infrastructure Monitoring
+description: |
+  Azure Infrastructure Monitoring allows monitoring of various Azure services. 
+target:
+  type: cloud
+  destination: cloud
+
+install:
+  mode: nerdlet
+  destination:
+    nerdletId: infra.azure
+    nerdletState:
+      providerName: azure
+
+fallback:
+  mode: link
+  destination:
+    url: >-
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/get-started/activate-azure-integrations/

--- a/install/gcp/gcp-infrastructure-monitoring/install.yml
+++ b/install/gcp/gcp-infrastructure-monitoring/install.yml
@@ -1,0 +1,21 @@
+id: gcp-infrastructure-monitoring
+name: GCP-Infrastructure-Monitoring
+title: GCP Infrastructure Monitoring
+description: |
+  GCP Infrastructure Monitoring allows monitoring of various Google Cloud Platform services. 
+target:
+  type: cloud
+  destination: cloud
+
+install:
+  mode: nerdlet
+  destination:
+    nerdletId: infra.gcp
+    nerdletState:
+      providerName: gcp
+      
+fallback:
+  mode: link
+  destination:
+    url: >-
+      https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/get-started/connect-google-cloud-platform-services-new-relic/

--- a/quickstarts/aws/amazon-athena/config.yml
+++ b/quickstarts/aws/amazon-athena/config.yml
@@ -30,8 +30,10 @@ documentation:
     description: |
       Monitor Amazon Athena by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-athena-monitoring-integration
 keywords:
   - aws
   - amazon web services
   - database
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/amazon-cloudwatch-metric-streams/config.yml
+++ b/quickstarts/aws/amazon-cloudwatch-metric-streams/config.yml
@@ -21,7 +21,9 @@ documentation:
       Faster telemetry from Amazon CloudWatch for all AWS Services and custom
       namespaces without API throttling.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream
 keywords:
   - aws
   - amazon web services
+installPlans:
+  - aws-cloudwatch-metric-streams

--- a/quickstarts/aws/amazon-documentdb/config.yml
+++ b/quickstarts/aws/amazon-documentdb/config.yml
@@ -28,8 +28,10 @@ documentation:
     description: |
       Monitor Amazon DocumentDB by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-documentdb-monitoring-integration
 keywords:
   - aws
   - amazon web services
   - database
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/amazon-msk/config.yml
+++ b/quickstarts/aws/amazon-msk/config.yml
@@ -28,8 +28,11 @@ documentation:
     description: |
       Monitor Amazon MSK by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-managed-kafka-msk-integration
 keywords:
   - aws
   - amazon web services
   - queue
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/amazon-web-services/config.yml
+++ b/quickstarts/aws/amazon-web-services/config.yml
@@ -37,10 +37,13 @@ documentation:
     description: |
       Enable integrations and get complete visibility into your infrastructure.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJwcm92aWRlck5hbWUiOiJhd3MifQ==&state=0a1d29d3-1cbf-b0bd-34f3-5ea545062807
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/get-started/introduction-aws-integrations/
 
 keywords:
   - aws
   - amazon web services
   - cloudwatch
   - cloudwach metric streams
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-api-gateway/config.yml
+++ b/quickstarts/aws/aws-api-gateway/config.yml
@@ -28,9 +28,12 @@ documentation:
     description: |
       Monitor AWS API Gateway by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-api-gateway-monitoring-integration
 keywords:
   - aws
   - amazon web services
   - api
   - networking
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-appsync/config.yml
+++ b/quickstarts/aws/aws-appsync/config.yml
@@ -28,8 +28,11 @@ documentation:
     description: |
       Monitor AWS AppSync by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-appsync-monitoring-integration
 keywords:
   - aws
   - amazon web services
   - api
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-auto-scaling/config.yml
+++ b/quickstarts/aws/aws-auto-scaling/config.yml
@@ -28,7 +28,10 @@ documentation:
     description: |
       Monitor AWS Auto Scaling by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-auto-scaling-monitoring-integration
 keywords:
   - aws
   - amazon web services
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-billing/config.yml
+++ b/quickstarts/aws/aws-billing/config.yml
@@ -28,7 +28,10 @@ documentation:
     description: |
       Monitor AWS Billing by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-billing-monitoring-integration
 keywords:
   - aws
   - amazon web services
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-cloudformation/config.yml
+++ b/quickstarts/aws/aws-cloudformation/config.yml
@@ -28,8 +28,11 @@ documentation:
     description: |
       Monitor AWS CloudFormation by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-cloudformation-integration
 keywords:
   - aws
   - amazon web services
   - automation
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-cloudfront/config.yml
+++ b/quickstarts/aws/aws-cloudfront/config.yml
@@ -1,6 +1,6 @@
 id: c6a0f98b-94f3-4f66-9217-83526d7c1afb
 name: aws-cloudfront
-description: "## What is AWS CloudFront?\n\nSpeeds up the distribution of web content served from Amazon Web Services.\n\n### Get started!\n\nStart monitoring AWS CloudFront by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS CloudFront documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-cloudfront-monitoring-integration) to learn more about New Relic monitoring for AWS CloudFront. "
+description: "## What is AWS CloudFront?\n\nSpeeds up the distribution of web content served from Amazon Web Services.\n\n### Get started!\n\nStart monitoring AWS CloudFront by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS CloudFront documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-cloudfront-monitoring-integration/) to learn more about New Relic monitoring for AWS CloudFront. "
 summary: Monitor AWS CloudFront by connecting AWS to New Relic
 logo: logo.svg
 level: New Relic
@@ -12,7 +12,10 @@ documentation:
   - name: AWS CloudFront installation docs
     description: Monitor AWS CloudFront by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-cloudfront-monitoring-integration/
 keywords:
   - aws
   - amazon web services
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-cloudtrail/config.yml
+++ b/quickstarts/aws/aws-cloudtrail/config.yml
@@ -28,8 +28,11 @@ documentation:
     description: |
       Monitor AWS CloudTrail by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-cloudtrail-monitoring-integration
 keywords:
   - aws
   - amazon web services
   - security
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-cognito/config.yml
+++ b/quickstarts/aws/aws-cognito/config.yml
@@ -1,6 +1,6 @@
 id: 70c5611b-51e8-41ca-8659-abc6b0d5c795
 name: aws-cognito
-description: "## What is AWS Cognito?\n\nAdd user account management functionality to your web or mobile application.\n\n### Get started!\n\nStart monitoring AWS Cognito by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS Cognito documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/amazon-cognito-monitoring-integration) to learn more about New Relic monitoring for AWS Cognito. "
+description: "## What is AWS Cognito?\n\nAdd user account management functionality to your web or mobile application.\n\n### Get started!\n\nStart monitoring AWS Cognito by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS Cognito documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/amazon-cognito-monitoring-integration/) to learn more about New Relic monitoring for AWS Cognito. "
 summary: Monitor AWS Cognito by connecting AWS to New Relic
 logo: logo.svg
 level: New Relic
@@ -12,7 +12,10 @@ documentation:
     description: |
       Monitor AWS Cognito by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/amazon-cognito-monitoring-integration/
 keywords:
   - aws
   - amazon web services
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-connect/config.yml
+++ b/quickstarts/aws/aws-connect/config.yml
@@ -1,6 +1,6 @@
 id: ddf0d06c-12c7-4951-9335-ab2c10dbd1c5
 name: aws-connect
-description: "## What is AWS Connect?\n\nBuild cloud-based omnichannel support centers to serve customers dynamically.\n\n### Get started!\n\nStart monitoring AWS Connect by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS Connect documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-connect-monitoring-integration) to learn more about New Relic monitoring for AWS Connect. "
+description: "## What is AWS Connect?\n\nBuild cloud-based omnichannel support centers to serve customers dynamically.\n\n### Get started!\n\nStart monitoring AWS Connect by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS Connect documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-connect-monitoring-integration/) to learn more about New Relic monitoring for AWS Connect. "
 summary: Monitor AWS Connect by connecting AWS to New Relic
 logo: logo.svg
 level: New Relic
@@ -12,7 +12,10 @@ documentation:
     description: |
       Monitor AWS Connect by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-connect-monitoring-integration/
 keywords:
   - aws
   - amazon web services
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-direct-connect/config.yml
+++ b/quickstarts/aws/aws-direct-connect/config.yml
@@ -1,6 +1,6 @@
 id: 913f6003-d559-4538-a6b2-9c19a7cc7d46
 name: aws-direct-connect
-description: "## What is AWS Direct Connect?\n\nEstablish a private, secure connection to AWS that runs outside of your ISP.\n\n### Get started!\n\nStart monitoring AWS Direct Connect by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS Direct Connect documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-direct-connect-monitoring-integration) to learn more about New Relic monitoring for AWS Direct Connect. "
+description: "## What is AWS Direct Connect?\n\nEstablish a private, secure connection to AWS that runs outside of your ISP.\n\n### Get started!\n\nStart monitoring AWS Direct Connect by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS Direct Connect documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-direct-connect-monitoring-integration/) to learn more about New Relic monitoring for AWS Direct Connect. "
 summary: Monitor AWS Direct Connect by connecting AWS to New Relic
 logo: logo.svg
 level: New Relic
@@ -12,8 +12,11 @@ documentation:
     description: |
       Monitor AWS Direct Connect by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-direct-connect-monitoring-integration/
 keywords:
   - aws
   - amazon web services
   - networking
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-dynamodb/config.yml
+++ b/quickstarts/aws/aws-dynamodb/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-dynamodb-monitoring-integration) to learn more about New Relic monitoring for AWS DynamoDB. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-dynamodb-monitoring-integration/) to learn more about New Relic monitoring for AWS DynamoDB. 
 summary: |-
   Monitor AWS DynamoDB by connecting AWS to New Relic
 logo: logo.svg
@@ -28,7 +28,7 @@ documentation:
     description: |
       Monitor AWS DynamoDB by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-dynamodb-monitoring-integration/
 keywords:
   - aws
   - amazon web services

--- a/quickstarts/aws/aws-ebs/config.yml
+++ b/quickstarts/aws/aws-ebs/config.yml
@@ -1,6 +1,6 @@
 id: e9aeb0ad-18d2-4e0f-b68b-356ef5788da4
 name: aws-ebs
-description: "## What is AWS EBS?\n\nBlock level storage volumes for Amazon EC2 instances.\n\n### Get started!\n\nStart monitoring AWS EBS by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS EBS documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-ebs-monitoring-integration) to learn more about New Relic monitoring for AWS EBS. "
+description: "## What is AWS EBS?\n\nBlock level storage volumes for Amazon EC2 instances.\n\n### Get started!\n\nStart monitoring AWS EBS by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS EBS documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-ebs-monitoring-integration/) to learn more about New Relic monitoring for AWS EBS. "
 summary: Monitor AWS EBS by connecting AWS to New Relic
 logo: logo.svg
 level: New Relic
@@ -11,7 +11,7 @@ documentation:
   - name: AWS EBS installation docs
     description: Monitor AWS EBS by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-ebs-monitoring-integration/
 keywords:
   - aws
   - amazon web services

--- a/quickstarts/aws/aws-ec2/config.yml
+++ b/quickstarts/aws/aws-ec2/config.yml
@@ -1,6 +1,6 @@
 id: 4e11966f-04c2-49ca-8815-9e7de8645b1b
 name: aws-ec2
-description: "## What is AWS EC2?\n\nBuild scalable and flexible applications on top of AWS container services.\n\n### Get started!\n\nStart monitoring AWS EC2 by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS EC2 documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-ec2-monitoring-integration) to learn more about New Relic monitoring for AWS EC2. "
+description: "## What is AWS EC2?\n\nBuild scalable and flexible applications on top of AWS container services.\n\n### Get started!\n\nStart monitoring AWS EC2 by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS EC2 documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-ec2-monitoring-integration/) to learn more about New Relic monitoring for AWS EC2. "
 summary: Monitor AWS EC2 by connecting AWS to New Relic
 logo: logo.svg
 level: New Relic
@@ -11,7 +11,7 @@ documentation:
   - name: AWS EC2 installation docs
     description: Monitor AWS EC2 by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-ec2-monitoring-integration/
 keywords:
   - aws
   - amazon web services

--- a/quickstarts/aws/aws-ecs-ecr/config.yml
+++ b/quickstarts/aws/aws-ecs-ecr/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-ecsecr-monitoring-integration) to learn more about New Relic monitoring for AWS ECS/ECR. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-ecsecr-monitoring-integration/) to learn more about New Relic monitoring for AWS ECS/ECR. 
 summary: |-
   Monitor AWS ECS/ECR by connecting AWS to New Relic
 logo: logo.svg
@@ -28,9 +28,12 @@ documentation:
     description: |
       Monitor AWS ECS/ECR by connecting AWS to New Relic.
     url: >-
-      https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-ecsecr-monitoring-integration
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-ecsecr-monitoring-integration/
 keywords:
   - aws
   - amazon web services
   - containers
   - infrastructure
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-efs/config.yml
+++ b/quickstarts/aws/aws-efs/config.yml
@@ -1,6 +1,6 @@
 id: 29b8f0ce-b573-48e3-98ab-52e4231d2225
 name: aws-efs
-description: "## What is AWS EFS?\n\nFull managed NFS with support for both AWS and on-prem resources.\n\n### Get started!\n\nStart monitoring AWS EFS by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS EFS documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-efs-monitoring-integration) to learn more about New Relic monitoring for AWS EFS. "
+description: "## What is AWS EFS?\n\nFull managed NFS with support for both AWS and on-prem resources.\n\n### Get started!\n\nStart monitoring AWS EFS by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS EFS documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-efs-monitoring-integration/) to learn more about New Relic monitoring for AWS EFS. "
 summary: Monitor AWS EFS by connecting AWS to New Relic
 logo: logo.svg
 level: New Relic
@@ -11,8 +11,11 @@ documentation:
   - name: AWS EFS installation docs
     description: Monitor AWS EFS by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-efs-monitoring-integration/
 keywords:
   - aws
   - amazon web services
   - storage
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-elastic-beanstalk/config.yml
+++ b/quickstarts/aws/aws-elastic-beanstalk/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-elastic-beanstalk-monitoring-integration) to learn more about New Relic monitoring for AWS Elastic Beanstalk. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elastic-beanstalk-monitoring-integration/) to learn more about New Relic monitoring for AWS Elastic Beanstalk. 
 summary: |-
   Monitor AWS Elastic Beanstalk by connecting AWS to New Relic
 logo: logo.svg
@@ -28,7 +28,10 @@ documentation:
     description: |
       Monitor AWS Elastic Beanstalk by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elastic-beanstalk-monitoring-integration/
 keywords:
   - aws
   - amazon web services
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-elasticache/config.yml
+++ b/quickstarts/aws/aws-elasticache/config.yml
@@ -1,6 +1,6 @@
 id: 5c1e7b31-df21-4acb-b72c-0a8786b88301
 name: aws-elasticache
-description: "## What is AWS ElastiCache?\n\nDeploy, operate, and scale an in-memory data store or cache in the cloud.\n\n### Get started!\n\nStart monitoring AWS ElastiCache by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS ElastiCache documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-elasticache-monitoring-integration) to learn more about New Relic monitoring for AWS ElastiCache. "
+description: "## What is AWS ElastiCache?\n\nDeploy, operate, and scale an in-memory data store or cache in the cloud.\n\n### Get started!\n\nStart monitoring AWS ElastiCache by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS ElastiCache documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elasticache-monitoring-integration/) to learn more about New Relic monitoring for AWS ElastiCache. "
 summary: Monitor AWS ElastiCache by connecting AWS to New Relic
 logo: logo.svg
 level: New Relic
@@ -11,8 +11,11 @@ documentation:
   - name: AWS ElastiCache installation docs
     description: Monitor AWS ElastiCache by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elasticache-monitoring-integration/
 keywords:
   - aws
   - amazon web services
   - database
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-elasticsearch/config.yml
+++ b/quickstarts/aws/aws-elasticsearch/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/elasticsearch-monitoring-integration) to learn more about New Relic monitoring for AWS Elasticsearch. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elasticsearch-monitoring-integration/) to learn more about New Relic monitoring for AWS Elasticsearch. 
 summary: |-
   Monitor AWS Elasticsearch by connecting AWS to New Relic
 logo: logo.svg
@@ -28,7 +28,7 @@ documentation:
     description: |
       Monitor AWS Elasticsearch by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elasticsearch-monitoring-integration/
 keywords:
   - aws
   - amazon web services

--- a/quickstarts/aws/aws-elb/config.yml
+++ b/quickstarts/aws/aws-elb/config.yml
@@ -1,6 +1,6 @@
 id: ceb7f12e-fc9c-48c8-8fa8-a6d353c5f751
 name: aws-elb
-description: "## What is AWS ELB?\n\nAutomatically redirect incoming web traffic to balance load when demand rises.\n\n### Get started!\n\nStart monitoring AWS ELB by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS ELB documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-elb-classic-monitoring-integration) to learn more about New Relic monitoring for AWS ELB. "
+description: "## What is AWS ELB?\n\nAutomatically redirect incoming web traffic to balance load when demand rises.\n\n### Get started!\n\nStart monitoring AWS ELB by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS ELB documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elb-classic-monitoring-integration/) to learn more about New Relic monitoring for AWS ELB. "
 summary: Monitor AWS ELB by connecting AWS to New Relic
 logo: logo.svg
 level: New Relic
@@ -12,9 +12,12 @@ documentation:
     description: |
       Monitor AWS ELB by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elb-classic-monitoring-integration/
 keywords:
   - aws
   - amazon web services
   - load balancer
   - networking
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-elemental-mediapackage-vod/config.yml
+++ b/quickstarts/aws/aws-elemental-mediapackage-vod/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-elemental-mediapackage-vod-monitoring-integration) to learn more about New Relic monitoring for AWS Elemental MediaPackage VOD.
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elemental-mediapackage-vod-monitoring-integration/) to learn more about New Relic monitoring for AWS Elemental MediaPackage VOD.
 summary: |-
   Monitor AWS Elemental MediaPackage VOD by connecting AWS to New Relic
 logo: logo.png
@@ -28,7 +28,10 @@ documentation:
     description: |
       Monitor AWS Elemental MediaPackage VOD by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elemental-mediapackage-vod-monitoring-integration/
 keywords:
   - aws
   - amazon web services
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-emr/config.yml
+++ b/quickstarts/aws/aws-emr/config.yml
@@ -1,6 +1,6 @@
 id: d84051ba-365f-4542-8db9-0829384ea55a
 name: aws-emr
-description: "## What is AWS EMR?\n\nProcess and manage big data inputs from popular frameworks.\n\n### Get started!\n\nStart monitoring AWS EMR by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS EMR documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-emr-monitoring-integration) to learn more about New Relic monitoring for AWS EMR. "
+description: "## What is AWS EMR?\n\nProcess and manage big data inputs from popular frameworks.\n\n### Get started!\n\nStart monitoring AWS EMR by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS EMR documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-emr-monitoring-integration/) to learn more about New Relic monitoring for AWS EMR. "
 summary: Monitor AWS EMR by connecting AWS to New Relic
 logo: logo.svg
 level: New Relic
@@ -11,7 +11,10 @@ documentation:
   - name: AWS EMR installation docs
     description: Monitor AWS EMR by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-emr-monitoring-integration/
 keywords:
   - aws
   - amazon web services
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-fsx/config.yml
+++ b/quickstarts/aws/aws-fsx/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-fsx-monitoring-integration) to learn more about New Relic monitoring for AWS FSx.
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-fsx-monitoring-integration/) to learn more about New Relic monitoring for AWS FSx.
 summary: |-
   Monitor AWS FSx by connecting AWS to New Relic
 logo: logo.png
@@ -28,7 +28,10 @@ documentation:
     description: |
       Monitor AWS FSx by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-fsx-monitoring-integration/
 keywords:
   - aws
   - amazon web services
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-glue/config.yml
+++ b/quickstarts/aws/aws-glue/config.yml
@@ -1,6 +1,6 @@
 id: 6f4ca9e9-5b33-4073-b609-948bd59da406
 name: aws-glue
-description: "## What is AWS Glue?\n\nFully managed service for data analytics and ETF operations.\n\n### Get started!\n\nStart monitoring AWS Glue by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS Glue documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-glue-monitoring-integration) to learn more about New Relic monitoring for AWS Glue. "
+description: "## What is AWS Glue?\n\nFully managed service for data analytics and ETF operations.\n\n### Get started!\n\nStart monitoring AWS Glue by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS Glue documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-glue-monitoring-integration/) to learn more about New Relic monitoring for AWS Glue. "
 summary: Monitor AWS Glue by connecting AWS to New Relic
 logo: logo.svg
 level: New Relic
@@ -11,7 +11,10 @@ documentation:
   - name: AWS Glue installation docs
     description: Monitor AWS Glue by connecting AWS to New Relic
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-glue-monitoring-integration/
 keywords:
   - aws
   - amazon web services
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-health/config.yml
+++ b/quickstarts/aws/aws-health/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-health-monitoring-integration) to learn more about New Relic monitoring for AWS Health. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-health-monitoring-integration/) to learn more about New Relic monitoring for AWS Health. 
 summary: |-
   Monitor AWS Health by connecting AWS to New Relic
 logo: logo.svg
@@ -28,7 +28,10 @@ documentation:
     description: |
       Monitor AWS Health by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-health-monitoring-integration/
 keywords:
   - aws
   - amazon web services
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-iam/config.yml
+++ b/quickstarts/aws/aws-iam/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-iam-monitoring-integration) to learn more about New Relic monitoring for AWS IAM. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-iam-monitoring-integration/) to learn more about New Relic monitoring for AWS IAM. 
 summary: |-
   Monitor AWS IAM by connecting AWS to New Relic
 logo: logo.svg
@@ -28,7 +28,10 @@ documentation:
     description: |
       Monitor AWS IAM by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-iam-monitoring-integration/
 keywords:
   - aws
   - amazon web services
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-iot/config.yml
+++ b/quickstarts/aws/aws-iot/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-iot-monitoring-integration) to learn more about New Relic monitoring for AWS IoT. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-iot-monitoring-integration/) to learn more about New Relic monitoring for AWS IoT. 
 summary: |-
   Monitor AWS IoT by connecting AWS to New Relic
 logo: logo.svg
@@ -28,7 +28,10 @@ documentation:
     description: |
       Monitor AWS IoT by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-iot-monitoring-integration/
 keywords:
   - aws
   - amazon web services
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-kinesis-data-firehose/config.yml
+++ b/quickstarts/aws/aws-kinesis-data-firehose/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-kinesis-data-firehose-monitoring-integration) to learn more about New Relic monitoring for AWS Kinesis Data Firehose. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-kinesis-data-firehose-monitoring-integration/) to learn more about New Relic monitoring for AWS Kinesis Data Firehose. 
 summary: |-
   Monitor AWS Kinesis Data Firehose by connecting AWS to New Relic
 logo: logo.svg
@@ -28,7 +28,7 @@ documentation:
     description: |
       Monitor AWS Kinesis Data Firehose by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-kinesis-data-firehose-monitoring-integration/
 keywords:
   - aws
   - amazon web services

--- a/quickstarts/aws/aws-kinesis-data-streams/config.yml
+++ b/quickstarts/aws/aws-kinesis-data-streams/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-kinesis-data-streams-monitoring-integration) to learn more about New Relic monitoring for AWS Kinesis Data Streams. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-kinesis-data-streams-monitoring-integration/) to learn more about New Relic monitoring for AWS Kinesis Data Streams. 
 summary: |-
   Monitor AWS Kinesis Data Streams by connecting AWS to New Relic
 logo: logo.svg
@@ -28,7 +28,10 @@ documentation:
     description: |
       Monitor AWS Kinesis Data Streams by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-kinesis-data-streams-monitoring-integration/
 keywords:
   - aws
   - amazon web services
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-lambda/config.yml
+++ b/quickstarts/aws/aws-lambda/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-lambda-monitoring-integration) to learn more about New Relic monitoring for AWS Lambda. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-lambda-monitoring-integration/) to learn more about New Relic monitoring for AWS Lambda. 
 summary: |-
   Monitor AWS Lambda by connecting AWS to New Relic
 logo: logo.svg
@@ -28,7 +28,7 @@ documentation:
     description: |
       Monitor AWS Lambda by connecting AWS to New Relic.
     url: >-
-      https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-lambda-monitoring-integration
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-lambda-monitoring-integration/
 keywords:
   - aws
   - amazon web services

--- a/quickstarts/aws/aws-mq/config.yml
+++ b/quickstarts/aws/aws-mq/config.yml
@@ -1,6 +1,6 @@
 id: 73de5982-8f59-4d2d-a90a-4838414d3304
 name: aws-mq
-description: "## What is AWS MQ?\n\nMessage brokering service for Apache ActiveMQ managed by AWS.\n\n### Get started!\n\nStart monitoring AWS MQ by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS MQ documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-mq-integration) to learn more about New Relic monitoring for AWS MQ. "
+description: "## What is AWS MQ?\n\nMessage brokering service for Apache ActiveMQ managed by AWS.\n\n### Get started!\n\nStart monitoring AWS MQ by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS MQ documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-mq-integration/) to learn more about New Relic monitoring for AWS MQ. "
 summary: Monitor AWS MQ by connecting AWS to New Relic
 logo: logo.svg
 level: New Relic
@@ -11,9 +11,12 @@ documentation:
   - name: AWS MQ installation docs
     description: Monitor AWS MQ by connecting AWS to New Relic
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-mq-integration/
 keywords:
   - aws
   - amazon web services
   - messaging
   - queue
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-neptunedb/config.yml
+++ b/quickstarts/aws/aws-neptunedb/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-neptune-monitoring-integration) to learn more about New Relic monitoring for AWS NeptuneDB. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-neptune-monitoring-integration/) to learn more about New Relic monitoring for AWS NeptuneDB. 
 summary: |-
   Monitor AWS NeptuneDB by connecting AWS to New Relic
 logo: logo.svg
@@ -28,8 +28,11 @@ documentation:
     description: |
       Monitor AWS NeptuneDB by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-neptune-monitoring-integration/
 keywords:
   - aws
   - amazon web services
   - database
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-nlb-alb/config.yml
+++ b/quickstarts/aws/aws-nlb-alb/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-albnlb-monitoring-integration) to learn more about New Relic monitoring for AWS NLB/ALB. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-albnlb-monitoring-integration/) to learn more about New Relic monitoring for AWS NLB/ALB. 
 summary: |-
   Monitor AWS NLB/ALB by connecting AWS to New Relic
 logo: logo.svg
@@ -25,10 +25,9 @@ authors:
 title: AWS NLB/ALB
 documentation:
   - name: AWS NLB/ALB installation docs
-    description: |
-      Monitor AWS NLB/ALB by connecting AWS to New Relic.
+    description: Monitor AWS NLB/ALB by connecting AWS to New Relic.
     url: >-
-      https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-albnlb-monitoring-integration
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-albnlb-monitoring-integration/
 keywords:
   - aws
   - amazon web services

--- a/quickstarts/aws/aws-outposts/config.yml
+++ b/quickstarts/aws/aws-outposts/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/get-started/introduction-aws-integrations) to learn more about New Relic monitoring for AWS Outposts.
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/get-started/introduction-aws-integrations/) to learn more about New Relic monitoring for AWS Outposts.
 summary: |-
   Monitor AWS Outposts by connecting AWS to New Relic
 logo: logo.png
@@ -28,7 +28,10 @@ documentation:
     description: |
       Monitor AWS Outposts by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/get-started/introduction-aws-integrations/
 keywords:
   - aws
   - amazon web services
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-qldb/config.yml
+++ b/quickstarts/aws/aws-qldb/config.yml
@@ -37,8 +37,11 @@ documentation:
     description: |
       Monitor AWS QLDB by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-qldb-monitoring-integration/
 keywords:
   - aws
   - amazon web services
   - database
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-rds-enhanced/config.yml
+++ b/quickstarts/aws/aws-rds-enhanced/config.yml
@@ -1,6 +1,6 @@
 id: 998141b4-32dd-4c6b-a550-4e0d74faacf3
 name: aws-rds-enhanced
-description: "## What is AWS RDS Enhanced?\n\nSupplement your RDS monitoring with real-time metrics about the OS.\n\n### Get started!\n\nStart monitoring AWS RDS Enhanced by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS RDS Enhanced documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-rds-enhanced-monitoring-integration) to learn more about New Relic monitoring for AWS RDS Enhanced. "
+description: "## What is AWS RDS Enhanced?\n\nSupplement your RDS monitoring with real-time metrics about the OS.\n\n### Get started!\n\nStart monitoring AWS RDS Enhanced by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS RDS Enhanced documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-rds-enhanced-monitoring-integration/) to learn more about New Relic monitoring for AWS RDS Enhanced. "
 summary: Monitor AWS RDS Enhanced by connecting AWS to New Relic
 logo: logo.svg
 level: New Relic
@@ -11,8 +11,11 @@ documentation:
   - name: AWS RDS Enhanced installation docs
     description: Monitor AWS RDS Enhanced by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-rds-enhanced-monitoring-integration/
 keywords:
   - aws
   - amazon web services
   - database
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-rds/config.yml
+++ b/quickstarts/aws/aws-rds/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-rds-monitoring-integration) to learn more about New Relic monitoring for AWS RDS. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-rds-monitoring-integration/) to learn more about New Relic monitoring for AWS RDS. 
 summary: |-
   Monitor AWS RDS by connecting AWS to New Relic
 logo: logo.svg
@@ -28,7 +28,7 @@ documentation:
     description: |
       Monitor AWS RDS by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-rds-monitoring-integration/
 keywords:
   - aws
   - amazon web services

--- a/quickstarts/aws/aws-redshift/config.yml
+++ b/quickstarts/aws/aws-redshift/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-redshift-integration) to learn more about New Relic monitoring for AWS Redshift. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-redshift-integration/) to learn more about New Relic monitoring for AWS Redshift. 
 summary: |-
   Monitor AWS Redshift by connecting AWS to New Relic
 logo: logo.svg
@@ -28,8 +28,11 @@ documentation:
     description: |
       Monitor AWS Redshift by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-redshift-integration/
 keywords:
   - aws
   - amazon web services
   - database
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-route-53/config.yml
+++ b/quickstarts/aws/aws-route-53/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-route-53-monitoring-integration) to learn more about New Relic monitoring for AWS Route 53. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-route-53-monitoring-integration/) to learn more about New Relic monitoring for AWS Route 53. 
 summary: |-
   Monitor AWS Route 53 by connecting AWS to New Relic
 logo: logo.svg
@@ -28,8 +28,11 @@ documentation:
     description: |
       Monitor AWS Route 53 by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-route-53-monitoring-integration/
 keywords:
   - aws
   - amazon web services
   - networking
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-route53-resolver/config.yml
+++ b/quickstarts/aws/aws-route53-resolver/config.yml
@@ -1,6 +1,6 @@
 id: 91a052fe-cb0f-4b98-ae79-56d61abef5ec
 name: aws-route53-resolver
-description: "## What is AWS Route53 Resolver?\n\nCreate and configure endpoints in AWS Route 53.\n\n### Get started!\n\nStart monitoring AWS Route53 Resolver by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS Route53 Resolver documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-route53-resolver-monitoring-integration) to learn more about New Relic monitoring for AWS Route53 Resolver. "
+description: "## What is AWS Route53 Resolver?\n\nCreate and configure endpoints in AWS Route 53.\n\n### Get started!\n\nStart monitoring AWS Route53 Resolver by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS Route53 Resolver documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-route53-resolver-monitoring-integration/) to learn more about New Relic monitoring for AWS Route53 Resolver. "
 summary: Monitor AWS Route53 Resolver by connecting AWS to New Relic
 logo: logo.svg
 level: New Relic
@@ -11,8 +11,11 @@ documentation:
   - name: AWS Route53 Resolver installation docs
     description: Monitor AWS Route53 Resolver by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-route53-resolver-monitoring-integration/
 keywords:
   - aws
   - amazon web services
   - networking
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-s3/config.yml
+++ b/quickstarts/aws/aws-s3/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-s3-monitoring-integration) to learn more about New Relic monitoring for AWS S3. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-s3-monitoring-integration/) to learn more about New Relic monitoring for AWS S3. 
 summary: |-
   Monitor AWS S3 by connecting AWS to New Relic
 logo: logo.svg
@@ -28,7 +28,7 @@ documentation:
     description: |
       Monitor AWS S3 by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-s3-monitoring-integration/
 keywords:
   - aws
   - amazon web services

--- a/quickstarts/aws/aws-ses/config.yml
+++ b/quickstarts/aws/aws-ses/config.yml
@@ -1,6 +1,6 @@
 id: 4d72d691-d338-4b53-9dbf-97c5030db09e
 name: aws-ses
-description: "## What is AWS SES?\n\nCloud-based service for sending and receiving email.\n\n### Get started!\n\nStart monitoring AWS SES by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS SES documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-simple-email-service-ses-monitoring-integration) to learn more about New Relic monitoring for AWS SES. "
+description: "## What is AWS SES?\n\nCloud-based service for sending and receiving email.\n\n### Get started!\n\nStart monitoring AWS SES by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS SES documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-simple-email-service-ses-monitoring-integration/) to learn more about New Relic monitoring for AWS SES. "
 summary: Monitor AWS SES by connecting AWS to New Relic
 logo: logo.svg
 level: New Relic
@@ -11,8 +11,11 @@ documentation:
   - name: AWS SES installation docs
     description: Cloud-based service for sending and receiving email.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-simple-email-service-ses-monitoring-integration/
 keywords:
   - aws
   - amazon web services
   - messaging
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-sns/config.yml
+++ b/quickstarts/aws/aws-sns/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-sns-monitoring-integration) to learn more about New Relic monitoring for AWS SNS. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-sns-monitoring-integration/) to learn more about New Relic monitoring for AWS SNS. 
 summary: |-
   Monitor AWS SNS by connecting AWS to New Relic
 logo: logo.svg
@@ -28,8 +28,11 @@ documentation:
     description: |
       Monitor AWS SNS by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-sns-monitoring-integration/
 keywords:
   - aws
   - amazon web services
   - messaging
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-sqs/config.yml
+++ b/quickstarts/aws/aws-sqs/config.yml
@@ -1,6 +1,6 @@
 id: ef58d468-bcee-4a66-a641-8ff5453b5363
 name: aws-sqs
-description: "## What is AWS SQS?\n\nProvides fully managed, hosted queues for storing messages in transit.\n\n### Get started!\n\nStart monitoring AWS SQS by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS SQS documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-sqs-monitoring-integration) to learn more about New Relic monitoring for AWS SQS. "
+description: "## What is AWS SQS?\n\nProvides fully managed, hosted queues for storing messages in transit.\n\n### Get started!\n\nStart monitoring AWS SQS by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS SQS documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/amazon-sqs-monitoring-integration/) to learn more about New Relic monitoring for AWS SQS. "
 summary: Monitor AWS SQS by connecting AWS to New Relic
 logo: logo.svg
 level: New Relic
@@ -11,7 +11,7 @@ documentation:
   - name: AWS SQS installation docs
     description: Monitor AWS SQS by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/amazon-sqs-monitoring-integration/
 keywords:
   - aws
   - amazon web services

--- a/quickstarts/aws/aws-step-functions/config.yml
+++ b/quickstarts/aws/aws-step-functions/config.yml
@@ -1,6 +1,6 @@
 id: 7a864c4a-5005-4419-a729-3da92426b49a
 name: aws-step-functions
-description: "## What is AWS Step Functions?\n\nOrchestrate serverless functions in Amazon Web Services, including Lambda.\n\n### Get started!\n\nStart monitoring AWS Step Functions by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS Step Functions documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-step-functions-monitoring-integration) to learn more about New Relic monitoring for AWS Step Functions. "
+description: "## What is AWS Step Functions?\n\nOrchestrate serverless functions in Amazon Web Services, including Lambda.\n\n### Get started!\n\nStart monitoring AWS Step Functions by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS Step Functions documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-step-functions-monitoring-integration/) to learn more about New Relic monitoring for AWS Step Functions. "
 summary: Monitor AWS Step Functions by connecting AWS to New Relic
 logo: logo.svg
 level: New Relic
@@ -11,8 +11,11 @@ documentation:
   - name: AWS Step Functions installation docs
     description: Monitor AWS Step Functions by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-step-functions-monitoring-integration/
 keywords:
   - aws
   - amazon web services
   - serverless
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-transitgateway/config.yml
+++ b/quickstarts/aws/aws-transitgateway/config.yml
@@ -1,6 +1,6 @@
 id: a77fc65d-c2a3-4025-94b6-4af11ec82739
 name: aws-transitgateway
-description: "## What is AWS TransitGateway?\n\nCollate VPC and on-premises resources through a central gateway.\n\n### Get started!\n\nStart monitoring AWS TransitGateway by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS TransitGateway documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/amazon-transit-gateway-monitoring-integration) to learn more about New Relic monitoring for AWS TransitGateway. "
+description: "## What is AWS TransitGateway?\n\nCollate VPC and on-premises resources through a central gateway.\n\n### Get started!\n\nStart monitoring AWS TransitGateway by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS TransitGateway documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/amazon-transit-gateway-monitoring-integration/) to learn more about New Relic monitoring for AWS TransitGateway. "
 summary: Monitor AWS TransitGateway by connecting AWS to New Relic
 logo: logo.svg
 level: New Relic
@@ -11,8 +11,11 @@ documentation:
   - name: AWS TransitGateway installation docs
     description: Monitor AWS TransitGateway by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/amazon-transit-gateway-monitoring-integration/
 keywords:
   - aws
   - amazon web services
   - networking
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-trusted-advisor/config.yml
+++ b/quickstarts/aws/aws-trusted-advisor/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-trusted-advisor-integration) to learn more about New Relic monitoring for AWS Trusted Advisor. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-trusted-advisor-integration/) to learn more about New Relic monitoring for AWS Trusted Advisor. 
 summary: |-
   Monitor AWS Trusted Advisor by connecting AWS to New Relic
 logo: logo.svg
@@ -28,7 +28,10 @@ documentation:
     description: |
       Monitor AWS Trusted Advisor by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-trusted-advisor-integration/
 keywords:
   - aws
   - amazon web services
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-vpc-flow-logs/config.yml
+++ b/quickstarts/aws/aws-vpc-flow-logs/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-vpc-flow-logs-monitoring-integration) to learn more about New Relic monitoring for AWS VPC Flow Logs. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-vpc-flow-logs-monitoring-integration/) to learn more about New Relic monitoring for AWS VPC Flow Logs. 
 summary: |-
   Monitor AWS VPC Flow Logs by connecting AWS to New Relic
 logo: logo.svg
@@ -28,8 +28,11 @@ documentation:
     description: |
       Monitor AWS VPC Flow Logs by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-vpc-flow-logs-monitoring-integration/
 keywords:
   - aws
   - amazon web services
   - networking
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-vpc/config.yml
+++ b/quickstarts/aws/aws-vpc/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-vpc-monitoring-integration) to learn more about New Relic monitoring for AWS VPC. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-vpc-monitoring-integration/) to learn more about New Relic monitoring for AWS VPC. 
 summary: |-
   Monitor AWS VPC by connecting AWS to New Relic
 logo: logo.svg
@@ -28,8 +28,11 @@ documentation:
     description: |
       Monitor AWS VPC by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-vpc-monitoring-integration/
 keywords:
   - aws
   - amazon web services
   - networking
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-waf/config.yml
+++ b/quickstarts/aws/aws-waf/config.yml
@@ -1,6 +1,6 @@
 id: 8aa3f09f-63ad-416f-b505-b377ad88ff06
 name: aws-waf
-description: "## What is AWS WAF?\n\nSecure web traffic with a firewall built on top of Amazon Web Services.\n\n### Get started!\n\nStart monitoring AWS WAF by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS WAF documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-waf-monitoring-integration) to learn more about New Relic monitoring for AWS WAF. "
+description: "## What is AWS WAF?\n\nSecure web traffic with a firewall built on top of Amazon Web Services.\n\n### Get started!\n\nStart monitoring AWS WAF by connecting Amazon Web Services (AWS) to New Relic!\n\nCheck out our AWS WAF documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-waf-monitoring-integration/) to learn more about New Relic monitoring for AWS WAF. "
 summary: Monitor AWS WAF by connecting AWS to New Relic
 logo: logo.svg
 level: New Relic
@@ -11,8 +11,11 @@ documentation:
   - name: AWS WAF installation docs
     description: Monitor AWS WAF by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-waf-monitoring-integration/
 keywords:
   - aws
   - amazon web services
   - networking
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/aws/aws-x-ray/config.yml
+++ b/quickstarts/aws/aws-x-ray/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-x-ray-monitoring-integration) to learn more about New Relic monitoring for AWS X-Ray.
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-x-ray-monitoring-integration/) to learn more about New Relic monitoring for AWS X-Ray.
 summary: |-
   Monitor AWS X-Ray by connecting AWS to New Relic
 logo: logo.png
@@ -28,8 +28,11 @@ documentation:
     description: |
       Monitor AWS X-Ray by connecting AWS to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5hd3MiLCJkYXRhU291cmNlIjoiMSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJhd3MifQ
+      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-x-ray-monitoring-integration/
 keywords:
   - aws
   - amazon web services
   - tracing
+
+installPlans:
+  - aws-infrastructure-monitoring

--- a/quickstarts/azure/azure-api-management/config.yml
+++ b/quickstarts/azure/azure-api-management/config.yml
@@ -1,6 +1,6 @@
 id: 86047b47-5628-4c80-8202-03ebd3133357
 name: azure-api-management
-description: "## What is Azure API Management?\n\nComplete API management platform built for multi-cloud environments.\n\n### Get started!\n\nStart monitoring Azure API Management by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure API Management documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-api-management-monitoring-integration) to learn more about New Relic monitoring for Azure API Management. "
+description: "## What is Azure API Management?\n\nComplete API management platform built for multi-cloud environments.\n\n### Get started!\n\nStart monitoring Azure API Management by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure API Management documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-api-management-monitoring-integration/) to learn more about New Relic monitoring for Azure API Management. "
 summary: Monitor Azure API Management by connecting Azure to New Relic
 logo: logo.svg
 level: New Relic
@@ -11,7 +11,10 @@ documentation:
   - name: Azure API Management installation docs
     description: Monitor Azure API Management by connecting Azure to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5henVyZSIsImRhdGFTb3VyY2UiOiI0IiwiZmVhdHVyZSI6ImFjY291bnRXaXphcmRTZXR1cCIsInByb3ZpZGVyTmFtZSI6ImF6dXJlIn0=
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-api-management-monitoring-integration/
 keywords:
   - azure
   - api
+
+installPlans:
+  - azure-infrastructure-monitoring

--- a/quickstarts/azure/azure-app-service/config.yml
+++ b/quickstarts/azure/azure-app-service/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-app-service-monitoring-integration) to learn more about New Relic monitoring for Azure App Service.
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-app-service-monitoring-integration/) to learn more about New Relic monitoring for Azure App Service. 
 summary: |-
   Monitor Azure App Service by connecting Azure to New Relic
 logo: logo.svg
@@ -29,7 +29,10 @@ documentation:
     description: |
       Monitor Azure App Service by connecting Azure to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5henVyZSIsImRhdGFTb3VyY2UiOiI0IiwiZmVhdHVyZSI6ImFjY291bnRXaXphcmRTZXR1cCIsInByb3ZpZGVyTmFtZSI6ImF6dXJlIn0=
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-app-service-monitoring-integration/
 keywords:
   - azure
   - web
+
+installPlans:
+  - azure-infrastructure-monitoring

--- a/quickstarts/azure/azure-containers/config.yml
+++ b/quickstarts/azure/azure-containers/config.yml
@@ -1,6 +1,6 @@
 id: fde01772-978b-40c4-9339-51f57c6f60a8
 name: azure-containers
-description: "## What is Azure Containers?\n\nFramework for building and running microservice applications on Azure.\n\n### Get started!\n\nStart monitoring Azure Containers by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure Containers documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-containers-monitoring-integration) to learn more about New Relic monitoring for Azure Containers. "
+description: "## What is Azure Containers?\n\nFramework for building and running microservice applications on Azure.\n\n### Get started!\n\nStart monitoring Azure Containers by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure Containers documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-containers-monitoring-integration/) to learn more about New Relic monitoring for Azure Containers. "
 summary: Monitor Azure Containers by connecting Azure to New Relic
 logo: logo.svg
 level: New Relic
@@ -11,7 +11,10 @@ documentation:
   - name: Azure Containers installation docs
     description: Monitor Azure Containers by connecting Azure to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5henVyZSIsImRhdGFTb3VyY2UiOiI0IiwiZmVhdHVyZSI6ImFjY291bnRXaXphcmRTZXR1cCIsInByb3ZpZGVyTmFtZSI6ImF6dXJlIn0=
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-containers-monitoring-integration/
 keywords:
   - azure
   - containers
+
+installPlans:
+  - azure-infrastructure-monitoring

--- a/quickstarts/azure/azure-cosmos-db/config.yml
+++ b/quickstarts/azure/azure-cosmos-db/config.yml
@@ -1,6 +1,6 @@
 id: 81c38d53-5931-4fbc-9288-57c2c84cb1fd
 name: azure-cosmos-db
-description: "## What is Azure Cosmos DB?\n\nQuickly and easily scale your database traffic across multiple Azure regions.\n\n### Get started!\n\nStart monitoring Azure Cosmos DB by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure Cosmos DB documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-cosmos-db-document-db-monitoring-integration) to learn more about New Relic monitoring for Azure Cosmos DB. "
+description: "## What is Azure Cosmos DB?\n\nQuickly and easily scale your database traffic across multiple Azure regions.\n\n### Get started!\n\nStart monitoring Azure Cosmos DB by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure Cosmos DB documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-cosmos-db-document-db-monitoring-integration/) to learn more about New Relic monitoring for Azure Cosmos DB. "
 summary: Monitor Azure Cosmos DB by connecting Azure to New Relic
 logo: logo.svg
 level: New Relic
@@ -13,7 +13,10 @@ documentation:
     description: |
       Monitor Azure Cosmos DB by connecting Azure to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5henVyZSIsImRhdGFTb3VyY2UiOiI0IiwiZmVhdHVyZSI6ImFjY291bnRXaXphcmRTZXR1cCIsInByb3ZpZGVyTmFtZSI6ImF6dXJlIn0=
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-cosmos-db-document-db-monitoring-integration/
 keywords:
   - azure
   - database
+
+installPlans:
+  - azure-infrastructure-monitoring

--- a/quickstarts/azure/azure-cost-management/config.yml
+++ b/quickstarts/azure/azure-cost-management/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-cost-management-monitoring-integration) to learn more about New Relic monitoring for Azure Cost Management.
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-cost-management-monitoring-integration/) to learn more about New Relic monitoring for Azure Cost Management. 
 summary: |
   Monitor Azure Cost Management by connecting Azure to New Relic
 logo: logo.svg
@@ -29,6 +29,9 @@ documentation:
     description: |
       Monitor Azure Cost Management by connecting Azure to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5henVyZSIsImRhdGFTb3VyY2UiOiI0IiwiZmVhdHVyZSI6ImFjY291bnRXaXphcmRTZXR1cCIsInByb3ZpZGVyTmFtZSI6ImF6dXJlIn0=
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-cost-management-monitoring-integration/
 keywords:
   - azure
+
+installPlans:
+  - azure-infrastructure-monitoring

--- a/quickstarts/azure/azure-datafactories/config.yml
+++ b/quickstarts/azure/azure-datafactories/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-data-factory-integration) to learn more about New Relic monitoring for Azure DataFactories. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-data-factory-integration/) to learn more about New Relic monitoring for Azure DataFactories. 
 summary: |-
   Monitor Azure DataFactories by connecting Azure to New Relic
 logo: logo.svg
@@ -28,6 +28,9 @@ documentation:
     description: |
       Monitor Azure DataFactories by connecting Azure to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5henVyZSIsImRhdGFTb3VyY2UiOiI0IiwiZmVhdHVyZSI6ImFjY291bnRXaXphcmRTZXR1cCIsInByb3ZpZGVyTmFtZSI6ImF6dXJlIn0=
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-data-factory-integration/
 keywords:
   - azure
+
+installPlans:
+  - azure-infrastructure-monitoring

--- a/quickstarts/azure/azure-event-hubs/config.yml
+++ b/quickstarts/azure/azure-event-hubs/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-event-hub-monitoring-integration) to learn more about New Relic monitoring for Azure Event Hubs. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-event-hub-monitoring-integration/) to learn more about New Relic monitoring for Azure Event Hubs. 
 summary: |-
   Monitor Azure Event Hubs by connecting Azure to New Relic
 logo: logo.svg
@@ -28,6 +28,9 @@ documentation:
     description: |
       Monitor Azure Event Hubs by connecting Azure to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5henVyZSIsImRhdGFTb3VyY2UiOiI0IiwiZmVhdHVyZSI6ImFjY291bnRXaXphcmRTZXR1cCIsInByb3ZpZGVyTmFtZSI6ImF6dXJlIn0=
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-event-hub-monitoring-integration/
 keywords:
   - azure
+
+installPlans:
+  - azure-infrastructure-monitoring

--- a/quickstarts/azure/azure-express-route/config.yml
+++ b/quickstarts/azure/azure-express-route/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-express-route-monitoring-integration) to learn more about New Relic monitoring for Azure Express Route. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-express-route-monitoring-integration/) to learn more about New Relic monitoring for Azure Express Route. 
 summary: |-
   Monitor Azure Express Route by connecting Azure to New Relic
 logo: logo.svg
@@ -28,7 +28,10 @@ documentation:
     description: |
       Monitor Azure Express Route by connecting Azure to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5henVyZSIsImRhdGFTb3VyY2UiOiI0IiwiZmVhdHVyZSI6ImFjY291bnRXaXphcmRTZXR1cCIsInByb3ZpZGVyTmFtZSI6ImF6dXJlIn0=
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-express-route-monitoring-integration/
 keywords:
   - azure
   - networking
+
+installPlans:
+  - azure-infrastructure-monitoring

--- a/quickstarts/azure/azure-front-door/config.yml
+++ b/quickstarts/azure/azure-front-door/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-front-door-monitoring-integration) to learn more about New Relic monitoring for Azure Front Door. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-front-door-monitoring-integration/) to learn more about New Relic monitoring for Azure Front Door. 
 summary: |-
   Monitor Azure Front Door by connecting Azure to New Relic
 logo: logo.svg
@@ -28,7 +28,10 @@ documentation:
     description: |
       Monitor Azure Front Door by connecting Azure to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5henVyZSIsImRhdGFTb3VyY2UiOiI0IiwiZmVhdHVyZSI6ImFjY291bnRXaXphcmRTZXR1cCIsInByb3ZpZGVyTmFtZSI6ImF6dXJlIn0=
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-front-door-monitoring-integration/
 keywords:
   - azure
   - networking
+
+installPlans:
+  - azure-infrastructure-monitoring

--- a/quickstarts/azure/azure-functions/config.yml
+++ b/quickstarts/azure/azure-functions/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-functions-monitoring-integration) to learn more about New Relic monitoring for Azure Functions.
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-functions-monitoring-integration/) to learn more about New Relic monitoring for Azure Functions. 
 summary: |-
   Monitor Azure Functions by connecting Azure to New Relic
 logo: logo.svg
@@ -29,7 +29,10 @@ documentation:
     description: |
       Monitor Azure Functions by connecting Azure to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5henVyZSIsImRhdGFTb3VyY2UiOiI0IiwiZmVhdHVyZSI6ImFjY291bnRXaXphcmRTZXR1cCIsInByb3ZpZGVyTmFtZSI6ImF6dXJlIn0=
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-functions-monitoring-integration/
 keywords:
   - azure
   - serverless
+
+installPlans:
+  - azure-infrastructure-monitoring

--- a/quickstarts/azure/azure-load-balancer/config.yml
+++ b/quickstarts/azure/azure-load-balancer/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-load-balancer-monitoring-integration) to learn more about New Relic monitoring for Azure Load Balancer. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-load-balancer-monitoring-integration/) to learn more about New Relic monitoring for Azure Load Balancer. 
 summary: |-
   Monitor Azure Load Balancer by connecting Azure to New Relic
 logo: logo.svg
@@ -28,7 +28,10 @@ documentation:
     description: |
       Monitor Azure Load Balancer by connecting Azure to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5henVyZSIsImRhdGFTb3VyY2UiOiI0IiwiZmVhdHVyZSI6ImFjY291bnRXaXphcmRTZXR1cCIsInByb3ZpZGVyTmFtZSI6ImF6dXJlIn0=
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-load-balancer-monitoring-integration/
 keywords:
   - azure
   - load balancer
+
+installPlans:
+  - azure-infrastructure-monitoring

--- a/quickstarts/azure/azure-logic-apps/config.yml
+++ b/quickstarts/azure/azure-logic-apps/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-logic-apps-monitoring-integration) to learn more about New Relic monitoring for Azure Logic Apps. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-logic-apps-monitoring-integration/) to learn more about New Relic monitoring for Azure Logic Apps. 
 summary: |-
   Monitor Azure Logic Apps by connecting Azure to New Relic
 logo: logo.svg
@@ -28,6 +28,9 @@ documentation:
     description: |
       Monitor Azure Logic Apps by connecting Azure to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5henVyZSIsImRhdGFTb3VyY2UiOiI0IiwiZmVhdHVyZSI6ImFjY291bnRXaXphcmRTZXR1cCIsInByb3ZpZGVyTmFtZSI6ImF6dXJlIn0=
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-logic-apps-monitoring-integration/
 keywords:
   - azure
+
+installPlans:
+  - azure-infrastructure-monitoring

--- a/quickstarts/azure/azure-machine-learning-services/config.yml
+++ b/quickstarts/azure/azure-machine-learning-services/config.yml
@@ -1,6 +1,6 @@
 id: 4022bc8b-c395-424e-9073-7d4174910da7
 name: azure-machine-learning-services
-description: "## What is Azure Machine Learning Services?\n\nBuild and manage machine-learning applications on Azure.\n\n### Get started!\n\nStart monitoring Azure Machine Learning Services by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure Machine Learning Services documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-machine-learning-integration) to learn more about New Relic monitoring for Azure Machine Learning Services. "
+description: "## What is Azure Machine Learning Services?\n\nBuild and manage machine-learning applications on Azure.\n\n### Get started!\n\nStart monitoring Azure Machine Learning Services by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure Machine Learning Services documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-machine-learning-integration/) to learn more about New Relic monitoring for Azure Machine Learning Services. "
 summary: Monitor Azure Machine Learning Services by connecting Azure to New Relic
 logo: logo.svg
 level: New Relic
@@ -11,6 +11,9 @@ documentation:
   - name: Azure Machine Learning Services installation docs
     description: Monitor Azure Machine Learning Services by connecting Azure to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5henVyZSIsImRhdGFTb3VyY2UiOiI0IiwiZmVhdHVyZSI6ImFjY291bnRXaXphcmRTZXR1cCIsInByb3ZpZGVyTmFtZSI6ImF6dXJlIn0=
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-machine-learning-integration/
 keywords:
   - azure
+
+installPlans:
+  - azure-infrastructure-monitoring

--- a/quickstarts/azure/azure-mariadb/config.yml
+++ b/quickstarts/azure/azure-mariadb/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-database-mariadb-monitoring-integration) to learn more about New Relic monitoring for Azure MariaDB. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-database-mariadb-monitoring-integration/) to learn more about New Relic monitoring for Azure MariaDB. 
 summary: |-
   Monitor Azure MariaDB by connecting Azure to New Relic
 logo: logo.svg
@@ -28,7 +28,10 @@ documentation:
     description: |
       Monitor Azure MariaDB by connecting Azure to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5henVyZSIsImRhdGFTb3VyY2UiOiI0IiwiZmVhdHVyZSI6ImFjY291bnRXaXphcmRTZXR1cCIsInByb3ZpZGVyTmFtZSI6ImF6dXJlIn0=
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-database-mariadb-monitoring-integration/
 keywords:
   - azure
   - database
+
+installPlans:
+  - azure-infrastructure-monitoring

--- a/quickstarts/azure/azure-mysql/config.yml
+++ b/quickstarts/azure/azure-mysql/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-database-mysql-monitoring-integration) to learn more about New Relic monitoring for Azure MySQL. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-database-mysql-monitoring-integration/) to learn more about New Relic monitoring for Azure MySQL. 
 summary: |-
   Monitor Azure MySQL by connecting Azure to New Relic
 logo: logo.svg
@@ -28,7 +28,10 @@ documentation:
     description: |
       Monitor Azure MySQL by connecting Azure to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5henVyZSIsImRhdGFTb3VyY2UiOiI0IiwiZmVhdHVyZSI6ImFjY291bnRXaXphcmRTZXR1cCIsInByb3ZpZGVyTmFtZSI6ImF6dXJlIn0=
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-database-mysql-monitoring-integration/
 keywords:
   - azure
   - database
+  
+installPlans:
+  - azure-infrastructure-monitoring

--- a/quickstarts/azure/azure-postgresql/config.yml
+++ b/quickstarts/azure/azure-postgresql/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-database-postgresql-monitoring-integration) to learn more about New Relic monitoring for Azure PostgreSQL.
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-database-postgresql-monitoring-integration/) to learn more about New Relic monitoring for Azure PostgreSQL.
 summary: |-
   Monitor Azure PostgreSQL by connecting Azure to New Relic
 logo: logo.svg
@@ -29,7 +29,10 @@ documentation:
     description: |
       Monitor Azure PostgreSQL by connecting Azure to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5henVyZSIsImRhdGFTb3VyY2UiOiI0IiwiZmVhdHVyZSI6ImFjY291bnRXaXphcmRTZXR1cCIsInByb3ZpZGVyTmFtZSI6ImF6dXJlIn0=
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-database-postgresql-monitoring-integration/
 keywords:
   - azure
   - database
+
+installPlans:
+  - azure-infrastructure-monitoring

--- a/quickstarts/azure/azure-power-bi-dedicated-capacities/config.yml
+++ b/quickstarts/azure/azure-power-bi-dedicated-capacities/config.yml
@@ -1,6 +1,6 @@
 id: 258a1a34-165c-4911-bcd4-80bb60597b24
 name: azure-power-bi-dedicated-capacities
-description: "## What is Azure Power BI Dedicated capacities?\n\nCollect Azure Power BI Dedicated data for Capacity. Maintained by Microsoft.\n\n### Get started!\n\nStart monitoring Azure Power BI Dedicated capacities by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure Power BI Dedicated capacities documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-power-bi-dedicated-capacities-monitoring-integration) to learn more about New Relic monitoring for Azure Power BI Dedicated capacities. "
+description: "## What is Azure Power BI Dedicated capacities?\n\nCollect Azure Power BI Dedicated data for Capacity. Maintained by Microsoft.\n\n### Get started!\n\nStart monitoring Azure Power BI Dedicated capacities by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure Power BI Dedicated capacities documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-power-bi-dedicated-capacities-monitoring-integration/) to learn more about New Relic monitoring for Azure Power BI Dedicated capacities. "
 summary: Monitor Azure Power BI Dedicated capacities by connecting Azure to New Relic
 logo: logo.png
 level: New Relic
@@ -12,6 +12,9 @@ documentation:
     description: |
       Monitor Azure Power BI Dedicated capacities by connecting Azure to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5henVyZSIsImRhdGFTb3VyY2UiOiI0IiwiZmVhdHVyZSI6ImFjY291bnRXaXphcmRTZXR1cCIsInByb3ZpZGVyTmFtZSI6ImF6dXJlIn0=
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-power-bi-dedicated-capacities-monitoring-integration/
 keywords:
   - azure
+
+installPlans:
+  - azure-infrastructure-monitoring

--- a/quickstarts/azure/azure-redis-cache/config.yml
+++ b/quickstarts/azure/azure-redis-cache/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-redis-cache-monitoring-integration) to learn more about New Relic monitoring for Azure Redis Cache. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-redis-cache-monitoring-integration/) to learn more about New Relic monitoring for Azure Redis Cache. 
 summary: |-
   Monitor Azure Redis Cache by connecting Azure to New Relic
 logo: logo.svg
@@ -28,7 +28,10 @@ documentation:
     description: |
       Monitor Azure Redis Cache by connecting Azure to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5henVyZSIsImRhdGFTb3VyY2UiOiI0IiwiZmVhdHVyZSI6ImFjY291bnRXaXphcmRTZXR1cCIsInByb3ZpZGVyTmFtZSI6ImF6dXJlIn0=
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-redis-cache-monitoring-integration/
 keywords:
   - azure
   - database
+
+installPlans:
+  - azure-infrastructure-monitoring

--- a/quickstarts/azure/azure-service-bus/config.yml
+++ b/quickstarts/azure/azure-service-bus/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-service-bus-monitoring-integration) to learn more about New Relic monitoring for Azure Service Bus. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-service-bus-monitoring-integration/) to learn more about New Relic monitoring for Azure Service Bus. 
 summary: |-
   Monitor Azure Service Bus by connecting Azure to New Relic
 logo: logo.svg
@@ -28,7 +28,10 @@ documentation:
     description: |
       Monitor Azure Service Bus by connecting Azure to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5henVyZSIsImRhdGFTb3VyY2UiOiI0IiwiZmVhdHVyZSI6ImFjY291bnRXaXphcmRTZXR1cCIsInByb3ZpZGVyTmFtZSI6ImF6dXJlIn0=
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-service-bus-monitoring-integration/
 keywords:
   - azure
   - messaging
+
+installPlans:
+  - azure-infrastructure-monitoring

--- a/quickstarts/azure/azure-sql-database/config.yml
+++ b/quickstarts/azure/azure-sql-database/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-sql-database-monitoring-integration) to learn more about New Relic monitoring for Azure SQL Database. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-sql-database-monitoring-integration/) to learn more about New Relic monitoring for Azure SQL Database. 
 summary: |-
   Monitor Azure SQL Database by connecting Azure to New Relic
 logo: logo.svg
@@ -28,7 +28,10 @@ documentation:
     description: |
       Monitor Azure SQL Database by connecting Azure to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5henVyZSIsImRhdGFTb3VyY2UiOiI0IiwiZmVhdHVyZSI6ImFjY291bnRXaXphcmRTZXR1cCIsInByb3ZpZGVyTmFtZSI6ImF6dXJlIn0=
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-sql-database-monitoring-integration/
 keywords:
   - azure
   - database
+
+installPlans:
+  - azure-infrastructure-monitoring

--- a/quickstarts/azure/azure-sql-managed-instances/config.yml
+++ b/quickstarts/azure/azure-sql-managed-instances/config.yml
@@ -1,6 +1,6 @@
 id: 16516e34-a906-4e5a-a173-1ce57a96339e
 name: azure-sql-managed-instances
-description: "## What is Azure SQL Managed Instances?\n\nCloud-based database service based on the SQL framework.\n\n### Get started!\n\nStart monitoring Azure SQL Managed Instances by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure SQL Managed Instances documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-sql-managed-instances-monitoring-integration) to learn more about New Relic monitoring for Azure SQL Managed Instances. "
+description: "## What is Azure SQL Managed Instances?\n\nCloud-based database service based on the SQL framework.\n\n### Get started!\n\nStart monitoring Azure SQL Managed Instances by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure SQL Managed Instances documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-sql-managed-instances-monitoring-integration/) to learn more about New Relic monitoring for Azure SQL Managed Instances. "
 summary: Monitor Azure SQL Managed Instances by connecting Azure to New Relic
 logo: logo.svg
 level: New Relic
@@ -11,7 +11,10 @@ documentation:
   - name: Azure SQL Managed Instances installation docs
     description: Monitor Azure SQL Managed Instances by connecting Azure to New Relic
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5henVyZSIsImRhdGFTb3VyY2UiOiI0IiwiZmVhdHVyZSI6ImFjY291bnRXaXphcmRTZXR1cCIsInByb3ZpZGVyTmFtZSI6ImF6dXJlIn0=
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-sql-managed-instances-monitoring-integration/
 keywords:
   - azure
   - database
+
+installPlans:
+  - azure-infrastructure-monitoring

--- a/quickstarts/azure/azure-storage/config.yml
+++ b/quickstarts/azure/azure-storage/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-storage-monitoring-integration) to learn more about New Relic monitoring for Azure Storage.
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-storage-monitoring-integration/) to learn more about New Relic monitoring for Azure Storage.
 summary: |-
   Monitor Azure Storage by connecting Azure to New Relic
 logo: logo.svg
@@ -29,7 +29,10 @@ documentation:
     description: |
       Monitor Azure Storage by connecting Azure to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5henVyZSIsImRhdGFTb3VyY2UiOiI0IiwiZmVhdHVyZSI6ImFjY291bnRXaXphcmRTZXR1cCIsInByb3ZpZGVyTmFtZSI6ImF6dXJlIn0=
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-storage-monitoring-integration/
 keywords:
   - azure
   - storage
+
+installPlans:
+  - azure-infrastructure-monitoring

--- a/quickstarts/azure/azure-virtual-machine-scale-sets/config.yml
+++ b/quickstarts/azure/azure-virtual-machine-scale-sets/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-virtual-machine-scale-sets-monitoring-integration) to learn more about New Relic monitoring for Azure Virtual Machine Scale Sets. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-virtual-machine-scale-sets-monitoring-integration/) to learn more about New Relic monitoring for Azure Virtual Machine Scale Sets. 
 summary: |-
   Monitor Azure Virtual Machine Scale Sets by connecting Azure to New Relic
 logo: logo.svg
@@ -28,6 +28,9 @@ documentation:
     description: |
       Monitor Azure Virtual Machine Scale Sets by connecting Azure to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5henVyZSIsImRhdGFTb3VyY2UiOiI0IiwiZmVhdHVyZSI6ImFjY291bnRXaXphcmRTZXR1cCIsInByb3ZpZGVyTmFtZSI6ImF6dXJlIn0=
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-virtual-machine-scale-sets-monitoring-integration/
 keywords:
   - azure
+
+installPlans:
+  - azure-infrastructure-monitoring

--- a/quickstarts/azure/azure-virtual-network/config.yml
+++ b/quickstarts/azure/azure-virtual-network/config.yml
@@ -1,6 +1,6 @@
 id: f812a124-5443-4451-94d3-32b54c109555
 name: azure-virtual-network
-description: "## What is Azure Virtual Network?\n\nNetwork for connecting on-prem, Azure, and external sources.\n\n### Get started!\n\nStart monitoring Azure Virtual Network by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure Virtual Network documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-virtual-network-monitoring-integration) to learn more about New Relic monitoring for Azure Virtual Network. "
+description: "## What is Azure Virtual Network?\n\nNetwork for connecting on-prem, Azure, and external sources.\n\n### Get started!\n\nStart monitoring Azure Virtual Network by connecting Microsoft Azure to New Relic!\n\nCheck out our Azure Virtual Network documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-virtual-network-monitoring-integration/) to learn more about New Relic monitoring for Azure Virtual Network. "
 summary: Monitor Azure Virtual Network by connecting Azure to New Relic
 logo: logo.svg
 level: New Relic
@@ -12,7 +12,10 @@ documentation:
   - name: Azure Virtual Network installation docs
     description: Monitor Azure Virtual Network by connecting Azure to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5henVyZSIsImRhdGFTb3VyY2UiOiI0IiwiZmVhdHVyZSI6ImFjY291bnRXaXphcmRTZXR1cCIsInByb3ZpZGVyTmFtZSI6ImF6dXJlIn0=
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-virtual-network-monitoring-integration/
 keywords:
   - azure
   - networking
+
+installPlans:
+  - azure-infrastructure-monitoring

--- a/quickstarts/azure/azure-vms/config.yml
+++ b/quickstarts/azure/azure-vms/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-vms-monitoring-integration) to learn more about New Relic monitoring for Azure VMs. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-vms-monitoring-integration/) to learn more about New Relic monitoring for Azure VMs. 
 summary: |-
   Monitor Azure VMs by connecting Azure to New Relic
 logo: logo.svg
@@ -28,6 +28,9 @@ documentation:
     description: |
       Monitor Azure VMs by connecting Azure to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5henVyZSIsImRhdGFTb3VyY2UiOiI0IiwiZmVhdHVyZSI6ImFjY291bnRXaXphcmRTZXR1cCIsInByb3ZpZGVyTmFtZSI6ImF6dXJlIn0=
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-vms-monitoring-integration/
 keywords:
   - azure
+
+installPlans:
+  - azure-infrastructure-monitoring

--- a/quickstarts/azure/azure-vpn-gateways/config.yml
+++ b/quickstarts/azure/azure-vpn-gateways/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-vpn-gateway-integration) to learn more about New Relic monitoring for Azure VPN Gateways. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-vpn-gateway-integration/) to learn more about New Relic monitoring for Azure VPN Gateways. 
 summary: |-
   Monitor Azure VPN Gateways by connecting Azure to New Relic
 logo: logo.svg
@@ -28,7 +28,10 @@ documentation:
     description: |
       Monitor Azure VPN Gateways by connecting Azure to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5henVyZSIsImRhdGFTb3VyY2UiOiI0IiwiZmVhdHVyZSI6ImFjY291bnRXaXphcmRTZXR1cCIsInByb3ZpZGVyTmFtZSI6ImF6dXJlIn0=
+      https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-vpn-gateway-integration/
 keywords:
   - azure
   - networking
+
+installPlans:
+  - azure-infrastructure-monitoring

--- a/quickstarts/gcp/gcp-cloud-run/config.yml
+++ b/quickstarts/gcp/gcp-cloud-run/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-run-monitoring-integration) to learn more about New Relic monitoring for GCP Cloud Run. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-run-monitoring-integration/) to learn more about New Relic monitoring for GCP Cloud Run. 
 summary: |-
   Monitor GCP Cloud Run by connecting GCP to New Relic
 logo: logo.svg
@@ -28,8 +28,11 @@ documentation:
     description: |
       Monitor GCP Cloud Run by connecting GCP to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5nY3AiLCJkYXRhU291cmNlIjoiNSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJnY3AifQ==
+      https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-run-monitoring-integration/
 keywords:
   - gcp
   - google cloud platform
   - containers
+
+installPlans:
+  - gcp-infrastructure-monitoring

--- a/quickstarts/gcp/gcp-dataflow/config.yml
+++ b/quickstarts/gcp/gcp-dataflow/config.yml
@@ -1,6 +1,6 @@
 id: dec05983-5c59-4fdd-9446-211d5bd7e20d
 name: gcp-dataflow
-description: "## What is GCP Dataflow?\n\nExecute Apache Beam pipelines in a fully managed google cloud environment.\n\n### Get started!\n\nStart monitoring GCP Dataflow by connecting Google Cloud Platform (GCP) to New Relic!\n\nCheck out our GCP Dataflow documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-dataflow-monitoring-integration) to learn more about New Relic monitoring for GCP Dataflow. "
+description: "## What is GCP Dataflow?\n\nExecute Apache Beam pipelines in a fully managed google cloud environment.\n\n### Get started!\n\nStart monitoring GCP Dataflow by connecting Google Cloud Platform (GCP) to New Relic!\n\nCheck out our GCP Dataflow documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-dataflow-monitoring-integration/) to learn more about New Relic monitoring for GCP Dataflow. "
 summary: Monitor GCP Dataflow by connecting GCP to New Relic
 logo: logo.svg
 level: New Relic
@@ -11,7 +11,10 @@ documentation:
   - name: GCP Dataflow installation docs
     description: Monitor GCP Dataflow by connecting GCP to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5nY3AiLCJkYXRhU291cmNlIjoiNSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJnY3AifQ==
+      https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-dataflow-monitoring-integration/
 keywords:
   - gcp
   - google cloud platform
+
+installPlans:
+  - gcp-infrastructure-monitoring

--- a/quickstarts/gcp/gcp-dataproc/config.yml
+++ b/quickstarts/gcp/gcp-dataproc/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-dataproc-monitoring-integration) to learn more about New Relic monitoring for GCP Dataproc. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-dataproc-monitoring-integration/) to learn more about New Relic monitoring for GCP Dataproc. 
 summary: |-
   Monitor GCP Dataproc by connecting GCP to New Relic
 logo: logo.svg
@@ -28,7 +28,10 @@ documentation:
     description: |
       Monitor GCP Dataproc by connecting GCP to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5nY3AiLCJkYXRhU291cmNlIjoiNSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJnY3AifQ==
+      https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-dataproc-monitoring-integration/
 keywords:
   - gcp
   - google cloud platform
+
+installPlans:
+  - gcp-infrastructure-monitoring

--- a/quickstarts/gcp/gcp-datastore/config.yml
+++ b/quickstarts/gcp/gcp-datastore/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-datastore-monitoring-integration) to learn more about New Relic monitoring for GCP Datastore. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-datastore-monitoring-integration/) to learn more about New Relic monitoring for GCP Datastore. 
 summary: |-
   Monitor GCP Datastore by connecting GCP to New Relic
 logo: logo.svg
@@ -28,8 +28,11 @@ documentation:
     description: |
       Monitor GCP Datastore by connecting GCP to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5nY3AiLCJkYXRhU291cmNlIjoiNSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJnY3AifQ==
+      https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-datastore-monitoring-integration/
 keywords:
   - gcp
   - google cloud platform
   - database
+
+installPlans:
+  - gcp-infrastructure-monitoring

--- a/quickstarts/gcp/gcp-dedicated-interconnect/config.yml
+++ b/quickstarts/gcp/gcp-dedicated-interconnect/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-direct-interconnect-monitoring-integration) to learn more about New Relic monitoring for GCP Dedicated Interconnect. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-direct-interconnect-monitoring-integration/) to learn more about New Relic monitoring for GCP Dedicated Interconnect. 
 summary: |-
   Monitor GCP Dedicated Interconnect by connecting GCP to New Relic
 logo: logo.svg
@@ -28,8 +28,11 @@ documentation:
     description: |
       Monitor GCP Dedicated Interconnect by connecting GCP to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5nY3AiLCJkYXRhU291cmNlIjoiNSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJnY3AifQ==
+      https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-direct-interconnect-monitoring-integration/
 keywords:
   - gcp
   - google cloud platform
   - networking
+
+installPlans:
+  - gcp-infrastructure-monitoring

--- a/quickstarts/gcp/gcp-firebase-database/config.yml
+++ b/quickstarts/gcp/gcp-firebase-database/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-database-monitoring-integration) to learn more about New Relic monitoring for GCP Firebase Database. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-database-monitoring-integration/) to learn more about New Relic monitoring for GCP Firebase Database. 
 summary: |-
   Monitor GCP Firebase Database by connecting GCP to New Relic
 logo: logo.svg
@@ -28,7 +28,10 @@ documentation:
     description: |
       Monitor GCP Firebase Database by connecting GCP to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5nY3AiLCJkYXRhU291cmNlIjoiNSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJnY3AifQ==
+      https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-database-monitoring-integration/
 keywords:
   - gcp
   - google cloud platform
+
+installPlans:
+  - gcp-infrastructure-monitoring

--- a/quickstarts/gcp/gcp-firebase-hosting/config.yml
+++ b/quickstarts/gcp/gcp-firebase-hosting/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-hosting-monitoring-integration) to learn more about New Relic monitoring for GCP Firebase Hosting. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-hosting-monitoring-integration/) to learn more about New Relic monitoring for GCP Firebase Hosting. 
 summary: |-
   Monitor GCP Firebase Hosting by connecting GCP to New Relic
 logo: logo.svg
@@ -28,7 +28,10 @@ documentation:
     description: |
       Monitor GCP Firebase Hosting by connecting GCP to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5nY3AiLCJkYXRhU291cmNlIjoiNSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJnY3AifQ==
+      https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-hosting-monitoring-integration/
 keywords:
   - gcp
   - google cloud platform
+
+installPlans:
+  - gcp-infrastructure-monitoring

--- a/quickstarts/gcp/gcp-firebase-storage/config.yml
+++ b/quickstarts/gcp/gcp-firebase-storage/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-storage-monitoring-integration) to learn more about New Relic monitoring for GCP Firebase Storage. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-storage-monitoring-integration/) to learn more about New Relic monitoring for GCP Firebase Storage. 
 summary: |-
   Monitor GCP Firebase Storage by connecting GCP to New Relic
 logo: logo.svg
@@ -28,7 +28,10 @@ documentation:
     description: |
       Monitor GCP Firebase Storage by connecting GCP to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5nY3AiLCJkYXRhU291cmNlIjoiNSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJnY3AifQ==
+      https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-storage-monitoring-integration/
 keywords:
   - gcp
   - google cloud platform
+
+installPlans:
+  - gcp-infrastructure-monitoring

--- a/quickstarts/gcp/gcp-firestore/config.yml
+++ b/quickstarts/gcp/gcp-firestore/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firestore-monitoring-integration) to learn more about New Relic monitoring for GCP Firestore. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firestore-monitoring-integration/) to learn more about New Relic monitoring for GCP Firestore. 
 summary: |-
   Monitor GCP Firestore by connecting GCP to New Relic
 logo: logo.svg
@@ -28,8 +28,11 @@ documentation:
     description: |
       Monitor GCP Firestore by connecting GCP to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5nY3AiLCJkYXRhU291cmNlIjoiNSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJnY3AifQ==
+      https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firestore-monitoring-integration/
 keywords:
   - gcp
   - google cloud platform
   - database
+
+installPlans:
+  - gcp-infrastructure-monitoring

--- a/quickstarts/gcp/gcp-router/config.yml
+++ b/quickstarts/gcp/gcp-router/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-router-monitoring-integration) to learn more about New Relic monitoring for GCP Router. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-router-monitoring-integration/) to learn more about New Relic monitoring for GCP Router. 
 summary: |-
   Monitor GCP Router by connecting GCP to New Relic
 logo: logo.svg
@@ -28,8 +28,11 @@ documentation:
     description: |
       Monitor GCP Router by connecting GCP to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5nY3AiLCJkYXRhU291cmNlIjoiNSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJnY3AifQ==
+      https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-router-monitoring-integration/
 keywords:
   - gcp
   - google cloud platform
   - networking
+
+installPlans:
+  - gcp-infrastructure-monitoring

--- a/quickstarts/gcp/gcp-vpc/config.yml
+++ b/quickstarts/gcp/gcp-vpc/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-serverless-vpc-access-monitoring-integration) to learn more about New Relic monitoring for GCP VPC. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-serverless-vpc-access-monitoring-integration/) to learn more about New Relic monitoring for GCP VPC. 
 summary: |-
   Monitor GCP VPC by connecting GCP to New Relic
 logo: logo.svg
@@ -28,8 +28,11 @@ documentation:
     description: |
       Monitor GCP VPC by connecting GCP to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5nY3AiLCJkYXRhU291cmNlIjoiNSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJnY3AifQ==
+      https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-serverless-vpc-access-monitoring-integration/
 keywords:
   - gcp
   - google cloud platform
   - networking
+
+installPlans:
+  - gcp-infrastructure-monitoring

--- a/quickstarts/gcp/google-app-engine/config.yml
+++ b/quickstarts/gcp/google-app-engine/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-app-engine-monitoring-integration) to learn more about New Relic monitoring for Google App Engine. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-app-engine-monitoring-integration/) to learn more about New Relic monitoring for Google App Engine. 
 summary: |-
   Monitor Google App Engine by connecting GCP to New Relic
 logo: logo.svg
@@ -28,7 +28,10 @@ documentation:
     description: |
       Monitor Google App Engine by connecting GCP to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5nY3AiLCJkYXRhU291cmNlIjoiNSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJnY3AifQ==
+      https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-app-engine-monitoring-integration/
 keywords:
   - gcp
   - google cloud platform
+
+installPlans:
+  - gcp-infrastructure-monitoring

--- a/quickstarts/gcp/google-bigquery/config.yml
+++ b/quickstarts/gcp/google-bigquery/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-bigquery-monitoring-integration) to learn more about New Relic monitoring for Google BigQuery. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-bigquery-monitoring-integration/) to learn more about New Relic monitoring for Google BigQuery. 
 summary: |-
   Monitor Google BigQuery by connecting GCP to New Relic
 logo: logo.svg
@@ -28,8 +28,11 @@ documentation:
     description: |
       Monitor Google BigQuery by connecting GCP to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5nY3AiLCJkYXRhU291cmNlIjoiNSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJnY3AifQ==
+      https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-bigquery-monitoring-integration/
 keywords:
   - gcp
   - google cloud platform
   - database
+
+installPlans:
+  - gcp-infrastructure-monitoring

--- a/quickstarts/gcp/google-cloud-functions/config.yml
+++ b/quickstarts/gcp/google-cloud-functions/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-functions-monitoring-integration) to learn more about New Relic monitoring for Google Cloud Functions. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-functions-monitoring-integration/) to learn more about New Relic monitoring for Google Cloud Functions. 
 summary: |-
   Monitor Google Cloud Functions by connecting GCP to New Relic
 logo: logo.svg
@@ -28,8 +28,11 @@ documentation:
     description: |
       Monitor Google Cloud Functions by connecting GCP to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5nY3AiLCJkYXRhU291cmNlIjoiNSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJnY3AifQ==
+      https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-functions-monitoring-integration/
 keywords:
   - gcp
   - google cloud platform
   - serverless
+
+installPlans:
+  - gcp-infrastructure-monitoring

--- a/quickstarts/gcp/google-cloud-spanner/config.yml
+++ b/quickstarts/gcp/google-cloud-spanner/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-spanner-monitoring-integration) to learn more about New Relic monitoring for Google Cloud Spanner. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-spanner-monitoring-integration/) to learn more about New Relic monitoring for Google Cloud Spanner. 
 summary: |-
   Monitor Google Cloud Spanner by connecting GCP to New Relic
 logo: logo.svg
@@ -28,8 +28,11 @@ documentation:
     description: |
       Monitor Google Cloud Spanner by connecting GCP to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5nY3AiLCJkYXRhU291cmNlIjoiNSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJnY3AifQ==
+      https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-spanner-monitoring-integration/
 keywords:
   - gcp
   - google cloud platform
   - database
+
+installPlans:
+  - gcp-infrastructure-monitoring

--- a/quickstarts/gcp/google-cloud-sql/config.yml
+++ b/quickstarts/gcp/google-cloud-sql/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-sql-monitoring-integration) to learn more about New Relic monitoring for Google Cloud SQL. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-sql-monitoring-integration/) to learn more about New Relic monitoring for Google Cloud SQL. 
 summary: |-
   Monitor Google Cloud SQL by connecting GCP to New Relic
 logo: logo.svg
@@ -28,8 +28,11 @@ documentation:
     description: |
       Monitor Google Cloud SQL by connecting GCP to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5nY3AiLCJkYXRhU291cmNlIjoiNSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJnY3AifQ==
+      https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-sql-monitoring-integration/
 keywords:
   - gcp
   - google cloud platform
   - database
+
+installPlans:
+  - gcp-infrastructure-monitoring

--- a/quickstarts/gcp/google-cloud-storage/config.yml
+++ b/quickstarts/gcp/google-cloud-storage/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-storage-monitoring-integration) to learn more about New Relic monitoring for Google Cloud Storage. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-storage-monitoring-integration/) to learn more about New Relic monitoring for Google Cloud Storage. 
 summary: |-
   Monitor Google Cloud Storage by connecting GCP to New Relic
 logo: logo.svg
@@ -28,8 +28,11 @@ documentation:
     description: |
       Monitor Google Cloud Storage by connecting GCP to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5nY3AiLCJkYXRhU291cmNlIjoiNSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJnY3AifQ==
+      https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-storage-monitoring-integration/
 keywords:
   - gcp
   - google cloud platform
   - storage
+
+installPlans:
+  - gcp-infrastructure-monitoring

--- a/quickstarts/gcp/google-compute-engine/config.yml
+++ b/quickstarts/gcp/google-compute-engine/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-compute-engine-monitoring-integration/) to learn more about New Relic monitoring for Google Compute Engine. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-compute-engine-monitoring-integration/) to learn more about New Relic monitoring for Google Compute Engine. 
 summary: |-
   Monitor Google Compute Engine by connecting GCP to New Relic
 logo: logo.svg
@@ -27,7 +27,10 @@ documentation:
   - name: Google Compute Engine installation docs
     description: |
       Monitor Google Compute Engine by connecting GCP to New Relic.
-    url: https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5nY3AiLCJkYXRhU291cmNlIjoiNSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJnY3AifQ==
+    url: https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-compute-engine-monitoring-integration/
 keywords:
   - gcp
   - google cloud platform
+
+installPlans:
+  - gcp-infrastructure-monitoring

--- a/quickstarts/gcp/google-load-balancing/config.yml
+++ b/quickstarts/gcp/google-load-balancing/config.yml
@@ -15,7 +15,7 @@ description: |-
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-load-balancing-monitoring-integration) to learn more about New Relic monitoring for Google Load Balancing. 
+  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-load-balancing-monitoring-integration/) to learn more about New Relic monitoring for Google Load Balancing. 
 summary: |-
   Monitor Google Load Balancing by connecting GCP to New Relic
 logo: logo.svg
@@ -28,9 +28,12 @@ documentation:
     description: |
       Monitor Google Load Balancing by connecting GCP to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5nY3AiLCJkYXRhU291cmNlIjoiNSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJnY3AifQ==
+      https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-load-balancing-monitoring-integration/
 keywords:
   - gcp
   - google cloud platform
   - load balancer
   - networking
+
+installPlans:
+  - gcp-infrastructure-monitoring

--- a/quickstarts/gcp/google-pub-sub/config.yml
+++ b/quickstarts/gcp/google-pub-sub/config.yml
@@ -1,6 +1,6 @@
 id: 7ee5466d-31ec-4b91-a7ca-18dc91b43424
 name: google-pub-sub
-description: "## What is Google Pub/Sub?\n\nIngests and delivers event streams for quick data processing and analysis.\n\n### Get started!\n\nStart monitoring Google Pub/Sub by connecting Google Cloud Platform (GCP) to New Relic!\n\nCheck out our Google Pub/Sub documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-pubsub-monitoring-integration) to learn more about New Relic monitoring for Google Pub/Sub. "
+description: "## What is Google Pub/Sub?\n\nIngests and delivers event streams for quick data processing and analysis.\n\n### Get started!\n\nStart monitoring Google Pub/Sub by connecting Google Cloud Platform (GCP) to New Relic!\n\nCheck out our Google Pub/Sub documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.\n\n### More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-pubsub-monitoring-integration/) to learn more about New Relic monitoring for Google Pub/Sub. "
 summary: Monitor Google Pub/Sub by connecting GCP to New Relic
 logo: logo.svg
 level: New Relic
@@ -11,8 +11,11 @@ documentation:
   - name: Google Pub/Sub installation docs
     description: Monitor Google Pub/Sub by connecting GCP to New Relic.
     url: >-
-      https://one.newrelic.com/launcher/infra.infra?pane=eyJuZXJkbGV0SWQiOiJpbmZyYS5nY3AiLCJkYXRhU291cmNlIjoiNSIsImZlYXR1cmUiOiJhY2NvdW50V2l6YXJkU2V0dXAiLCJwcm92aWRlck5hbWUiOiJnY3AifQ==
+      https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-pubsub-monitoring-integration/
 keywords:
   - gcp
   - google cloud platform
   - queue
+
+installPlans:
+  - gcp-infrastructure-monitoring

--- a/utils/__tests__/validate_install_plans.test.js
+++ b/utils/__tests__/validate_install_plans.test.js
@@ -9,7 +9,7 @@ const githubHelpers = require('../github-api-helpers');
 const nrGraphqlHelpers = require('../nr-graphql-helpers');
 
 jest.mock('@actions/core');
-jest.spyOn(global.console, 'error').mockImplementation(() => {});
+jest.spyOn(global.console, 'error').mockImplementation(() => { });
 
 jest.mock('../github-api-helpers', () => ({
   ...jest.requireActual('../github-api-helpers'),
@@ -53,13 +53,15 @@ const mockGraphqlRequestBody = (variables = {}) => ({
       os: ['LINUX', 'WINDOWS'],
     },
     primary: {
-      mode: 'TARGETED',
-      destination: 'test-install-installer',
+      targeted: {
+        recipeName: 'test-install-installer',
+      }
     },
     fallback: {
-      mode: 'LINK',
-      destination:
-        'https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux/#manual-install',
+      link: {
+        url:
+          'https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux/#manual-install',
+      }
     },
     ...variables,
   },
@@ -105,7 +107,7 @@ describe('Action: validate install plan id', () => {
   test('errors with invalid install plan', async () => {
     const files = mockGithubAPIFiles([invalidInstallFilename1]);
     const requestBody = mockGraphqlRequestBody({
-      fallback: { mode: 'LINK', destination: 'invalid-url' },
+      fallback: { link: { url: 'invalid-url' } },
     });
     const response = mockGraphqlResponse({
       errors: [

--- a/utils/schemas/install_config.json
+++ b/utils/schemas/install_config.json
@@ -25,6 +25,9 @@
         "destination": {
           "recipeName": "infrastructure-agent-installer",
           "nerdletId": "setup-nerdlets.setup-python-integration",
+          "nerdletState": {
+            "integration": "python"
+          },
           "url": "https://docs.newrelic.com/docs/agents/python-agent/installation/standard-python-agent-install/#install"
         }
       },
@@ -33,6 +36,9 @@
         "destination": {
           "recipeName": "infrastructure-agent-installer",
           "nerdletId": "setup-nerdlets.setup-python-integration",
+          "nerdletState": {
+            "name": "value"
+          },
           "url": "https://docs.newrelic.com/docs/agents/python-agent/installation/standard-python-agent-install/#install"
         }
       }
@@ -189,6 +195,9 @@
           "destination": {
             "recipeName": "infrastructure-agent-installer",
             "nerdletId": "setup-nerdlets.setup-python-integration",
+            "nerdletState": {
+              "integration": "python"
+            },
             "url": "https://docs.newrelic.com/docs/agents/python-agent/installation/standard-python-agent-install/#install"
           }
         }
@@ -224,6 +233,9 @@
             {
               "recipeName": "infrastructure-agent-installer",
               "nerdletId": "setup-nerdlets.setup-python-integration",
+              "nerdletState": {
+                "integration": "python"
+              },
               "url": "https://docs.newrelic.com/docs/agents/python-agent/installation/standard-python-agent-install/#install"
             }
           ],
@@ -248,6 +260,25 @@
               "examples": [
                 "setup-nerdlets.setup-python-integration"
               ]
+            },
+            "nerdletState": {
+              "$id": "#/properties/install/properties/destination/properties/nerdletState",
+              "type": "object",
+              "title": "The urlState to be passed to the nerdlet",
+              "description": "State object to be provided to the nerdlet's urlState.",
+              "default": {},
+              "examples": [
+                [
+                  {
+                    "initialValue": 10,
+                    "anotherProperty": "https://example.com",
+                    "childObj": {
+                      "isProperty": true
+                    }
+                  }
+                ]
+              ],
+              "additionalProperties": true
             },
             "url": {
               "$id": "#/properties/install/properties/destination/properties/url",
@@ -275,6 +306,9 @@
           "destination": {
             "recipeName": "infrastructure-agent-installer",
             "nerdletId": "setup-nerdlets.setup-python-integration",
+            "nerdletState": {
+              "name": "value"
+            },
             "url": "https://docs.newrelic.com/docs/agents/python-agent/installation/standard-python-agent-install/#install"
           }
         }
@@ -310,6 +344,9 @@
             {
               "recipeName": "infrastructure-agent-installer",
               "nerdletId": "setup-nerdlets.setup-python-integration",
+              "nerdletState": {
+                "name": "value"
+              },
               "url": "https://docs.newrelic.com/docs/agents/python-agent/installation/standard-python-agent-install/#install"
             }
           ],
@@ -333,6 +370,18 @@
               "default": "",
               "examples": [
                 "setup-nerdlets.setup-python-integration"
+              ]
+            },
+            "nerdletState": {
+              "$id": "#/properties/fallback/properties/destination/properties/nerdletState",
+              "type": "object",
+              "title": "The urlState to be passed to the nerdlet",
+              "description": "State object to be provided to the nerdlet's urlState.",
+              "default": "",
+              "examples": [
+                {
+                  "name": "value"
+                }
               ]
             },
             "url": {

--- a/utils/validate-install-plans.js
+++ b/utils/validate-install-plans.js
@@ -66,15 +66,18 @@ const buildInstallPlanDirectiveVariable = ({ mode, destination }) => {
   switch (mode) {
     case 'targetedInstall':
       return {
-        mode: 'TARGETED',
-        destination: destination && destination.recipeName,
+        targeted: {
+          recipeName: destination && destination.recipeName
+        }
       };
     case 'link':
-      return { mode: 'LINK', destination: destination && destination.url };
+      return { link: { url: destination && destination.url } };
     case 'nerdlet':
       return {
-        mode: 'NERDLET',
-        destination: destination && destination.nerdletId,
+        nerdlet: {
+          nerdletId: destination && destination.nerdletId,
+          nerdletState: destination && destination.nerdletState
+        }
       };
     default:
       return { mode, destination: undefined };


### PR DESCRIPTION
# Summary

This is adding the nerdletState install plan directive field, applying it to one existing AWS install plan, and creating new install plans for AWS, GCP, and Azure leveraging it.

These install plans have been applied to the majority of AWS, GCP, and Azure quickstarts as well as updating their existing documentation links to point to documentation rather than the nerdlet opened by this install plan.
