### PR TITLE
Limit concurrent requests to nerdgraph

### DIFF
--- a/utils/__tests__/nr_graphql_helpers.test.js
+++ b/utils/__tests__/nr_graphql_helpers.test.js
@@ -1,30 +1,52 @@
 'use strict';
-const { getCategoryTermsFromKeywords } = require('../nr-graphql-helpers');
+const {
+  getCategoryTermsFromKeywords,
+  chunk,
+} = require('../nr-graphql-helpers');
 
-test('getCategoryTermsFromKeywords returns undefined if no keywords are provided', () => {
-  const mockKeywords = undefined;
-  const categoriesFromKeywords = getCategoryTermsFromKeywords(mockKeywords);
+describe('getCategoryTermsFromKeywords', () => {
+  test('getCategoryTermsFromKeywords returns undefined if no keywords are provided', () => {
+    const mockKeywords = undefined;
+    const categoriesFromKeywords = getCategoryTermsFromKeywords(mockKeywords);
 
-  expect(categoriesFromKeywords).toEqual(undefined);
+    expect(categoriesFromKeywords).toEqual(undefined);
+  });
+
+  test('getCategoryTermsFromKeywords returns undefined if no keywords match a category', () => {
+    const mockKeywords = ['python', 'apm', 'http'];
+    const categoriesFromKeywords = getCategoryTermsFromKeywords(mockKeywords);
+
+    expect(categoriesFromKeywords).toEqual(undefined);
+  });
+
+  test('getCategoryTermsFromKeywords returns 1 categoryTerm given a set of keywords where a keyword belong to 1 category', () => {
+    const mockKeywords = ['python', 'azure'];
+    const categoriesFromKeywords = getCategoryTermsFromKeywords(mockKeywords);
+
+    expect(categoriesFromKeywords).toEqual(['azure']);
+  });
+
+  test('getCategoryTermsFromKeywords returns 2 categoryTerms given a set of keywords where keywords belong to 2 categories', () => {
+    const mockKeywords = ['python', 'os', 'containers'];
+    const categoriesFromKeywords = getCategoryTermsFromKeywords(mockKeywords);
+
+    expect(categoriesFromKeywords).toEqual(['os', 'containers']);
+  });
 });
 
-test('getCategoryTermsFromKeywords returns undefined if no keywords match a category', () => {
-  const mockKeywords = ['python', 'apm', 'http'];
-  const categoriesFromKeywords = getCategoryTermsFromKeywords(mockKeywords);
-
-  expect(categoriesFromKeywords).toEqual(undefined);
-});
-
-test('getCategoryTermsFromKeywords returns 1 categoryTerm given a set of keywords where a keyword belong to 1 category', () => {
-  const mockKeywords = ['python', 'azure'];
-  const categoriesFromKeywords = getCategoryTermsFromKeywords(mockKeywords);
-
-  expect(categoriesFromKeywords).toEqual(['azure']);
-});
-
-test('getCategoryTermsFromKeywords returns 2 categoryTerms given a set of keywords where keywords belong to 2 categories', () => {
-  const mockKeywords = ['python', 'os', 'containers'];
-  const categoriesFromKeywords = getCategoryTermsFromKeywords(mockKeywords);
-
-  expect(categoriesFromKeywords).toEqual(['os', 'containers']);
+describe('chunk', () => {
+  it('returns empty array for chunk size of 0', () =>
+    expect(chunk([1, 2, 3, 4], 0)).toEqual([]));
+  it('returns empty array for chunk size less than 0', () =>
+    expect(chunk([1, 2, 3, 4], -10)).toEqual([]));
+  it('returns evenly sized chunks', () =>
+    expect(chunk([1, 2, 3, 4], 2)).toEqual([
+      [1, 2],
+      [3, 4],
+    ]));
+  it('returns mostly evenly sized chunks', () =>
+    expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]));
+  it('handles empty array', () => expect(chunk([], 2)).toEqual([]));
+  it('returns original array in one chunk when chunk size > array length', () =>
+    expect(chunk([1, 2, 3, 4], 5)).toEqual([[1, 2, 3, 4]]));
 });

--- a/utils/create-validate-install-plans.js
+++ b/utils/create-validate-install-plans.js
@@ -129,9 +129,10 @@ const createValidateUpdateInstallPlan = async (installPlanFiles) => {
   const installPlanRequests = installPlanFiles.map(
     transformInstallPlansToRequestVariables
   );
-  const chunkedInstallPlanRequests = chunk(installPlanRequests, 5);
+  const chunkedInstallPlanRequests = chunk(installPlanRequests, 5); // Run requests in groups of 5
 
   let graphqlResponses = [];
+  // using a For Of loop so that it respects the `await`
   for (const reqChunk of chunkedInstallPlanRequests) {
     const chunkRes = await Promise.all(
       reqChunk.map(async ({ variables, filePath }) => {

--- a/utils/create-validate-install-plans.js
+++ b/utils/create-validate-install-plans.js
@@ -8,6 +8,7 @@ const {
 const {
   fetchNRGraphqlResults,
   translateMutationErrors,
+  chunk,
 } = require('./nr-graphql-helpers');
 
 const INSTALL_PLAN_MUTATION = `# gql 
@@ -122,22 +123,28 @@ const transformInstallPlansToRequestVariables = ({ filename }) => {
 /**
  * Validates for an array of install plan filenames
  * @param {Array} installPlanFiles - Array containing install plan file names.
- * @return {Boolean} - Boolean value indicating whether all files were validated
+ * @return {Promise.<Boolean>} - Boolean value indicating whether all files were validated
  */
 const createValidateUpdateInstallPlan = async (installPlanFiles) => {
   const installPlanRequests = installPlanFiles.map(
     transformInstallPlansToRequestVariables
   );
+  const chunkedInstallPlanRequests = chunk(installPlanRequests, 5);
 
-  const graphqlResponses = await Promise.all(
-    installPlanRequests.map(async ({ variables, filePath }) => {
-      const { data, errors } = await fetchNRGraphqlResults({
-        queryString: INSTALL_PLAN_MUTATION,
-        variables,
-      });
-      return { data, filePath, errors };
-    })
-  );
+  let graphqlResponses = [];
+  for (const reqChunk of chunkedInstallPlanRequests) {
+    const chunkRes = await Promise.all(
+      reqChunk.map(async ({ variables, filePath }) => {
+        const { data, errors } = await fetchNRGraphqlResults({
+          queryString: INSTALL_PLAN_MUTATION,
+          variables,
+        });
+
+        return { data, filePath, errors };
+      })
+    );
+    graphqlResponses = [...graphqlResponses, ...chunkRes];
+  }
 
   let hasFailed = false;
 

--- a/utils/create_validate_pr_quickstarts.js
+++ b/utils/create_validate_pr_quickstarts.js
@@ -343,9 +343,10 @@ const getGraphqlRequests = (files) => {
  */
 const createValidateUpdateQuickstarts = async (files) => {
   const graphqlRequests = getGraphqlRequests(filterOutTestFiles(files));
-  const chunkedRequests = chunk(graphqlRequests, 5);
+  const chunkedRequests = chunk(graphqlRequests, 5); // Run requests in groups of 5
 
   let graphqlResponses = [];
+  // using a For Of loop so that it respects the `await`
   for (const reqChunk of chunkedRequests) {
     const chunkRes = await Promise.all(
       reqChunk.map(async ({ variables, filePath }) => {

--- a/utils/create_validate_pr_quickstarts.js
+++ b/utils/create_validate_pr_quickstarts.js
@@ -16,6 +16,7 @@ const {
   fetchNRGraphqlResults,
   translateMutationErrors,
   getCategoryTermsFromKeywords,
+  chunk,
 } = require('./nr-graphql-helpers');
 
 const GITHUB_REPO_BASE_URL =
@@ -338,22 +339,26 @@ const getGraphqlRequests = (files) => {
 /**
  * Builds and sends GraphQL mutations to validate the quickstarts in a PR and prints out any errors
  * @param {Array} files - A list of all files changed in the PR.
- * @return {Boolean} A value indicating if the GitHub Action should fail
+ * @return {Promise.<Boolean>} A value indicating if the GitHub Action should fail
  */
 const createValidateUpdateQuickstarts = async (files) => {
   const graphqlRequests = getGraphqlRequests(filterOutTestFiles(files));
+  const chunkedRequests = chunk(graphqlRequests, 5);
 
-  const graphqlResponses = await Promise.all(
-    graphqlRequests.map(async ({ variables, filePath }) => {
-      const { data, errors } = await fetchNRGraphqlResults({
-        queryString: QUICKSTART_MUTATION,
-        variables,
-      });
+  let graphqlResponses = [];
+  for (const reqChunk of chunkedRequests) {
+    const chunkRes = await Promise.all(
+      reqChunk.map(async ({ variables, filePath }) => {
+        const { data, errors } = await fetchNRGraphqlResults({
+          queryString: QUICKSTART_MUTATION,
+          variables,
+        });
 
-      return { data, errors, filePath };
-    })
-  );
-
+        return { data, errors, filePath };
+      })
+    );
+    graphqlResponses = [...graphqlResponses, ...chunkRes];
+  }
   return Boolean(countErrors(graphqlResponses));
 };
 

--- a/utils/nr-graphql-helpers.js
+++ b/utils/nr-graphql-helpers.js
@@ -120,8 +120,30 @@ const getCategoryTermsFromKeywords = (configKeywords = []) => {
   return categoryKeywords.length > 0 ? categoryKeywords : undefined;
 };
 
+/**
+ * Breaks an array up into parts, the last part may have less elements
+ * @param {Array} array - an array of anything
+ * @param {Number} chunkSize - the size of the parts
+ * @returns {Array} the array broken out into smaller array chunks
+ */
+const chunk = (array, chunkSize) => {
+  let chunkedArray = [];
+  let j = array.length;
+
+  if (chunkSize < 1) {
+    return chunkedArray;
+  }
+
+  for (let i = 0; i < j; i += chunkSize) {
+    chunkedArray = [...chunkedArray, array.slice(i, i + chunkSize)];
+  }
+
+  return chunkedArray;
+};
+
 module.exports = {
   fetchNRGraphqlResults,
   translateMutationErrors,
   getCategoryTermsFromKeywords,
+  chunk,
 };

--- a/utils/nr-graphql-helpers.js
+++ b/utils/nr-graphql-helpers.js
@@ -25,6 +25,9 @@ const buildRequestBody = ({ queryString, variables }) =>
 const fetchNRGraphqlResults = async (queryBody) => {
   let results;
   let graphqlErrors = [];
+
+  // To help us ensure that the request hits and is processed by nerdgraph
+  // This will try the request 3 times, waiting a little longer between each attempt
   const retry = Policy.handleAll().retry().attempts(3).exponential();
 
   try {

--- a/utils/nr-graphql-helpers.js
+++ b/utils/nr-graphql-helpers.js
@@ -28,7 +28,11 @@ const fetchNRGraphqlResults = async (queryBody) => {
 
   // To help us ensure that the request hits and is processed by nerdgraph
   // This will try the request 3 times, waiting a little longer between each attempt
-  const retry = Policy.handleAll().retry().attempts(3).exponential();
+  // It will retry on status codes 400+, 2** would be success and we wouldn't want to retry for a 3**
+  const retry = Policy.handleWhenResult((response) => response.status >= 400)
+    .retry()
+    .attempts(3)
+    .exponential();
 
   try {
     const body = buildRequestBody(queryBody);

--- a/utils/package.json
+++ b/utils/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@actions/core": "^1.4.0",
     "ajv": "^8.4.0",
+    "cockatiel": "^3.0.0-beta.0",
     "glob": "^7.1.7",
     "graphql": "^16.3.0",
     "graphql-markdown": "^6.0.0",

--- a/utils/yarn.lock
+++ b/utils/yarn.lock
@@ -873,6 +873,11 @@ co@^4.6.0:
   resolved "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
   integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
 
+cockatiel@^3.0.0-beta.0:
+  version "3.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/cockatiel/-/cockatiel-3.0.0-beta.0.tgz#f1616d999e6414e82cb49ac0664d4c1249a42b8a"
+  integrity sha512-4H6SA90M3HXWqShMhgx2YvoYoB3x32oZwynxFfBEmiK+5DLjh7fC/1C9Uat5YLcmQ/h9mgncAvi+8eYXbCOTxA==
+
 collect-v8-coverage@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz"


### PR DESCRIPTION
# Summary
* The concurrency of requests to nerdgraph during validation was
  overloading some systems and making us bad users of the api.
* This limits the number of concurrent requests per job to 5

## TODO
- [x] Add retries to calls to nerdgraph
- [ ] Maybe add more logging?

## Resolutions
- Closes #777 
- Closes #783
