### PR TITLE
chore: update branch protection steps with required checks

### DIFF
--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -82,7 +82,15 @@ jobs:
               branch: 'main',
               required_status_checks: {
                 strict: true,
-                contexts: []
+                contexts: [
+                    'Validation / Image count and extension compliance',
+                    'Validation / Quickstart schema compliance',
+                    'Validation / Conventional commit compliance',
+                    'Validation / Ensure logos exist',
+                    'Validation / Install plan ids exist',
+                    'Validation / Install plan schema compliance',
+                    'Validation / Quickstart id & name are unique'
+                ]
               },
               restrictions: {
                 "users":[],

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,15 @@ jobs:
               branch: 'main',
               required_status_checks: {
                 strict: true,
-                contexts: []
+                contexts: [
+                    'Validation / Image count and extension compliance',
+                    'Validation / Quickstart schema compliance',
+                    'Validation / Conventional commit compliance',
+                    'Validation / Ensure logos exist',
+                    'Validation / Install plan ids exist',
+                    'Validation / Install plan schema compliance',
+                    'Validation / Quickstart id & name are unique'
+                ]
               },
               restrictions: {
                 "users":[],
@@ -165,7 +173,15 @@ jobs:
               branch: 'main',
               required_status_checks: {
                 strict: true,
-                contexts: []
+                contexts: [
+                    'Validation / Image count and extension compliance',
+                    'Validation / Quickstart schema compliance',
+                    'Validation / Conventional commit compliance',
+                    'Validation / Ensure logos exist',
+                    'Validation / Install plan ids exist',
+                    'Validation / Install plan schema compliance',
+                    'Validation / Quickstart id & name are unique'
+                ]
               },
               restrictions: {
                 "users":[],


### PR DESCRIPTION
# Summary

To enforce the validations passing, we are adding them as required steps for merging into main. Previously, there were none. Adding them manually to the repo also doesn't work since code in the workflows resets them, so we updated the workflow code.

