### PR TITLE
fix for validating quickstarts with no install plans

### DIFF
--- a/.github/workflows/validate_install_plans.yml
+++ b/.github/workflows/validate_install_plans.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
 
       - name: Install dependencies
         run: cd utils && yarn install

--- a/utils/__tests__/validate_install_quickstart_plans.test.js
+++ b/utils/__tests__/validate_install_quickstart_plans.test.js
@@ -45,6 +45,14 @@ describe('Action: validate install plan id', () => {
     expect(global.console.error).not.toHaveBeenCalled();
   });
 
+  test.only(`succeeds when quickstart doesn't contain any install plan`, () => {
+    const files = mockGithubAPIFiles(['mock-quickstart-5/config.yml']);
+    githubHelpers.filterQuickstartConfigFiles.mockReturnValueOnce(files);
+
+    validateInstallPlanIds(files);
+    expect(global.console.error).not.toHaveBeenCalled();
+  });
+
   test('fails with invalid install plan id', () => {
     const files = mockGithubAPIFiles([invalidQuickstartFilename1]);
     githubHelpers.filterQuickstartConfigFiles.mockReturnValueOnce(files);

--- a/utils/__tests__/validate_install_quickstart_plans.test.js
+++ b/utils/__tests__/validate_install_quickstart_plans.test.js
@@ -17,6 +17,7 @@ jest.mock('../github-api-helpers', () => ({
 const validQuickstartFilename = 'mock-quickstart-2/config.yml';
 const invalidQuickstartFilename1 = 'mock-quickstart-1/config.yml';
 const invalidQuickstartFilename2 = 'mock-quickstart-3/config.yml';
+const validQuickstartWithoutInstallPlan = 'mock-quickstart-5/config.yml';
 
 const mockGithubAPIFiles = (filenames) =>
   filenames.map((filename) => ({
@@ -45,8 +46,8 @@ describe('Action: validate install plan id', () => {
     expect(global.console.error).not.toHaveBeenCalled();
   });
 
-  test.only(`succeeds when quickstart doesn't contain any install plan`, () => {
-    const files = mockGithubAPIFiles(['mock-quickstart-5/config.yml']);
+  test.only(`succeeds when valid quickstart doesn't contain any install plan`, () => {
+    const files = mockGithubAPIFiles([validQuickstartWithoutInstallPlan]);
     githubHelpers.filterQuickstartConfigFiles.mockReturnValueOnce(files);
 
     validateInstallPlanIds(files);

--- a/utils/mock_files/mock-quickstart-5/config.yml
+++ b/utils/mock_files/mock-quickstart-5/config.yml
@@ -1,0 +1,37 @@
+id: mock-2-id
+# Name of the quickstart (required)
+name: template-quickstart
+
+# Displayed in the UI (required)
+title: Template Quickstart
+
+# Long-form description of the quickstart (required)
+description: |
+  The template quickstart allows you to get visibility into the performance and available of your example service and dependencies. Use this quickstart together with the mock up integrations.
+
+# Displayed in search results and recommendations. Summarizes a quickstarts functionality.
+summary: |
+  A short form description for this quickstart
+
+# Support level: New Relic | Verified | Community (required)
+level: Community
+
+# Authors of the quickstart (required)
+authors:
+  - John Smith
+
+# Keywords for filtering / searching criteria in the UI
+keywords:
+  - list
+  - of
+  - searchable
+  - keywords
+
+documentation:
+  - name: Installation Docs
+    url: docs.newrelic.com
+    description: Description about this doc reference
+
+# Content / Design
+logo: logo.png
+website: https://www.newrelic.com

--- a/utils/validate-quickstart-install-plans.js
+++ b/utils/validate-quickstart-install-plans.js
@@ -34,7 +34,8 @@ const getAllInstallPlanIds = () => {
 const getConfigInstallPlans = (configFiles) => {
   return configFiles.map(({ filename }) => {
     const filePath = path.join(process.cwd(), `../${filename}`);
-    const { installPlans } = readQuickstartFile(filePath).contents[0];
+    const installPlans =
+      readQuickstartFile(filePath).contents[0]?.installPlans || [];
 
     return { filePath, installPlans };
   });


### PR DESCRIPTION
# Summary

This PR should resolve the error we were seeing for PR's submitting quickstarts with no install plans. Previously, install plans being missing from the config would cause an error, but is actually a valid quickstart submission.

Also:
* added a unit test for this case.
* updated install plan validation job to use node 16, which lets us use optional chaining & other snazzy additions.

# Links
Resolves: #756