### PR TITLE
fix for error logging

### DIFF
--- a/.github/workflows/validate_install_plans.yml
+++ b/.github/workflows/validate_install_plans.yml
@@ -40,7 +40,7 @@ jobs:
         id: validation
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NR_API_URL: 'https://api.newrelic.com/graphql'
+          NR_API_URL: ${{ secrets.NR_API_URL }}
           NR_API_TOKEN: ${{ secrets.NR_API_TOKEN }}
         run: 
           URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${{ steps.get_pr_number.outputs.pr-number }}/files"

--- a/.github/workflows/validate_packs.yml
+++ b/.github/workflows/validate_packs.yml
@@ -43,7 +43,7 @@ jobs:
         id: validation
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NR_API_URL: "https://api.newrelic.com/graphql"
+          NR_API_URL: ${{ secrets.NR_API_URL }}
           NR_API_TOKEN: ${{ secrets.NR_API_TOKEN }}
         run: |
           URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${{ steps.get_pr_number.outputs.pr-number }}/files"

--- a/utils/__tests__/validate_icon_and_logo.test.js
+++ b/utils/__tests__/validate_icon_and_logo.test.js
@@ -4,10 +4,7 @@ const fs = require('fs');
 
 const helpers = require('../helpers');
 
-const {
-  validateLogo,
-  handleErrors,
-} = require('../validate_logos');
+const { validateLogo, handleErrors } = require('../validate_logos');
 
 jest.mock('../helpers');
 jest.mock('fs');
@@ -74,8 +71,6 @@ describe('validate logo tests', () => {
       ];
 
       const errorMessages = validateLogo(mainConfigPaths);
-
-      console.warn(errorMessages);
 
       expect(errorMessages.length).toBe(3);
     });

--- a/utils/nr-graphql-helpers.js
+++ b/utils/nr-graphql-helpers.js
@@ -59,11 +59,12 @@ const fetchNRGraphqlResults = async (queryBody) => {
  * Handle errors from GraphQL request
  * @param {Object[]} errors  - An array of any errors found
  * @param {String} filePath  - The path related to the validation error
+ * @param {Object[]} installPlanErrors - Array of install plan errors which are handled differently
  * @returns {void}
  */
-const translateMutationErrors = (errors, filePath) => {
+const translateMutationErrors = (errors, filePath, installPlanErrors = []) => {
   console.error(
-    `ERROR: The following errors occurred while validating: ${filePath}`
+    `\nERROR: The following errors occurred while validating: ${filePath}`
   );
   errors.forEach((error) => {
     if (error.extensions && error.extensions.argumentPath) {
@@ -74,6 +75,22 @@ const translateMutationErrors = (errors, filePath) => {
       console.error(`- ${error.message}`);
     }
   });
+
+  if (installPlanErrors.length > 0) {
+    console.error(
+      `DEBUG: The following are install plan errors that occured while validating: ${filePath} and can be safely ignored.`
+    );
+
+    installPlanErrors.forEach((error) => {
+      if (error.extensions && error.extensions.argumentPath) {
+        const errorPrefix = error.extensions.argumentPath.join('/');
+
+        console.error(`- ${errorPrefix}: ${error.message}`);
+      } else {
+        console.error(`- ${error.message}`);
+      }
+    });
+  }
 };
 
 /**

--- a/utils/nr-graphql-helpers.js
+++ b/utils/nr-graphql-helpers.js
@@ -59,7 +59,7 @@ const fetchNRGraphqlResults = async (queryBody) => {
  * Handle errors from GraphQL request
  * @param {Object[]} errors  - An array of any errors found
  * @param {String} filePath  - The path related to the validation error
- * @param {Object[]} installPlanErrors - Array of install plan errors which are handled differently
+ * @param {Object[]}  [installPlanErrors=[]] - Array of install plan errors which are handled differently
  * @returns {void}
  */
 const translateMutationErrors = (errors, filePath, installPlanErrors = []) => {

--- a/utils/validate_pr_quickstarts.js
+++ b/utils/validate_pr_quickstarts.js
@@ -366,19 +366,24 @@ const countErrors = (graphqlResponses) => {
 
   graphqlResponses.forEach(({ errors, filePath }) => {
     // filter out errors where install plan id does not exist
-    const remainingErrors = errors.filter(
-      (error) =>
+
+    const installPlanErrorExists = (error) =>
+      !(
         !error?.extensions?.argumentPath?.includes('installPlanStepIds') ||
         !error?.message?.includes(
           'contains an install plan step that does not exist'
         )
+      );
+
+    const installPlanErrors = errors.filter(installPlanErrorExists);
+    const remainingErrors = errors.filter(
+      (error) => !installPlanErrorExists(error)
     );
 
     errorCount += remainingErrors.length;
 
-    // we want to print out all errors, including install plan id does not exist
     if (errors.length > 0) {
-      translateMutationErrors(errors, filePath);
+      translateMutationErrors(remainingErrors, filePath, installPlanErrors);
     }
   });
 

--- a/utils/validate_pr_quickstarts.js
+++ b/utils/validate_pr_quickstarts.js
@@ -378,7 +378,7 @@ const countErrors = (graphqlResponses) => {
 
     // we want to print out all errors, including install plan id does not exist
     if (errors.length > 0) {
-      translateMutationErrors(remainingErrors, filePath);
+      translateMutationErrors(errors, filePath);
     }
   });
 


### PR DESCRIPTION
# Summary

We currently filter out install plan errors we encounter, but still wish to have those logged out. In this instance however, we weren't logging them out 🙈 

With this change, we now log all errors out, including errors relating to install plans not existing.

Output looks like:
```
ERROR: The following errors occurred while validating: quickstarts/elasticsearch/config.yml
- Argument "quickstartMetadata" has invalid value $quickstartMetadata.
In field "summary": Expected type "String!", found null.

ERROR: The following errors occurred while validating: quickstarts/fastly/config.yml
- quickstartMetadata/dashboards/rawConfiguration/pages/widgets/linkedEntityGuids: `linkedEntityGuids` must not be set
- quickstartMetadata/alertConditions/rawConfiguration/terms/operator: `operator` can't be blank
DEBUG: The following are install plan errors that occured while validating: quickstarts/fastly/config.yml and can be safely ignored.
- quickstartMetadata/installPlanStepIds: `installPlanStepIds` contains an install plan step that does not exist: 'third-party-fastly'
```