### PR TITLE
chore: removed entity ids from json

### DIFF
--- a/quickstarts/speedscale/dashboards/speedscale-reports.json
+++ b/quickstarts/speedscale/dashboards/speedscale-reports.json
@@ -1,105 +1,101 @@
 {
-    "name": "Speedscale Reports",
-    "description": null,
-    "pages": [
-      {
-        "name": "Speedscale Reports",
-        "description": null,
-        "widgets": [
-          {
-            "visualization": {
-              "id": "viz.markdown"
-            },
-            "layout": {
-              "column": 1,
-              "row": 1,
-              "height": 3,
-              "width": 4
-            },
-            "title": "",
-            "rawConfiguration": {
-              "text": "![Speedscale](https://speedscale.com/wp-content/uploads/2020/05/Landscape-1.svg)\n\nQuestions about this dashboard?\n\nEmail: support@speedscale.com"
-            },
-            "linkedEntityGuids": null
+  "name": "Speedscale Reports",
+  "description": null,
+  "pages": [
+    {
+      "name": "Speedscale Reports",
+      "description": null,
+      "widgets": [
+        {
+          "visualization": {
+            "id": "viz.markdown"
           },
-          {
-            "visualization": {
-              "id": "viz.bar"
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "height": 3,
+            "width": 4
+          },
+          "title": "",
+          "rawConfiguration": {
+            "text": "![Speedscale](https://speedscale.com/wp-content/uploads/2020/05/Landscape-1.svg)\n\nQuestions about this dashboard?\n\nEmail: support@speedscale.com"
+          },
+          "linkedEntityGuids": null
+        },
+        {
+          "visualization": {
+            "id": "viz.bar"
+          },
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Services",
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
             },
-            "layout": {
-              "column": 5,
-              "row": 1,
-              "height": 3,
-              "width": 4
-            },
-            "title": "Services",
-            "rawConfiguration": {
-              "facet": {
-                "showOtherSeries": false
-              },
-              "nrqlQueries": [
-                {
-                  "accountId": 0,
-                  "query": "SELECT count(*) FROM Speedscale WHERE name = 'testReport' SINCE 1 week ago FACET serviceName"
-                }
-              ]
-            },
-            "linkedEntityGuids": [
-              "MzI5MTg1NXxWSVp8REFTSEJPQVJEfDI5MTA4OTc"
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT count(*) FROM Speedscale WHERE name = 'testReport' SINCE 1 week ago FACET serviceName"
+              }
             ]
           },
-          {
-            "visualization": {
-              "id": "viz.bar"
+          "linkedEntityGuids": null
+        },
+        {
+          "visualization": {
+            "id": "viz.bar"
+          },
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Snapshots",
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
             },
-            "layout": {
-              "column": 9,
-              "row": 1,
-              "height": 3,
-              "width": 4
-            },
-            "title": "Snapshots",
-            "rawConfiguration": {
-              "facet": {
-                "showOtherSeries": false
-              },
-              "nrqlQueries": [
-                {
-                  "accountId": 0,
-                  "query": "SELECT count(*) FROM Speedscale WHERE name = 'testReport' SINCE 1 week ago FACET snapshotName"
-                }
-              ]
-            },
-            "linkedEntityGuids": [
-              "MzI5MTg1NXxWSVp8REFTSEJPQVJEfDI5MTA4OTc"
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT count(*) FROM Speedscale WHERE name = 'testReport' SINCE 1 week ago FACET snapshotName"
+              }
             ]
           },
-          {
-            "visualization": {
-              "id": "viz.table"
+          "linkedEntityGuids": null
+        },
+        {
+          "visualization": {
+            "id": "viz.table"
+          },
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "height": 5,
+            "width": 12
+          },
+          "title": "Report List",
+          "rawConfiguration": {
+            "dataFormatters": [],
+            "facet": {
+              "showOtherSeries": false
             },
-            "layout": {
-              "column": 1,
-              "row": 4,
-              "height": 5,
-              "width": 12
-            },
-            "title": "Report List",
-            "rawConfiguration": {
-              "dataFormatters": [],
-              "facet": {
-                "showOtherSeries": false
-              },
-              "nrqlQueries": [
-                {
-                  "accountId": 0,
-                  "query": "SELECT timestamp, snapshotName, serviceName, config, buildTag, successRate, status, testId, link FROM Speedscale SINCE 1 week ago WHERE name = 'testReport'"
-                }
-              ]
-            },
-            "linkedEntityGuids": null
-          }
-        ]
-      }
-    ]
-  }
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT timestamp, snapshotName, serviceName, config, buildTag, successRate, status, testId, link FROM Speedscale SINCE 1 week ago WHERE name = 'testReport'"
+              }
+            ]
+          },
+          "linkedEntityGuids": null
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR removed entity IDs, from the dashboard json as it was blocking this PR https://github.com/newrelic/newrelic-quickstarts/runs/5415786835?check_suite_focus=true

It also lints the JSON