### PR TITLE
feat: add 30 day sum billboard chart

### DIFF
--- a/quickstarts/oma-data-gov/dashboards/data-ingest-baseline.json
+++ b/quickstarts/oma-data-gov/dashboards/data-ingest-baseline.json
@@ -27,7 +27,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "SELECT rate(sum(GigabytesIngested), 1 day) AS avgGbIngestTimeseries FROM NrConsumption WHERE productLine='DataPlatform' TIMESERIES AUTO since 9 months ago facet consumingAccountName limit max"
+                  "query": "SELECT rate(sum(GigabytesIngested), 1 day) AS 'Daily Ingest Rate' FROM NrConsumption WHERE productLine='DataPlatform' TIMESERIES AUTO since 9 months ago facet consumingAccountName limit max"
                 }
               ]
             },
@@ -35,27 +35,32 @@
           },
           {
             "visualization": {
-              "id": "viz.billboard"
+              "id": "viz.line"
             },
             "layout": {
               "column": 5,
               "row": 1,
               "height": 4,
-              "width": 1
+              "width": 2
             },
-            "title": "30 Day Ingest Sum (All Accounts & Telemetry Types)",
+            "title": "30 Day Rate (All Accounts & Telemetry Types)",
             "rawConfiguration": {
               "dataFormatters": [],
               "facet": {
                 "showOtherSeries": false
               },
+              "legend": {
+                "enabled": true
+              },
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "SELECT sum(GigabytesIngested) AS avgGbIngest FROM NrConsumption WHERE productLine='DataPlatform' since 30 days ago limit max compare with 1 month ago"
+                  "query": "SELECT rate(sum(GigabytesIngested), 30 day) AS '30 Day Rate' FROM NrConsumption WHERE productLine='DataPlatform' since 30 days ago limit max compare with 1 month ago TIMESERIES 7 days"
                 }
               ],
-              "thresholds": []
+              "yAxisLeft": {
+                "zero": true
+              }
             },
             "linkedEntityGuids": null
           },
