### PR TITLE
move deps out of dev

### DIFF
--- a/utils/package.json
+++ b/utils/package.json
@@ -19,7 +19,7 @@
     "sanitize-dashboard": "node sanitize_dashboards.js",
     "generate-schema-docs": "node graphql-schemas/generate-schema-docs.js"
   },
-  "devDependencies": {
+  "dependencies": {
     "@actions/core": "^1.4.0",
     "ajv": "^8.4.0",
     "cockatiel": "^3.0.0-beta.0",
@@ -34,6 +34,5 @@
     "parse-link-header": "^1.0.1",
     "prettier": "2.3.2",
     "uuid": "^8.3.2"
-  },
-  "dependencies": {}
+  }
 }


### PR DESCRIPTION
# Summary
Moves all dependencies out of dev dependencies so they will still be installed when `NODE_ENV` is set to `production`