### PR TITLE
fix: validation pathing

### DIFF
--- a/utils/__tests__/validate_quickstarts.test.js
+++ b/utils/__tests__/validate_quickstarts.test.js
@@ -10,7 +10,7 @@ jest.spyOn(global.console, 'error').mockImplementation(() => {});
 const getTestFile = (schemaType) => {
   const files = {
     alert: {
-      path: '/alerts/',
+      path: '/quickstarts/testname/alerts/',
       contents: [
         {
           name: 'fakealert',
@@ -23,7 +23,7 @@ const getTestFile = (schemaType) => {
       ],
     },
     dashboard: {
-      path: '/dashboards/',
+      path: '/quickstarts/testname/dashboards/',
       contents: [
         {
           name: 'fakedashboard',
@@ -39,7 +39,7 @@ const getTestFile = (schemaType) => {
       ],
     },
     flex: {
-      path: '/instrumentation/flex/',
+      path: '/quickstarts/testname/instrumentation/flex/',
       contents: [
         {
           name: 'fakeflexconfig',
@@ -50,7 +50,7 @@ const getTestFile = (schemaType) => {
       ],
     },
     synthetic: {
-      path: '/instrumentation/synthetics/',
+      path: '/quickstarts/testname/instrumentation/synthetics/',
       contents: [
         {
           name: 'fakesynthetic',
@@ -58,7 +58,7 @@ const getTestFile = (schemaType) => {
       ],
     },
     main_config: {
-      path: '/main_config/', // this can be any path
+      path: '/quickstarts/testname/main_config/', // this can be any path
       contents: [
         {
           title: 'Fake Quickstart',
@@ -66,7 +66,7 @@ const getTestFile = (schemaType) => {
           description: 'fakeDescription',
           authors: ['fakeAuthor'],
           level: 'New Relic',
-          logo: 'logo.png'
+          logo: 'logo.png',
         },
       ],
     },

--- a/utils/validate_quickstarts.js
+++ b/utils/validate_quickstarts.js
@@ -84,22 +84,26 @@ const validateFile = (file) => {
 
   console.log(`Validating ${removeRepoPathPrefix(filePath)}`);
   switch (true) {
-    case filePath.includes('/alerts/'): // validate using alert schema
+    case filePath.includes('/quickstarts/') && filePath.includes('/alerts/'): // validate using alert schema
       errors = validateAgainstSchema(file.contents[0], alertSchema);
       break;
-    case filePath.includes('/dashboards/'): // validate using dashboard schema
+    case filePath.includes('/quickstarts/') &&
+      filePath.includes('/dashboards/'): // validate using dashboard schema
       errors = validateAgainstSchema(file.contents[0], dashboardSchema);
       break;
     case filePath.includes('/install/'): // validate using install schema
       errors = validateAgainstSchema(file.contents[0], installSchema);
       break;
-    case filePath.includes('/instrumentation/synthetics/'): // validate using synthetics schema
+    case filePath.includes('/quickstarts/') &&
+      filePath.includes('/instrumentation/synthetics/'): // validate using synthetics schema
       errors = validateAgainstSchema(file.contents[0], syntheticSchema);
       break;
-    case filePath.includes('/instrumentation/logging/'): // validate using logging schema
+    case filePath.includes('/quickstarts/') &&
+      filePath.includes('/instrumentation/logging/'): // validate using logging schema
       errors = validateAgainstSchema(file.contents[0], loggingSchema);
       break;
-    case filePath.includes('/instrumentation/flex/'): // validate using flex config schema.
+    case filePath.includes('/quickstarts/') &&
+      filePath.includes('/instrumentation/flex/'): // validate using flex config schema.
       // The flex YAML is two documents, validate each of them
       errors = [
         ...validateAgainstSchema(file.contents[0], flexConfigSchema),


### PR DESCRIPTION
# Summary
* JSON schema validation was mistaking an install plan under a
  `/dashboards/` directory for an actual dashboard
* This adds a check for the quickstarts directory when evaluating
  related components