@@ -64,7 +69,7 @@
               "id": "viz.billboard"
             },
             "layout": {
-              "column": 6,
+              "column": 7,
               "row": 1,
               "height": 4,
               "width": 3
@@ -90,7 +95,7 @@
               "id": "viz.billboard"
             },
             "layout": {
-              "column": 9,
+              "column": 10,
               "row": 1,
               "height": 4,
               "width": 3
@@ -113,22 +118,6 @@
           },
           {
             "visualization": {
-              "id": "viz.markdown"
-            },
-            "layout": {
-              "column": 12,
-              "row": 1,
-              "height": 4,
-              "width": 1
-            },
-            "title": "",
-            "rawConfiguration": {
-              "text": "## Relevant NR1 Docs\n\n### Solutions Guides\n\n[Data Governance Solutions Guide](https://docs.newrelic.com/docs/new-relic-solutions/observability-maturity/introduction)\n\n### Technical Docs\n\n[Manage Incoming Data](https://docs.newrelic.com/docs/data-apis/manage-data/manage-data-coming-new-relic/)\n\n[Data Management Hub](https://docs.newrelic.com/docs/data-apis/manage-data/manage-your-data/)\n\n[Drop Data Using Nerdgraph](https://docs.newrelic.com/docs/data-apis/manage-data/drop-data-using-nerdgraph/)\n\n[Alert on Data Ingest Anomalies](https://docs.newrelic.com/docs/accounts/accounts-billing/new-relic-one-pricing-billing/usage-queries-alerts/)"
-            },
-            "linkedEntityGuids": null
-          },
-          {
-            "visualization": {
               "id": "viz.line"
             },
             "layout": {
@@ -145,7 +134,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "SELECT rate(sum(GigabytesIngested), 1 day) AS avgGbIngestTimeseries FROM NrConsumption WHERE productLine='DataPlatform' TIMESERIES AUTO since 9 months ago limit max COMPARE WITH 3 months ago"
+                  "query": "SELECT rate(sum(GigabytesIngested), 1 day) AS 'Daily Ingest Rate' FROM NrConsumption WHERE productLine='DataPlatform' TIMESERIES AUTO since 9 months ago limit max COMPARE WITH 3 months ago"
                 }
               ],
               "yAxisLeft": {
@@ -162,7 +151,7 @@
               "column": 5,
               "row": 5,
               "height": 3,
-              "width": 4
+              "width": 3
             },
             "title": "Daily Ingest Rate (By Data Type)",
             "rawConfiguration": {
@@ -189,10 +178,10 @@
               "id": "viz.line"
             },
             "layout": {
-              "column": 9,
+              "column": 8,
               "row": 5,
               "height": 3,
-              "width": 4
+              "width": 3
             },
             "title": "Gigabytes Ingested Derivative",
             "rawConfiguration": {
@@ -211,6 +200,48 @@
               "yAxisLeft": {
                 "zero": true
               }
+            },
+            "linkedEntityGuids": null
+          },
+          {
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "layout": {
+              "column": 11,
+              "row": 5,
+              "height": 3,
+              "width": 2
+            },
+            "title": "30 Day Sum (All Accounts & Telemetry Types)",
+            "rawConfiguration": {
+              "dataFormatters": [],
+              "facet": {
+                "showOtherSeries": false
+              },
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "SELECT sum(GigabytesIngested) AS '30 Day Sum' FROM NrConsumption WHERE productLine='DataPlatform' since 30 days ago limit max compare with 1 month ago "
+                }
+              ],
+              "thresholds": []
+            },
+            "linkedEntityGuids": null
+          },
+          {
+            "visualization": {
+              "id": "viz.markdown"
+            },
+            "layout": {
+              "column": 1,
+              "row": 8,
+              "height": 3,
+              "width": 12
+            },
+            "title": "",
+            "rawConfiguration": {
+              "text": "## Relevant NR1 Docs\n\n### Solutions Guides\n\n[Data Governance Solutions Guide](https://docs.newrelic.com/docs/new-relic-solutions/observability-maturity/introduction)\n\n### Technical Docs\n\n[Manage Incoming Data](https://docs.newrelic.com/docs/data-apis/manage-data/manage-data-coming-new-relic/)\n\n[Data Management Hub](https://docs.newrelic.com/docs/data-apis/manage-data/manage-your-data/)\n\n[Drop Data Using Nerdgraph](https://docs.newrelic.com/docs/data-apis/manage-data/drop-data-using-nerdgraph/)\n\n[Alert on Data Ingest Anomalies](https://docs.newrelic.com/docs/accounts/accounts-billing/new-relic-one-pricing-billing/usage-queries-alerts/)"
             },
             "linkedEntityGuids": null
           }
@@ -294,7 +325,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "SELECT rate(sum(GigabytesIngested), 1 day) AS avgGbIngestTimeseries FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'ApmEventsBytes' TIMESERIES AUTO since 9 months ago limit max COMPARE WITH 3 months ago"
+                  "query": "SELECT rate(sum(GigabytesIngested), 1 day) AS 'Daily Ingest Rate' FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'ApmEventsBytes' TIMESERIES AUTO since 9 months ago limit max COMPARE WITH 3 months ago"
                 }
               ],
               "yAxisLeft": {
@@ -376,7 +407,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "SELECT sum(GigabytesIngested) AS avgGbIngest FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'ApmEventsBytes' since 30 days ago limit max compare with 1 month ago"
+                  "query": "SELECT sum(GigabytesIngested) AS '30 Day Sum' FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'ApmEventsBytes' since 30 days ago limit max compare with 1 month ago"
                 }
               ],
               "thresholds": []
