### PR TITLE
Serialize nerdlet state

### DIFF
--- a/utils/create-validate-install-plans.js
+++ b/utils/create-validate-install-plans.js
@@ -12,7 +12,7 @@ const {
 } = require('./nr-graphql-helpers');
 
 const INSTALL_PLAN_MUTATION = `# gql 
-mutation (
+mutation QuickstartRepoInstallPlanMutation (
   $description: String!
   $dryRun: Boolean
   $displayName: String!
@@ -74,7 +74,7 @@ const buildInstallPlanDirectiveVariable = ({ mode, destination }) => {
       return {
         nerdlet: {
           nerdletId: destination && destination.nerdletId,
-          nerdletState: destination && destination.nerdletState,
+          nerdletState: destination && JSON.stringify(destination.nerdletState),
         },
       };
     default:
@@ -137,6 +137,7 @@ const createValidateUpdateInstallPlan = async (installPlanFiles) => {
   for (const reqChunk of chunkedInstallPlanRequests) {
     const chunkRes = await Promise.all(
       reqChunk.map(async ({ variables, filePath }) => {
+        console.log(JSON.stringify(variables));
         const { data, errors } = await fetchNRGraphqlResults({
           queryString: INSTALL_PLAN_MUTATION,
           variables,

--- a/utils/create-validate-install-plans.js
+++ b/utils/create-validate-install-plans.js
@@ -137,7 +137,6 @@ const createValidateUpdateInstallPlan = async (installPlanFiles) => {
   for (const reqChunk of chunkedInstallPlanRequests) {
     const chunkRes = await Promise.all(
       reqChunk.map(async ({ variables, filePath }) => {
-        console.log(JSON.stringify(variables));
         const { data, errors } = await fetchNRGraphqlResults({
           queryString: INSTALL_PLAN_MUTATION,
           variables,

--- a/utils/create_validate_pr_quickstarts.js
+++ b/utils/create_validate_pr_quickstarts.js
@@ -24,7 +24,7 @@ const GITHUB_REPO_BASE_URL =
 const GITHUB_RAW_BASE_URL =
   'https://raw.githubusercontent.com/newrelic/newrelic-quickstarts/main';
 const QUICKSTART_MUTATION = `# gql
-mutation (
+mutation QuickstartRepoQuickstartMutation (
   $dryRun: Boolean
   $id: ID!
   $quickstartMetadata: Nr1CatalogQuickstartMetadataInput!


### PR DESCRIPTION
# Summary
* Nerdlet state for install plans must be string JSON, it was an object instead
* Update mutations with names for easier future debugging

