### PR TITLE
Fix featured quickstart validation

### DIFF
--- a/utils/__tests__/nr_graphql_helpers.test.js
+++ b/utils/__tests__/nr_graphql_helpers.test.js
@@ -16,18 +16,15 @@ test('getCategoryTermsFromKeywords returns undefined if no keywords match a cate
 });
 
 test('getCategoryTermsFromKeywords returns 1 categoryTerm given a set of keywords where a keyword belong to 1 category', () => {
-  const mockKeywords = ['python', 'featured'];
+  const mockKeywords = ['python', 'azure'];
   const categoriesFromKeywords = getCategoryTermsFromKeywords(mockKeywords);
 
-  expect(categoriesFromKeywords).toEqual(['featured']);
+  expect(categoriesFromKeywords).toEqual(['azure']);
 });
 
 test('getCategoryTermsFromKeywords returns 2 categoryTerms given a set of keywords where keywords belong to 2 categories', () => {
-  const mockKeywords = ['python', 'featured', 'containers'];
+  const mockKeywords = ['python', 'os', 'containers'];
   const categoriesFromKeywords = getCategoryTermsFromKeywords(mockKeywords);
 
-  expect(categoriesFromKeywords).toEqual([
-    'featured',
-    'containers',
-  ]);
+  expect(categoriesFromKeywords).toEqual(['os', 'containers']);
 });

--- a/utils/instant-observability-categories.json
+++ b/utils/instant-observability-categories.json
@@ -1,13 +1,5 @@
 [
   {
-    "displayName": "All",
-    "associatedKeywords": []
-  },
-  {
-    "displayName": "Featured",
-    "associatedKeywords": ["featured"]
-  },
-  {
     "displayName": "Application monitoring",
     "associatedKeywords": ["language agent"]
   },

--- a/utils/nr-graphql-helpers.js
+++ b/utils/nr-graphql-helpers.js
@@ -80,22 +80,24 @@ const translateMutationErrors = (errors, filePath) => {
  * Method which filters out user supplied keywords to only keywords which are valid categoryTerms.
  * @param {String[] | undefined} configKeywords  - An array of keywords specified in a quickstart config.yml
  * @returns {String[] | undefined } An array of quickstart categoryTerms
- * 
- * @example 
- * // input 
- * ['python', 'featured', 'infrastructure', 'banana', 'animal']
- * 
+ *
+ * @example
+ * // input
+ * ['python', 'azure', 'infrastructure', 'banana', 'animal']
+ *
  * // return
- * ['featured', 'infrastructure']
+ * ['azure', 'infrastructure']
  */
 const getCategoryTermsFromKeywords = (configKeywords = []) => {
-  const allCategoryKeywords = instantObservabilityCategories.flatMap(category => category.associatedKeywords);
+  const allCategoryKeywords = instantObservabilityCategories.flatMap(
+    (category) => category.associatedKeywords
+  );
 
   const categoryKeywords = configKeywords.reduce((acc, keyword) => {
-    if (allCategoryKeywords.includes(keyword)){
+    if (allCategoryKeywords.includes(keyword)) {
       acc.push(keyword);
     }
-    return  acc;
+    return acc;
   }, []);
 
   return categoryKeywords.length > 0 ? categoryKeywords : undefined;


### PR DESCRIPTION
# Summary
* Remove `featured` keyword to category association. This was causing an
  error with validation in the API, since it is not used for that
  association.
* Remove `all` category to keyword mapping because it isn't used.