@@ -455,7 +486,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "SELECT rate(sum(GigabytesIngested), 1 day) AS avgGbIngestTimeseries FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'TracingBytes' TIMESERIES AUTO since 9 months ago limit max COMPARE WITH 3 months ago"
+                  "query": "SELECT rate(sum(GigabytesIngested), 1 day) AS 'Daily Ingest Rate' FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'TracingBytes' TIMESERIES AUTO since 9 months ago limit max COMPARE WITH 3 months ago"
                 }
               ],
               "yAxisLeft": {
@@ -537,7 +568,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "SELECT sum(GigabytesIngested) AS avgGbIngest FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'TracingBytes' since 30 days ago limit max compare with 1 month ago"
+                  "query": "SELECT sum(GigabytesIngested) AS '30 Day Sum' FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'TracingBytes' since 30 days ago limit max compare with 1 month ago"
                 }
               ],
               "thresholds": []
@@ -616,7 +647,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "SELECT rate(sum(GigabytesIngested), 1 day) AS avgGbIngestTimeseries FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'BrowserEventsBytes' TIMESERIES AUTO since 9 months ago limit max COMPARE WITH 3 months ago"
+                  "query": "SELECT rate(sum(GigabytesIngested), 1 day) AS 'Daily Ingest Rate' FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'BrowserEventsBytes' TIMESERIES AUTO since 9 months ago limit max COMPARE WITH 3 months ago"
                 }
               ],
               "yAxisLeft": {
@@ -698,7 +729,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "SELECT sum(GigabytesIngested) AS avgGbIngest FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'BrowserEventsBytes' since 30 days ago limit max compare with 1 month ago"
+                  "query": "SELECT sum(GigabytesIngested) AS '30 Day Sum' FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'BrowserEventsBytes' since 30 days ago limit max compare with 1 month ago"
                 }
               ],
               "thresholds": []
@@ -777,7 +808,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "SELECT rate(sum(GigabytesIngested), 1 day) AS avgGbIngestTimeseries FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'MobileEventsBytes' TIMESERIES AUTO since 9 months ago limit max COMPARE WITH 3 months ago"
+                  "query": "SELECT rate(sum(GigabytesIngested), 1 day) AS 'Daily Ingest Rate' FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'MobileEventsBytes' TIMESERIES AUTO since 9 months ago limit max COMPARE WITH 3 months ago"
                 }
               ],
               "yAxisLeft": {
@@ -859,7 +890,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "SELECT sum(GigabytesIngested) AS avgGbIngest FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'MobileEventsBytes' since 30 days ago limit max compare with 1 month ago"
+                  "query": "SELECT sum(GigabytesIngested) AS '30 Day Sum' FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'MobileEventsBytes' since 30 days ago limit max compare with 1 month ago"
                 }
               ],
               "thresholds": []
@@ -938,7 +969,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "SELECT rate(sum(GigabytesIngested), 1 day) AS avgGbIngestTimeseries FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'LoggingBytes' TIMESERIES AUTO since 9 months ago limit max COMPARE WITH 3 months ago"
+                  "query": "SELECT rate(sum(GigabytesIngested), 1 day) AS 'Daily Ingest Rate' FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'LoggingBytes' TIMESERIES AUTO since 9 months ago limit max COMPARE WITH 3 months ago"
                 }
               ],
               "yAxisLeft": {
@@ -1020,7 +1051,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "SELECT sum(GigabytesIngested) AS avgGbIngest FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'LoggingBytes' since 30 days ago limit max compare with 1 month ago"
+                  "query": "SELECT sum(GigabytesIngested) AS '30 Day Sum' FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'LoggingBytes' since 30 days ago limit max compare with 1 month ago"
                 }
               ],
               "thresholds": []
@@ -1099,7 +1130,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "SELECT rate(sum(GigabytesIngested), 1 day) AS avgGbIngestTimeseries FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'InfraHostBytes' TIMESERIES AUTO since 9 months ago limit max COMPARE WITH 3 months ago"
+                  "query": "SELECT rate(sum(GigabytesIngested), 1 day) AS 'Daily Ingest Rate' FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'InfraHostBytes' TIMESERIES AUTO since 9 months ago limit max COMPARE WITH 3 months ago"
                 }
               ],
               "yAxisLeft": {
@@ -1181,7 +1212,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "SELECT sum(GigabytesIngested) AS avgGbIngest FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'InfraHostBytes' since 30 days ago limit max compare with 1 month ago"
+                  "query": "SELECT sum(GigabytesIngested) AS '30 Day Sum' FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'InfraHostBytes' since 30 days ago limit max compare with 1 month ago"
                 }
               ],
               "thresholds": []
