### PR TITLE
Send support level when submitting a quickstart

### DIFF
--- a/utils/__tests__/validate_pr_quickstarts.test.js
+++ b/utils/__tests__/validate_pr_quickstarts.test.js
@@ -127,6 +127,7 @@ const expectedMockQuickstart2MutationInput = {
     sourceUrl:
       'https://github.com/newrelic/newrelic-quickstarts/tree/main/utils/mock_files/mock-quickstart-2',
     summary: 'A short form description for this quickstart',
+    supportLevel: 'COMMUNITY',
     installPlanStepIds: ['infra-agent-targeted'],
     alertConditions: [
       {

--- a/utils/create_validate_pr_quickstarts.js
+++ b/utils/create_validate_pr_quickstarts.js
@@ -46,6 +46,12 @@ mutation QuickstartRepoQuickstartMutation (
  */
 const MOCK_UUID = '00000000-0000-0000-0000-000000000000';
 
+const SUPPORT_LEVEL_ENUMS = {
+  'New Relic': 'NEW_RELIC',
+  Community: 'COMMUNITY',
+  Verified: 'VERIFIED',
+};
+
 /**
  * Gets the unique base quickstart directory from a given file path.
  * e.g. filePath: 'quickstarts/python/aiohttp/alerts/ApdexScore.yml' + targetChild: 'alerts' = 'python/aiohttp'.
@@ -136,6 +142,7 @@ const buildMutationVariables = (quickstartConfig) => {
     summary,
     installPlans,
     id,
+    level,
   } = quickstartConfig.contents[0] || {};
   const alertConfigPaths = getQuickstartAlertsConfigs(quickstartConfig.path);
   const dashboardConfigPaths = getQuickstartDashboardConfigs(
@@ -168,6 +175,7 @@ const buildMutationVariables = (quickstartConfig) => {
         quickstartConfig.path
       )}`,
       summary: summary && summary.trim(),
+      supportLevel: SUPPORT_LEVEL_ENUMS[level],
       installPlanStepIds: installPlans,
       dashboards:
         dashboardConfigPaths.length > 0


### PR DESCRIPTION
# Summary

We realized that the support level behind the scenes was always set to `Community` regardless of how it was configured in the quickstart. Because we rely on this value to determine the "verified" icon, we added support for a `supportLevel` argument when submitting a quickstart. This PR adds support for sending the configured support level.