### PR TITLE
fix: sets community levels updates contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,7 +241,27 @@ documentation:
 - All quickstarts will be set to `Community` level by default unless specified differently by the `Author`.
 - Levels can only be modified by New Relic employees.
 - If you have questions on how to increase the level of support please file an [issue](../../issues)
-- The shield icon is only applied to those quickstarts with `Support Level` New Relic OR `Support Level` Verified.
+- The shield icon is only applied to those quickstarts with support level `New Relic` OR support Level `Verified`.
+- In most cases a quickstart that is referencing an [experimental open source project](https://github.com/newrelic-experimental) should be set to the `Community` level.
+- If you are referencing an experimental project and want to set the quickstart to `Verified` please be aware of the support requirements below.
+
+**New Relic**
+
+- Verified for quality by New Relic
+- Created by New Relics employees
+- Supported by New Relic
+
+**Verified**
+
+- Verified for quality by New Relic
+- Created by New Relics employees or partners
+- Supported by individual authors or partners
+
+**Community**
+
+- Contributed & supported by the community
+- Created by community members
+- Supported by individual authors and community members
 
 
 #### Dashboard JSON

--- a/install/on-host-integration/ibm-mq/install.yml
+++ b/install/on-host-integration/ibm-mq/install.yml
@@ -4,6 +4,8 @@ title: New Relic integration for IBM MQ
 description: |
   The New Relic IBM MQ monitor allows you to monitor the performance of MQ Objects like channels and queues.
 
+level: Community
+
 target:
   type: agent
   destination: host

--- a/install/third-party/databricks/install.yml
+++ b/install/third-party/databricks/install.yml
@@ -9,6 +9,8 @@ target:
   type: integration
   destination: cloud
 
+level: Community
+
 install:
   mode: link
   destination:

--- a/install/third-party/trendmicro-cloudone-conformity/install.yml
+++ b/install/third-party/trendmicro-cloudone-conformity/install.yml
@@ -10,6 +10,8 @@ target:
   type: integration
   destination: cloud
 
+level: Community
+
 install:
   mode: link
   destination:

--- a/quickstarts/grafana/grafana-dashboard-migration/config.yml
+++ b/quickstarts/grafana/grafana-dashboard-migration/config.yml
@@ -18,7 +18,7 @@ summary: |
   Convert Grafana Prometheus dashboards to New Relic dashboards.
 
 # Support level: New Relic | Verified | Community (required)
-level: New Relic
+level: Verified
 
 # Authors of the quickstart (required)
 authors:

--- a/quickstarts/mlops/bring-your-own/config.yml
+++ b/quickstarts/mlops/bring-your-own/config.yml
@@ -11,7 +11,7 @@ description: |
 summary: |
   Bring your own data from any kind of ML stack with this flexible integration framework to keep your data-science projects on track.
 # Support level: New Relic | Verified | Community (required)
-level: New Relic
+level: Community
 
 # Authors of the quickstart (required)
 authors:

--- a/quickstarts/netlify/config.yml
+++ b/quickstarts/netlify/config.yml
@@ -30,7 +30,7 @@ summary: |
   Analyze the health of your Netlify builds and Jamstack applications
 
 # Support level: New Relic | Verified | Community (required)
-level: New Relic
+level: Community
 
 # Authors of the quickstart (required)
 authors:


### PR DESCRIPTION
This PR sets the correct support levels on quick starts referencing experimental projects. 
It also updates he contributor guide to more explicitly explain the levels. 