@@ -1260,7 +1291,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "SELECT rate(sum(GigabytesIngested), 1 day) AS avgGbIngestTimeseries FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'InfraProcessBytes' TIMESERIES AUTO since 9 months ago limit max COMPARE WITH 3 months ago"
+                  "query": "SELECT rate(sum(GigabytesIngested), 1 day) AS 'Daily Ingest Rate' FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'InfraProcessBytes' TIMESERIES AUTO since 9 months ago limit max COMPARE WITH 3 months ago"
                 }
               ],
               "yAxisLeft": {
@@ -1342,7 +1373,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "SELECT sum(GigabytesIngested) AS avgGbIngest FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'InfraProcessBytes' since 30 days ago limit max compare with 1 month ago"
+                  "query": "SELECT sum(GigabytesIngested) AS '30 Day Sum' FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'InfraProcessBytes' since 30 days ago limit max compare with 1 month ago"
                 }
               ],
               "thresholds": []
@@ -1421,7 +1452,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "SELECT rate(sum(GigabytesIngested), 1 day) AS avgGbIngestTimeseries FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'InfraIntegrationBytes' TIMESERIES AUTO since 9 months ago limit max COMPARE WITH 3 months ago"
+                  "query": "SELECT rate(sum(GigabytesIngested), 1 day) AS 'Daily Ingest Rate' FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'InfraIntegrationBytes' TIMESERIES AUTO since 9 months ago limit max COMPARE WITH 3 months ago"
                 }
               ],
               "yAxisLeft": {
@@ -1503,7 +1534,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "SELECT sum(GigabytesIngested) AS avgGbIngest FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'InfraIntegrationBytes' since 30 days ago limit max compare with 1 month ago"
+                  "query": "SELECT sum(GigabytesIngested) AS '30 Day Sum' FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'InfraIntegrationBytes' since 30 days ago limit max compare with 1 month ago"
                 }
               ],
               "thresholds": []
@@ -1598,7 +1629,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "SELECT rate(sum(GigabytesIngested), 1 day) AS avgGbIngestTimeseries FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'ServerlessBytes' TIMESERIES AUTO since 9 months ago limit max COMPARE WITH 3 months ago"
+                  "query": "SELECT rate(sum(GigabytesIngested), 1 day) AS 'Daily Ingest Rate' FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'ServerlessBytes' TIMESERIES AUTO since 9 months ago limit max COMPARE WITH 3 months ago"
                 }
               ],
               "yAxisLeft": {
@@ -1680,7 +1711,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "SELECT sum(GigabytesIngested) AS avgGbIngest FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'ServerlessBytes' since 30 days ago limit max compare with 1 month ago"
+                  "query": "SELECT sum(GigabytesIngested) AS '30 Day Sum' FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'ServerlessBytes' since 30 days ago limit max compare with 1 month ago"
                 }
               ],
               "thresholds": []
@@ -1759,7 +1790,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "SELECT rate(sum(GigabytesIngested), 1 day) AS avgGbIngestTimeseries FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'CustomEventsBytes' TIMESERIES AUTO since 9 months ago limit max COMPARE WITH 3 months ago"
+                  "query": "SELECT rate(sum(GigabytesIngested), 1 day) AS 'Daily Ingest Rate' FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'CustomEventsBytes' TIMESERIES AUTO since 9 months ago limit max COMPARE WITH 3 months ago"
                 }
               ],
               "yAxisLeft": {
@@ -1841,7 +1872,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "SELECT sum(GigabytesIngested) AS avgGbIngest FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'CustomEventsBytes' since 30 days ago limit max compare with 1 month ago"
+                  "query": "SELECT sum(GigabytesIngested) AS '30 Day Rate' FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'CustomEventsBytes' since 30 days ago limit max compare with 1 month ago"
                 }
               ],
               "thresholds": []

