### PR TITLE
fix: newline change to trigger publish

### DIFF
--- a/quickstarts/ruby/rails/config.yml
+++ b/quickstarts/ruby/rails/config.yml
@@ -34,3 +34,5 @@ keywords:
   - ruby
 installPlans:
   - setup-ruby-agent
+
+


### PR DESCRIPTION
# Summary

The Rails quickstart is missing some screenshots on the catalogs. This is a quick PR to trigger the publishing workflows to get those screenshots into the database.