### PR TITLE
update commit, push steps to reduce errors

### DIFF
--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -36,15 +36,6 @@ jobs:
         id: generate-uuids
         run: cd utils && yarn generate-uuids
 
-      - name: Commit changes
-        id: commit-changes
-        run: |
-          git config --local user.email "${{ env.THIRD_PARTY_GIT_AUTHOR_EMAIL }}"
-          git config --local user.name "${{ env.THIRD_PARTY_GIT_AUTHOR_NAME }}"
-          git add ./quickstarts/*
-          git diff-index --quiet HEAD ./quickstarts/* || git commit -m 'chore: generate UUID(s) [skip ci]'
-          echo "::set-output name=commit::true"
-
       - name: Temporarily disable branch protections
         id: disable-branch-protection
         if: always()
@@ -63,6 +54,18 @@ jobs:
               required_pull_request_reviews: null
             })
             console.log("Result:", result)
+
+      - name: Commit changes
+        id: commit-changes
+        run: |
+          git config --local user.email "${{ env.THIRD_PARTY_GIT_AUTHOR_EMAIL }}"
+          git config --local user.name "${{ env.THIRD_PARTY_GIT_AUTHOR_NAME }}"
+          
+          # main could have been modified since we checked out, so pull before committing
+          git pull --ff-only origin main
+
+          git add ./quickstarts/*
+          git diff-index --quiet HEAD ./quickstarts/* || { git commit -m 'chore: generate UUID(s) [skip ci]' && echo "::set-output name=commit::true"; }
 
       - name: Push Commit
         if: steps.commit-changes.outputs.commit == 'true'


### PR DESCRIPTION
## Summary

The changes made were:
* first change was moving the commit step closer to the push step in
the overall workflow. Now, branch protection happens first, then commit,
then push. This should reduce the time between commit and push.
* second change was adding a pull command before changes are committed.
This should tighten the window of this step failing due a change
to main in main not being pulled, before we try to push local changes.
* the last change is grouping the echo command in the commit step with
the commit command. Now, echo setting the output should only happen when
we have changes to commit. If we dont have any changes, echo shouldnt
occur, and the push step should not run.

## Links
Relates to: #862 