--- a/quickstarts/oma-data-gov/dashboards/data-ingest-baseline.json
+++ b/quickstarts/oma-data-gov/dashboards/data-ingest-baseline.json
@@ -41,6 +41,32 @@
               "column": 5,
               "row": 1,
               "height": 4,
+              "width": 1
+            },
+            "title": "30 Day Ingest Sum (All Accounts & Telemetry Types)",
+            "rawConfiguration": {
+              "dataFormatters": [],
+              "facet": {
+                "showOtherSeries": false
+              },
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "SELECT sum(GigabytesIngested) AS avgGbIngest FROM NrConsumption WHERE productLine='DataPlatform' since 30 days ago limit max compare with 1 month ago"
+                }
+              ],
+              "thresholds": []
+            },
+            "linkedEntityGuids": null
+          },
+          {
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "layout": {
+              "column": 6,
+              "row": 1,
+              "height": 4,
               "width": 3
             },
             "title": "30 Day Ingest Rate (By Telemetry Type))",
@@ -64,7 +90,7 @@
               "id": "viz.billboard"
             },
             "layout": {
-              "column": 8,
+              "column": 9,
               "row": 1,
               "height": 4,
               "width": 3
@@ -90,10 +116,10 @@
               "id": "viz.markdown"
             },
             "layout": {
-              "column": 11,
+              "column": 12,
               "row": 1,
               "height": 4,
-              "width": 2
+              "width": 1
             },
             "title": "",
             "rawConfiguration": {
@@ -342,9 +368,32 @@
               "column": 1,
               "row": 4,
               "height": 7,
-              "width": 6
+              "width": 2
             },
