### PR TITLE
Manually generate UUID

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,92 @@ env:
   THIRD_PARTY_GIT_AUTHOR_NAME: nr-opensource-bot
 
 jobs:
+  generate-uuid:
+    name: Generate UUID
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
+          ref: 'main'
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
+
+      - name: Install dependencies
+        run: cd utils && yarn install
+
+      - name: Generate UUIDs for quickstarts
+        id: generate-uuids
+        run: cd utils && yarn generate-uuids
+
+      - name: Commit changes
+        id: commit-changes
+        run: |
+          git config --local user.email "${{ env.THIRD_PARTY_GIT_AUTHOR_EMAIL }}"
+          git config --local user.name "${{ env.THIRD_PARTY_GIT_AUTHOR_NAME }}"
+          git add ./quickstarts/*
+          git diff-index --quiet HEAD ./quickstarts/* || git commit -m 'chore: generate UUID(s) [skip ci]'
+          echo "::set-output name=commit::true"
+      - name: Temporarily disable branch protections
+        id: disable-branch-protection
+        if: always()
+        uses: actions/github-script@v1
+        with:
+          github-token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
+          previews: luke-cage-preview
+          script: |
+            const result = await github.repos.updateBranchProtection({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: 'main',
+              required_status_checks: null,
+              restrictions: null,
+              enforce_admins: null,
+              required_pull_request_reviews: null
+            })
+            console.log("Result:", result)
+      - name: Push Commit
+        if: steps.commit-changes.outputs.commit == 'true'
+        run: git push origin HEAD
+
+      - name: Re-enable branch protections
+        id: enable-branch-protection
+        if: always()
+        uses: actions/github-script@v1
+        with:
+          github-token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
+          previews: luke-cage-preview
+          script: |
+            const result = await github.repos.updateBranchProtection({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: 'main',
+              required_status_checks: {
+                strict: true,
+                contexts: []
+              },
+              restrictions: {
+                "users":[],
+                "teams":[],
+                "apps":[]
+              },
+              enforce_admins: null,
+              required_pull_request_reviews: {
+                dismiss_stale_reviews: true,
+                required_approving_review_count: 1,
+                dismissal_restrictions: {
+                  users: [],
+                  teams: []
+                }
+              }
+            })
+            console.log("Result:", result)
+            
   generate-schema-docs:
     name: Generate schema documentation
     needs: [generate-uuid]

--- a/quickstarts/codestream/teams-cs/config.yml
+++ b/quickstarts/codestream/teams-cs/config.yml
@@ -1,3 +1,4 @@
+id: c1a50e3c-f81a-4af2-b2ab-878076c9cc82
 name: microsoft-teams-for-codestream
 
 title: Microsoft Teams for CodeStream


### PR DESCRIPTION
We moved UUID generation to a new job but it failed on a forked PR. this generates a UUID for the quickstart that slipped through and adds the job back to the release workflow while we debug