-            "title": "GB Ingest (By Account)",
+            "title": "GB Ingest 30 Day Sum  (All Accounts)",
+            "rawConfiguration": {
+              "dataFormatters": [],
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "SELECT sum(GigabytesIngested) AS avgGbIngest FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'ApmEventsBytes' since 30 days ago limit max compare with 1 month ago"
+                }
+              ],
+              "thresholds": []
+            },
+            "linkedEntityGuids": null
+          },
+          {
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "layout": {
+              "column": 3,
+              "row": 4,
+              "height": 7,
+              "width": 4
+            },
+            "title": "GB Ingest 30 Day Rate (By Account)",
             "rawConfiguration": {
               "dataFormatters": [],
               "nrqlQueries": [
@@ -480,7 +529,30 @@
               "column": 1,
               "row": 4,
               "height": 7,
-              "width": 6
+              "width": 2
+            },
+            "title": "GB Ingest 30 Day Sum (All Accounts)",
+            "rawConfiguration": {
+              "dataFormatters": [],
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "SELECT sum(GigabytesIngested) AS avgGbIngest FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'TracingBytes' since 30 days ago limit max compare with 1 month ago"
+                }
+              ],
+              "thresholds": []
+            },
+            "linkedEntityGuids": null
+          },
+          {
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "layout": {
+              "column": 3,
+              "row": 4,
+              "height": 7,
+              "width": 4
             },
             "title": "GB Ingest (By Account)",
             "rawConfiguration": {
@@ -618,7 +690,30 @@
               "column": 1,
               "row": 4,
               "height": 7,
-              "width": 6
+              "width": 2
+            },
+            "title": "GB Ingest  30 Day Sum (All Acounts)",
+            "rawConfiguration": {
+              "dataFormatters": [],
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "SELECT sum(GigabytesIngested) AS avgGbIngest FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'BrowserEventsBytes' since 30 days ago limit max compare with 1 month ago"
+                }
+              ],
+              "thresholds": []
+            },
+            "linkedEntityGuids": null
+          },
+          {
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "layout": {
+              "column": 3,
+              "row": 4,
+              "height": 7,
+              "width": 4
             },
             "title": "GB Ingest (By Account)",
             "rawConfiguration": {
@@ -756,7 +851,30 @@
               "column": 1,
               "row": 4,
               "height": 7,
-              "width": 6
+              "width": 2
+            },
+            "title": "GB Ingest 30 Day Sum (All Accounts)",
+            "rawConfiguration": {
+              "dataFormatters": [],
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "SELECT sum(GigabytesIngested) AS avgGbIngest FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'MobileEventsBytes' since 30 days ago limit max compare with 1 month ago"
+                }
+              ],
+              "thresholds": []
+            },
+            "linkedEntityGuids": null
+          },
+          {
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "layout": {
+              "column": 3,
+              "row": 4,
+              "height": 7,
+              "width": 4
             },
             "title": "GB Ingest (By Account)",
             "rawConfiguration": {
@@ -894,7 +1012,30 @@
               "column": 1,
               "row": 4,
               "height": 7,
-              "width": 6
+              "width": 2
+            },
+            "title": "GB Ingest 30 Day Sum (All Accounts)",
+            "rawConfiguration": {
+              "dataFormatters": [],
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "SELECT sum(GigabytesIngested) AS avgGbIngest FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'LoggingBytes' since 30 days ago limit max compare with 1 month ago"
+                }
+              ],
+              "thresholds": []
+            },
+            "linkedEntityGuids": null
+          },
+          {
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "layout": {
+              "column": 3,
+              "row": 4,
+              "height": 7,
+              "width": 4
             },
             "title": "GB Ingest (By Account)",
             "rawConfiguration": {
@@ -1032,7 +1173,30 @@
               "column": 1,
               "row": 4,
               "height": 7,
-              "width": 6
+              "width": 2
+            },
+            "title": "GB Ingest 30 Day Sum (All Accounts)",
+            "rawConfiguration": {
+              "dataFormatters": [],
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "SELECT sum(GigabytesIngested) AS avgGbIngest FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'InfraHostBytes' since 30 days ago limit max compare with 1 month ago"
+                }
+              ],
+              "thresholds": []
+            },
+            "linkedEntityGuids": null
+          },
+          {
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "layout": {
+              "column": 3,
+              "row": 4,
+              "height": 7,
+              "width": 4
             },
             "title": "GB Ingest (By Account)",
             "rawConfiguration": {
@@ -1170,7 +1334,30 @@
               "column": 1,
               "row": 4,
               "height": 7,
-              "width": 6
+              "width": 2
+            },
+            "title": "GB Ingest 30 Day Sum (All Accounts)",
+            "rawConfiguration": {
+              "dataFormatters": [],
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "SELECT sum(GigabytesIngested) AS avgGbIngest FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'InfraProcessBytes' since 30 days ago limit max compare with 1 month ago"
+                }
+              ],
+              "thresholds": []
+            },
+            "linkedEntityGuids": null
+          },
+          {
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "layout": {
+              "column": 3,
+              "row": 4,
+              "height": 7,
+              "width": 4
             },
             "title": "GB Ingest (By Account)",
             "rawConfiguration": {
@@ -1308,7 +1495,30 @@
               "column": 1,
               "row": 4,
               "height": 7,
-              "width": 6
+              "width": 2
+            },
+            "title": "GB Ingest 30 Day Sum (All Accounts)",
+            "rawConfiguration": {
+              "dataFormatters": [],
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "SELECT sum(GigabytesIngested) AS avgGbIngest FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'InfraIntegrationBytes' since 30 days ago limit max compare with 1 month ago"
+                }
+              ],
+              "thresholds": []
+            },
+            "linkedEntityGuids": null
+          },
+          {
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "layout": {
+              "column": 3,
+              "row": 4,
+              "height": 7,
+              "width": 4
             },
             "title": "GB Ingest (By Account)",
             "rawConfiguration": {
@@ -1360,7 +1570,7 @@
             },
             "title": "",
             "rawConfiguration": {
-              "text": "# TIP\n\nFor a much deeper view into the sources of ingest that contribute to `InfraIntegrationBytes` Install the *Infrastructure Integration Analysis* [dashboard](https://github.com/newrelic/newrelic-quickstarts/tree/main/quickstarts/audit/infrastructure-integrations-data-analysis) form New Relic I/O."
+              "text": "# TIP\n\n# For a much deeper view into the sources of ingest that contribute to `InfraIntegrationBytes` Install the *Infrastructure Integration Analysis* [dashboard](https://github.com/newrelic/newrelic-quickstarts/tree/main/quickstarts/audit/infrastructure-integrations-data-analysis) form New Relic I/O."
             },
             "linkedEntityGuids": null
           }
@@ -1462,7 +1672,30 @@
               "column": 1,
               "row": 4,
               "height": 7,
-              "width": 6
+              "width": 2
+            },
+            "title": "GB Ingest 30 Day Sum(All Accounts)",
+            "rawConfiguration": {
+              "dataFormatters": [],
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "SELECT sum(GigabytesIngested) AS avgGbIngest FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'ServerlessBytes' since 30 days ago limit max compare with 1 month ago"
+                }
+              ],
+              "thresholds": []
+            },
+            "linkedEntityGuids": null
+          },
+          {
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "layout": {
+              "column": 3,
+              "row": 4,
+              "height": 7,
+              "width": 4
             },
             "title": "GB Ingest (By Account)",
             "rawConfiguration": {
@@ -1600,7 +1833,30 @@
               "column": 1,
               "row": 4,
               "height": 7,
-              "width": 6
+              "width": 2
+            },
+            "title": "GB Ingest 30 Day Sum (All Accounts)",
+            "rawConfiguration": {
+              "dataFormatters": [],
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "SELECT sum(GigabytesIngested) AS avgGbIngest FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'CustomEventsBytes' since 30 days ago limit max compare with 1 month ago"
+                }
+              ],
+              "thresholds": []
+            },
+            "linkedEntityGuids": null
+          },
+          {
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "layout": {
+              "column": 3,
+              "row": 4,
+              "height": 7,
+              "width": 4
             },
             "title": "GB Ingest (By Account)",
             "rawConfiguration": {
@@ -1738,7 +1994,30 @@
               "column": 1,
               "row": 4,
               "height": 7,
-              "width": 6
+              "width": 2
+            },
+            "title": "GB Ingest 30 Day Sum (All Accounts)",
+            "rawConfiguration": {
+              "dataFormatters": [],
+              "nrqlQueries": [
+                {
+                  "accountId": 0,
+                  "query": "SELECT sum(GigabytesIngested) AS avgGbIngest FROM NrConsumption WHERE productLine='DataPlatform' and usageMetric = 'PixieBytes' since 30 days ago limit max compare with 1 month ago"
+                }
+              ],
+              "thresholds": []
+            },
+            "linkedEntityGuids": null
+          },
+          {
+            "visualization": {
+              "id": "viz.billboard"
+            },
+            "layout": {
+              "column": 3,
+              "row": 4,
+              "height": 7,
+              "width": 4
             },
             "title": "GB Ingest (By Account)",
             "rawConfiguration": {


### PR DESCRIPTION
# Summary

Added a 30 day sum chart to the baseline governance dashboard (overview page and all telemetry type breakout pages).
On the overview page the 30 day sum is billboard showing a single number represented the sum of all ingest (in GB) for all accounts and telemetry types.

On the breakout pages the chart is a billboard showing a single number for the 30 day gb ingest sum for a single telemetry type (for all accounts).

- [✅ ] Did you check you NRQL syntax? - Does it work?
- [ ✅] Did you check your dashboard image quality? -  Do they look good?
- [NA ] Did you check that your alerts actually work?
- [ NA] Did you include an InstallPlan and Documentation reference?
- [ ✅] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ✅] Did you attach images of your dashboards to the PR so we can see them working?

### Screenshots

Attach images of any visual changes, such as a dashboard here.
