### PR TITLE
Misc quickstart fixes

### DIFF
--- a/quickstarts/catchpoint/config.yml
+++ b/quickstarts/catchpoint/config.yml
@@ -1,11 +1,8 @@
 id: ac2341e3-05bb-49c5-b445-b16b27fc6ea0
-# Name of the quickstart
 name: catchpoint-quickstart
+title: Catchpoint
 
-# Displayed in the UI
-title: Catchpoint quickstart
 
-# Long-form description of the quickstart
 description: |
   This quickstart uses the Catchpoint Test Data Webhook to send data to the New Relic Platform, this is accomplished by using New Relic’s Metrics API. We will rely on a third-party Google Cloud function to accept the data from the Catchpoint API, process it in the desired format, and then push it to New Relic. This approach allows you to visualize Catchpoint's digital experience data with New Relic’s Application Performance Monitoring (APM) data together.
 
@@ -14,7 +11,7 @@ description: |
   - Catchpoint Overview dashboard: Overview of errors and request components of tests
   - Catchpoint Recent Errors dashboard: Recent errors with test id, timestamp, node name and error code
   - Catchpoint Response size: Monitor the average response size in MB
-  - Catchpoint Test Times: Test time of with respect to test ids.
+  - Catchpoint Test Times: Test time of with respect to test ids
 
 # Displayed in search results and recommendations. Summarizes a quickstarts functionality.
 summary: |
@@ -38,7 +35,7 @@ keywords:
 
 
 documentation:
-  - name: Installation Docs
+  - name: Catchpoint installation docs
     url: https://www.catchpoint.com/blog/webhook-implementation
     description: Learn more about the Catchpoint Test Data Webhook.
   - name: Catchpoint Github repository

--- a/quickstarts/gigamon/config.yml
+++ b/quickstarts/gigamon/config.yml
@@ -1,23 +1,18 @@
 id: d6b36ecf-bf99-475c-938f-370153db8e70
-# Name of the quickstart (required)
 name: gigamon-newrelic
+title: Gigamon
 
-# Displayed in the UI (required)
-title: Gigamon Quickstart
-
-# Long-form description of the quickstart (required)
 description: |
   Gigamon helps the world’s leading organizations run fast, stay secure and innovate. We provide the industry’s first elastic visibility and analytics fabric, which closes the cloud visibility gap by enabling cloud tools to see the network and network tools to see the cloud. With visibility across their entire hybrid cloud network, organizations can improve customer experience, eliminate security blind spots, and reduce cost and complexity. Gigamon has been awarded over 90 technology patents and enjoys world-class customer satisfaction with more than 4,000 organizations, including over 80 percent of the Fortune 100 and hundreds of government and educational organizations worldwide.
- 
-  To try this integration in your environment please reach out to tme@gigamon.com. If you are not aware of Gigamon Cloud Suite please reach out to sales@gigamon.com. 
 
-# Displayed in search results and recommendations. Summarizes a quickstarts functionality.
+  To try this integration in your environment please reach out to tme@gigamon.com. If you are not aware of Gigamon Cloud Suite please reach out to sales@gigamon.com.
+
 summary: |
 
   Gigamon Cloud Suite enables collection of network traffic from every instance in the cloud collecting metadata of over 5,000 network traffic-related attributes for a holistic overview of and a much deeper level of security-related inspection.
 
 # Support level: New Relic | Verified | Community (required)
-level: Verified 
+level: Verified
 
 # Authors of the quickstart (required)
 authors:
@@ -31,22 +26,15 @@ keywords:
   - featured
   - newrelic partner
 
-
-# Reference to install plans located under /install directory
-# Allows us to construct reusable "install plans" and just use their ID in the quickstart config
 installPlans:
   - third-party-gigamon
 
 documentation:
-  - name: Gigamon Cloud Suite Installation
-    url: >- 
+  - name: Gigamon integration guide
+    url: >-
        https://www.gigamon.com/content/dam/resource-library/english/deployment-guide/gigamon-new-relic-integration-quick-start-guide.pdf
-    description: | 
+    description: |
         An overview of the architecture and deployment methodology for Gigamon Hawk integrated with New Relic
 
-#    url: https://www.gigamon.com/lp/free-trial/request-live-cloud-demo.html
-#    description: The link refers to setting up demo for Cloud Suite Solution required to deploy the NewRelic Integration.
-
-# Content / Design
 logo: logo.png
 website: https://www.gigamon.com

--- a/quickstarts/glassbox/config.yml
+++ b/quickstarts/glassbox/config.yml
@@ -1,19 +1,23 @@
 id: bdb952f3-28db-4ee7-89c6-b00244b0bb73
 name: glassbox
-title: Glassbox quickstart
+title: Glassbox
+
 description: |
   Glassbox empowers organizations to create frictionless digital journeys for their customers. Our digital experience analytics and Session Replay platform works in real time across mobile apps and websites to accelerate loyalty and growth. Through AI-driven visualization and analytics tools, Glassbox helps teams to prioritize customer experience and digital product enhancements from a single collaborative system.
 
   The Glassbox quickstart helps you understand the impact of application performance on your customers’ digital experience. Gain deeper contextual insights by combining the data capture and session replay capabilities of Glassbox with New Relic One. Get a view of behavioral insights and KPIs inside a pre-built New Relic dashboard, which links directly to a session replay in Glassbox, so you can find the root cause of the digital issue and fix performance issues faster.
 
   For more information or support, please go to [glassbox.com](https://www.glassbox.com/)
+
 summary: |
-  The Glassbox quickstart helps you understand the impact of 
-  application performance on your customers’ digital experience.
+  The Glassbox quickstart helps you understand the impact of application performance on your customers’ digital experience.
+
 level: Community
+logo: logo.png
 authors:
   - Joseph Counts (New Relic)
   - Glassbox
+
 keywords:
   - glassbox
   - newrelic partner
@@ -23,7 +27,7 @@ keywords:
 installPlans:
   - third-party-glassbox
 documentation:
-  - name: Integraton Guide
+  - name: Glasbox integraton guide
     url: https://support.glassbox.com/hc/en-gb/articles/4405777280401-How-to-Connect-New-Relic
-    description: Integrate your Glassbox data with New Relic
-logo: logo.png
+    description: Integrate your Glassbox data with New Relic.
+

--- a/quickstarts/golang/pkg-errors/config.yml
+++ b/quickstarts/golang/pkg-errors/config.yml
@@ -1,11 +1,16 @@
 id: 1599c1e3-cd4d-4edf-bd44-32a7602fbcfd
 name: pkg-errors
 title: pkg/errors
-summary: Monitor pkg/errors with New Relic's Golang agent
+
+# pkg/errors should be lowercase.
+
+summary: |
+   This quickstart automatically instruments pkg/errors with the New Relic Go agent and allows you to instantly monitor your Go application with out-of-the-box dashboards and alerts.
+
 description: |
   ## What is pkg/errors?
 
-  Wrap pkg/errors errors to improve stack traces and error class information
+  [Package errors](https://github.com/pkg/errors) provides simple error handling primitives.
 
   ## Get started!
 
@@ -13,16 +18,21 @@ description: |
 
   ## More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/agents/go-agent/) to learn more about New Relic monitoring for pkg/errors. 
+  Check out the [documentation](https://docs.newrelic.com/docs/agents/go-agent/) to learn more about New Relic monitoring for pkg/errors.
+
 logo: logo.png
 level: Community
 authors:
   - New Relic
+
 keywords:
   - golang
   - errors
+  - pkg/errors
+
 installPlans:
   - setup-go-agent
+
 documentation:
   - name: Go agent compatibility and requirements
     url: >-

--- a/quickstarts/golang/pkg-errors/config.yml
+++ b/quickstarts/golang/pkg-errors/config.yml
@@ -34,7 +34,8 @@ installPlans:
   - setup-go-agent
 
 documentation:
-  - name: Go agent compatibility and requirements
+  - name: Installation docs
     url: >-
       https://docs.newrelic.com/docs/agents/go-agent/get-started/go-agent-compatibility-requirements/
+    description: Go agent compatibility and requirements
 

--- a/quickstarts/jumpstart/config.yml
+++ b/quickstarts/jumpstart/config.yml
@@ -1,17 +1,14 @@
 id: fbca935b-5a3e-41d7-b708-c24d90fcd820
-# Name of the quickstart (required)
 name: jumpstart-quickstart
-
-# Displayed in the UI (required)
-title: Jumpstart quickstart
+title: Jumpstart quickstart tool
 
 # Long-form description of the quickstart (required)
 description: |
-  The Jumpstart quickstart is a tool that has everything you need to help you get started building your own quickstart. It has some basic steps to follow to get started, some sample dashboards and queries, as well as a list of resources to help you build your own quickstart faster !
+  The Jumpstart quickstart is a tool that has everything you need to help you get started building your own quickstart. It has some basic steps to follow to get started, some sample dashboards and queries, as well as a list of resources to help you build your own quickstart faster!
 
 # Displayed in search results and recommendations. Summarizes a quickstarts functionality.
 summary: |
-  A Quickstart to help you get started building your own quickstart!
+  A sample quickstart to help you get started building your own quickstart for New Relic I/O.
 
 # Support level: New Relic | Verified | Community (required)
 level: Community
@@ -26,17 +23,14 @@ keywords:
   - quickstart
   - intro
 
-# Reference to install plans located under /install directory
-# Allows us to construct reusable "install plans" and just use their ID in the quickstart config
 installPlans:
   - third-party-jumpstart
 
 documentation:
-  - name: Guides to quickstarts
+  - name: Guide to build a quickstart
     url: >-
       https://developer.newrelic.com/contribute-to-quickstarts/build-a-quickstart/
-    description: Description about this doc reference
-
+    description:  Detailed instructions how to contribute a quickstart to New Relic I/O.
 # Content / Design
 logo: logo.png
 website: https://www.newrelic.com

--- a/quickstarts/oma-aqm/config.yml
+++ b/quickstarts/oma-aqm/config.yml
@@ -1,14 +1,11 @@
 id: ccdf1cf7-29f0-42ca-ae0d-239dfb073fd0
-# Name of the quickstart (required)
 name: alert-quality-management
-
-# Displayed in the UI (required)
-title: Alert Quality Management Quickstart
+title: Alert Quality Management
 
 # Long-form description of the quickstart (required)
 description: |
   Alert Quality Management (AQM) focuses on reducing the number of nuisance incidents so that you focus only on alerts with true business impact. This reduces alert fatigue and ensures that you and your team focus your attention on the right places at the right times.
-  
+
   For more information view the [implementation guide](https://docs.newrelic.com/docs/new-relic-solutions/observability-maturity/uptime-performance-reliability/aqm-implementation-guide/).
 
 # Displayed in search results and recommendations. Summarizes a quickstarts functionality.
@@ -26,15 +23,15 @@ authors:
 # Keywords for filtering / searching criteria in the UI
 keywords:
   - oma
-  - observabilty maturity
+  - observability maturity
   - AQM
   - alert quality management
 
 documentation:
-  - name: Installation Docs
-    url: >- 
+  - name: Implementation guide
+    url: >-
       https://docs.newrelic.com/docs/new-relic-solutions/observability-maturity/uptime-performance-reliability/aqm-implementation-guide/
-    description:  | 
+    description:  |
         The implementation guide will show you how to implement the AQM process, including the webhook required to generate the data that feeds this dashboard.
 
 # Content / Design

--- a/quickstarts/python/aiohttp/config.yml
+++ b/quickstarts/python/aiohttp/config.yml
@@ -1,30 +1,32 @@
 id: e7948525-8726-46a5-83fa-04732ad42fd1
 name: aiohttp
+title: AIOHTTP
 description: |
   ## AIO HTTP complete monitoring quickstart
-  Instantly monitor Python applications with AIO HTTPS quickstart. Our [Python](https://docs.newrelic.com/docs/agents/python-agent/) integration lets you quickly identify and resolve potential performance issues with your AIO HTTP server and enhance user experiences.
-  
+
+  Instantly monitor Python applications with AIO HTTP quickstart. Our [Python](https://docs.newrelic.com/docs/agents/python-agent/) integration lets you quickly identify and resolve potential performance issues with your AIO HTTP server and enhance user experiences.
+
   ### Monitoring AIO HTTP
-  
+
   Python application developers can extend AIO HTTP performance monitoring to collect, clean, and analyze data to make better data-driven business decisions. Monitoring is vital to ensure uptime and data reliability by keeping an eye on the AIO HTTP server and AIO HTTP client.
 
-  New Relic's AIO HTTP quickstart provides dashboards and built-in instrumentation to track AIO HTTP requests, CPU utilization, garbage collection CPU time, memory heap used, most popular transactions, throughput reports, top 5 slowest transactions, and more. 
+  New Relic's AIO HTTP quickstart provides dashboards and built-in instrumentation to track AIO HTTP requests, CPU utilization, garbage collection CPU time, memory heap used, most popular transactions, throughput reports, top 5 slowest transactions, and more.
 
   Count on real-time alerts to apdex scores, CPU utilization, and transaction errors. Expand the Python agent's default monitoring and behavior through the agent API or agent config file and target additional activity and functional calls.
-  
-  ### New Relic - The complte AIO HTTP dashboard tool
-  
+  ``
+  ### New Relic - The complete AIO HTTP dashboard tool
+
   The AIO HTTP dashboard tool ensures total visibility into critical metrics, leveraging dashboards and synthetic checks. With APIs and flexible custom instrumentation options, developers can use multiple building blocks to improve performance and adapt data for your app.
-  
+
   #### What's included?
-  
+
   - Dashboards - CPU Utilization, memory heap used, garbage collection CPU time, top 5 slowest transactions, throughput reports, most popular transactions, and more.
   - Alerts - apdex score, cpu utilization, transaction error.
 
-  Know what's happening in real-time by tracking CPU utilization, throughput reports, and popular transactions with full-stack observability of your entire infrastructure. 
+  Know what's happening in real-time by tracking CPU utilization, throughput reports, and popular transactions with full-stack observability of your entire infrastructure.
 
-  With the AIO HTTP complete monitoring quickstart, you can remediate errors before they impact user experience. 
-  
+  With the AIO HTTP complete monitoring quickstart, you can remediate errors before they impact user experience.
+
 summary: New Relic's AIO HTTP complete monitoring quickstart offers dashboards, alerts, and custom instrumentation to track the health and performance of your Python application before it impacts user experience.
 
 
@@ -32,7 +34,7 @@ logo: logo.svg
 level: New Relic
 authors:
   - New Relic
-title: AIOHTTP
+
 documentation:
   - name: AIOHTTP installation docs
     description: |
@@ -40,9 +42,12 @@ documentation:
       management.
     url: >-
       https://docs.newrelic.com/docs/agents/python-agent/getting-started/compatibility-requirements-python-agent
+
 keywords:
   - python
   - apm
   - http
+  - aiohttp
+
 installPlans:
   - setup-python-agent

--- a/quickstarts/python/aiohttp/config.yml
+++ b/quickstarts/python/aiohttp/config.yml
@@ -13,7 +13,7 @@ description: |
   New Relic's AIO HTTP quickstart provides dashboards and built-in instrumentation to track AIO HTTP requests, CPU utilization, garbage collection CPU time, memory heap used, most popular transactions, throughput reports, top 5 slowest transactions, and more.
 
   Count on real-time alerts to apdex scores, CPU utilization, and transaction errors. Expand the Python agent's default monitoring and behavior through the agent API or agent config file and target additional activity and functional calls.
-  ``
+
   ### New Relic - The complete AIO HTTP dashboard tool
 
   The AIO HTTP dashboard tool ensures total visibility into critical metrics, leveraging dashboards and synthetic checks. With APIs and flexible custom instrumentation options, developers can use multiple building blocks to improve performance and adapt data for your app.

--- a/quickstarts/python/bottle/config.yml
+++ b/quickstarts/python/bottle/config.yml
@@ -1,35 +1,40 @@
 id: 38dc3bf5-e96c-43b8-98f4-80e444cdb657
-name: bottle
+name: Bottle
+title: Bottle
 description: |
-  ## What is bottle?
+  ## What is Bottle?
 
-  WSGI micro web-framework for Python. Single file module with no dependencies
+  Bottle is a WSGI micro web-framework for Python and is a single file module with no dependencies
   other than the Python Standard Library.
-
 
   ## Get started!
 
-  Leverage community expertise and instantly get value out of your telemetry data. This quickstart automatically instruments bottle with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts. Further leverage New Relic's APM capabilities by setting up [errors inbox](https://docs.newrelic.com/docs/apm/apm-ui-pages/errors-inbox/errors-inbox/), [transaction tracing](https://docs.newrelic.com/docs/apm/transactions/transaction-traces/introduction-transaction-traces/), and [service maps](https://docs.newrelic.com/docs/understand-dependencies/understand-system-dependencies/service-maps/introduction-service-maps/).
+  Leverage community expertise and instantly get value out of your telemetry data. This quickstart automatically instruments Bottle with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts. Further leverage New Relic's APM capabilities by setting up [errors inbox](https://docs.newrelic.com/docs/apm/apm-ui-pages/errors-inbox/errors-inbox/), [transaction tracing](https://docs.newrelic.com/docs/apm/transactions/transaction-traces/introduction-transaction-traces/), and [service maps](https://docs.newrelic.com/docs/understand-dependencies/understand-system-dependencies/service-maps/introduction-service-maps/).
 
   ## More info
 
   Check out the [documentation](https://docs.newrelic.com/docs/agents/python-agent/) to learn more about New Relic monitoring for bottle.
+
 summary: |
-  Monitor bottle with New Relic's Python agent
+  This quickstart automatically instruments Bottle with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts.
+
 logo: logo.svg
 level: New Relic
 authors:
   - New Relic
-title: bottle
+
 documentation:
-  - name: bottle installation docs
+  - name: Bottle installation docs
     description: |
       WSGI micro web-framework for Python. Single file module with no
       dependencies other than the Python Standard Library.
     url: >-
       https://docs.newrelic.com/docs/agents/python-agent/getting-started/instrumented-python-packages
+
 keywords:
   - apm
   - python
+  - bottle
+
 installPlans:
   - setup-python-agent

--- a/quickstarts/python/celery/config.yml
+++ b/quickstarts/python/celery/config.yml
@@ -1,19 +1,38 @@
 id: c0484a1b-d778-47f5-879b-2d01dce3df78
 name: celery
-description: "## What is celery?\n\nOpen source distributed task queue built for real-time operations.\n\n## Get started!\n\nLeverage community expertise and instantly get value out of your telemetry data. This quickstart automatically instruments celery with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts. Further leverage New Relic's APM capabilities by setting up [errors inbox](https://docs.newrelic.com/docs/apm/apm-ui-pages/errors-inbox/errors-inbox/), [transaction tracing](https://docs.newrelic.com/docs/apm/transactions/transaction-traces/introduction-transaction-traces/), and [service maps](https://docs.newrelic.com/docs/understand-dependencies/understand-system-dependencies/service-maps/introduction-service-maps/).\n\n## More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/agents/python-agent/) to learn more about New Relic monitoring for celery."
-summary: Monitor celery with New Relic's Python agent
+title: Celery
+
+description: |
+  ## What is celery?
+
+  Open source distributed task queue built for real-time operations.
+
+  ## Get started!
+
+  Leverage community expertise and instantly get value out of your telemetry data. This quickstart automatically instruments celery with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts. Further leverage New Relic's APM capabilities by setting up [errors inbox](https://docs.newrelic.com/docs/apm/apm-ui-pages/errors-inbox/errors-inbox/), [transaction tracing](https://docs.newrelic.com/docs/apm/transactions/transaction-traces/introduction-transaction-traces/), and [service maps](https://docs.newrelic.com/docs/understand-dependencies/understand-system-dependencies/service-maps/introduction-service-maps/).
+
+  ## More info
+
+  Check out the [documentation](https://docs.newrelic.com/docs/agents/python-agent/) to learn more about New Relic monitoring for celery.
+
+summary: |
+  This quickstart automatically instruments Celery with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts
+
 logo: logo.svg
 level: New Relic
 authors:
   - New Relic
-title: celery
+
 documentation:
-  - name: celery installation docs
+  - name: Celery installation docs
     description: Open source distributed task queue built for real-time operations.
     url: >-
       https://docs.newrelic.com/docs/agents/python-agent/getting-started/instrumented-python-packages
+
 keywords:
   - apm
   - python
+  - celery
+
 installPlans:
   - setup-python-agent

--- a/quickstarts/python/django/config.yml
+++ b/quickstarts/python/django/config.yml
@@ -1,34 +1,37 @@
 id: d8ab0fa9-205e-4c7d-92f1-09ef04b2b8e6
 name: django
+title: Django
 description: |
-  ## What is django?
+  ## What is Django?
 
   Django is a Python-based free, open-source web framework that follows the model-template-views architectural pattern. The framework enables the rapid development of secure and maintainable websites. It takes away the hassle of web development from developers, and empowers them to focus on writing apps without reinventing the wheel.
 
   ### New Relic Django quickstart features
-  
+
   The New Relic Django monitoring quickstart has the following features:
   - Dashboard: Our standard dashboard provides a clear overview of transactions and errors. The dashboards also help you track other key indicators like daily transaction errors, comparison between weekly transaction errors, memory heap used, most popular transactions, and more.
   - Alerts: You can get instant alerts on performance metrics like Apdex score, CPU utilization, and transaction error.
-  
+
   ### Why monitor Django with New Relic?
-  
-  Proactively monitor Django with [New Relic’s Python agent](https://docs.newrelic.com/docs/apm/agents/python-agent/getting-started/introduction-new-relic-python/). With an interactive dashboard, you can explore, query, and visualize your data. The quickstart also has three alerts that can detect changes in key metrics: 
-  - The transaction error alert is triggered when transactions fail more than 10% of the time during a 5-minute period. 
+
+  Proactively monitor Django with [New Relic’s Python agent](https://docs.newrelic.com/docs/apm/agents/python-agent/getting-started/introduction-new-relic-python/). With an interactive dashboard, you can explore, query, and visualize your data. The quickstart also has three alerts that can detect changes in key metrics:
+  - The transaction error alert is triggered when transactions fail more than 10% of the time during a 5-minute period.
   - The high CPU utilization alert is triggered when the CPU utilization is above 90%.
   - Similarly, the Apdex score alert is triggered when the Apdex score is below 0.5 during a period of 5 minutes.
-  
+
   In addition, the New Relic Django integration can automatically add [browser monitoring](https://newrelic.com/products/browser-monitoring) to any HTML page responses for the Django Python web framework. Install the New Relic Django quickstart to instrument Django with New Relic’s Python agent, and track Django’s key metrics in real-time.
 
 summary: |
   Monitoring Django is critical to ensure that you detect incidents and respond to them quickly. Download the New Relic Django quickstart to proactively track your Django’s performance metrics via New Relic’s Python agent.
+
 logo: logo.svg
 level: New Relic
 authors:
   - New Relic
-title: django
+
+
 documentation:
-  - name: django installation docs
+  - name: Django installation docs
     description: |
       Django is a Python-based free and open-source web framework that follows
       the model-template-views architectural pattern.
@@ -37,5 +40,6 @@ documentation:
 keywords:
   - apm
   - python
+  - django
 installPlans:
   - setup-python-agent

--- a/quickstarts/python/facepy/config.yml
+++ b/quickstarts/python/facepy/config.yml
@@ -1,19 +1,39 @@
 id: 846aaa7d-ecce-455f-88f8-4ed1661fb966
 name: facepy
-description: "## What is facepy?\n\nFramework for using Python to access and communicate with Facebook’s APIs.\n\n## Get started!\n\nLeverage community expertise and instantly get value out of your telemetry data. This quickstart automatically instruments facepy with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts. Further leverage New Relic's APM capabilities by setting up [errors inbox](https://docs.newrelic.com/docs/apm/apm-ui-pages/errors-inbox/errors-inbox/), [transaction tracing](https://docs.newrelic.com/docs/apm/transactions/transaction-traces/introduction-transaction-traces/), and [service maps](https://docs.newrelic.com/docs/understand-dependencies/understand-system-dependencies/service-maps/introduction-service-maps/).\n\n## More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/agents/python-agent/) to learn more about New Relic monitoring for facepy."
-summary: Monitor facepy with New Relic's Python agent
+title: Facepy
+
+description: |
+  ## What is Facepy?
+
+  Facepy is a framework for using Python to access and communicate with Facebook’s APIs.
+
+  ## Get started!
+
+  Leverage community expertise and instantly get value out of your telemetry data. This quickstart automatically instruments Facepy with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts. Further leverage New Relic's APM capabilities by setting up [errors inbox](https://docs.newrelic.com/docs/apm/apm-ui-pages/errors-inbox/errors-inbox/), [transaction tracing](https://docs.newrelic.com/docs/apm/transactions/transaction-traces/introduction-transaction-traces/), and [service maps](https://docs.newrelic.com/docs/understand-dependencies/understand-system-dependencies/service-maps/introduction-service-maps/).
+
+  ## More info
+
+  Check out the [documentation](https://docs.newrelic.com/docs/agents/python-agent/) to learn more about New Relic monitoring for Facepy.
+
+summary: |
+  This quickstart automatically instruments Facepy with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts.
+
 logo: logo.svg
 level: New Relic
 authors:
   - New Relic
-title: facepy
+
 documentation:
-  - name: facepy installation docs
-    description: Framework for using Python to access and communicate with Facebook’s APIs.
+  - name: Facepy installation docs
+    description: |
+      Framework for using Python to access and communicate with Facebook’s APIs.
     url: >-
       https://docs.newrelic.com/docs/agents/python-agent/getting-started/instrumented-python-packages
+
 keywords:
   - apm
   - python
+  - facepy
+
 installPlans:
   - setup-python-agent

--- a/quickstarts/python/fastapi/config.yml
+++ b/quickstarts/python/fastapi/config.yml
@@ -1,10 +1,11 @@
 id: e559ec64-f765-4470-a15f-1901fcebb468
 name: fastAPI
+title: FastAPI
+
 description: |
-  ## What is fastAPI?
+  ## What is FastAPI?
 
-  FastAPI is a modern and really fast web framework for developing RESTful APIs in Python. 
-
+  FastAPI is a modern and really fast web framework for developing RESTful APIs in Python.
 
   ## Get started!
 
@@ -12,16 +13,17 @@ description: |
 
   ## More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/agents/python-agent/) to learn more about New Relic monitoring for fastAPI.
+  Check out the [documentation](https://docs.newrelic.com/docs/agents/python-agent/) to learn more about New Relic monitoring for FastAPI.
 
 summary: |
-  Monitor fastAPI with New Relic's Python agent
+   This quickstart automatically instruments FastAPI with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts
+
 logo: logo.png
 level: New Relic
 authors:
   - New Relic
   - Emil Hammarstrand
-title: fastAPI
+
 documentation:
   - name: Python installation docs
     description: |

--- a/quickstarts/python/feedparser/config.yml
+++ b/quickstarts/python/feedparser/config.yml
@@ -1,5 +1,6 @@
 id: 006a5c26-9aa0-4249-b83f-118d7057f5da
 name: feedparser
+title: Feedparser
 description: |
   ## Why monitor Feedparser?
 
@@ -25,20 +26,24 @@ description: |
 
 summary: |
   Monitoring Feedparser is essential to detect incidents and respond to them quickly. Download the New Relic Feedparser quickstart to track Feedparser’s critical metrics and improve performance.
+
 logo: logo.svg
 level: New Relic
 authors:
   - New Relic
   - Emil Hammarstrand
-title: feedparser
+
 documentation:
-  - name: feedparser installation docs
+  - name: Feedparser installation docs
     description: |
       Python parser for a wide variety of Atom and RSS feeds.
     url: >-
       https://docs.newrelic.com/docs/agents/python-agent/getting-started/instrumented-python-packages
+
 keywords:
   - apm
   - python
+  - feedparser
+
 installPlans:
   - setup-python-agent

--- a/quickstarts/python/flask/config.yml
+++ b/quickstarts/python/flask/config.yml
@@ -1,14 +1,16 @@
 id: 2c13db46-a9ce-4595-854f-32e76dac6793
 name: flask
+title: Flask
 description: |
   ## Why monitor Flask?
 
   Flask is a Python web application micro-framework built with a focus on simplicity. It provides developers the freedom to build the structure of a web application. New Relic Flask Quickstart empowers you with dashboards and alerts to effectively monitor Flask’s performance metrics like transaction errors, CPU utilization, apdex score, and many more.
 
-  ### Flask quickstart highlights
+  ## Flask quickstart highlights
 
-  The New Relic Flask quickstart has the following features - 
-    Dashboards - Our dashboards proactively monitor metrics like 
+  The New Relic Flask quickstart has the following features:
+
+  ### Dashboards
     - CPU Utilization
     - memory heap used
     - garbage collection
@@ -16,39 +18,40 @@ description: |
     - top 5 slowest transactions
     - throughput reports
     - most popular transactions and more
-   Alerts - 
-    - apdex score, 
-    - cpu utilization, 
+
+  ### Alerts
+    - apdex score
+    - cpu utilization
     - transaction error
-   
+
   ### New Relic + Flask = Optimum performance monitoring
 
-  Newrelic Flask quickstart automatically instruments Flask with the [New Relic Python agent](https://docs.newrelic.com/docs/apm/agents/python-agent/getting-started/introduction-new-relic-python/), and instantly monitors your application with out-of-the-box dashboards and alerts. The dashboards provide interactive visualizations to explore your data, understand context, and resolve problems faster. The Python agent allows you to leverage all our platform to customize the data you need from your app.
+  The New Relic Flask quickstart automatically instruments Flask with the [New Relic Python agent](https://docs.newrelic.com/docs/apm/agents/python-agent/getting-started/introduction-new-relic-python/), and instantly monitors your application with out-of-the-box dashboards and alerts. The dashboards provide interactive visualizations to explore your data, understand context, and resolve problems faster. The Python agent allows you to leverage all our platform to customize the data you need from your app.
 
   The integration monitors Flask’s performance metrics like apdex (user satisfaction), CPU utilization and transaction errors. With the integration, you can track key transactions specific to your business, create custom dashboards, and get alerts for any error. You can also query business data to get more insights and use thread profiler sessions to see detailed stack traces of sampled threads.
 
   Install the New Relic Flask Quickstart now to monitor Flask’s endpoints and key performance indicators efficiently. It strengthens you to keep developing seamless web apps.
 
-
- 
 summary: |
   Monitoring Flask’s performance metrics is crucial to build web applications with no hassle. Install New Relic Flask Quickstart to access dashboards and alerts to proactively monitor your Flask application.
-  
+
 logo: logo.svg
 level: New Relic
 authors:
   - New Relic
   - Emil Hammarstrand
-title: flask
 documentation:
-  - name: flask installation docs
+  - name: Flask installation docs
     description: |
-      Popular python web application microframework built with a focus on
+      Popular python web application micro framework built with a focus on
       simplicity.
     url: >-
       https://docs.newrelic.com/docs/agents/python-agent/getting-started/instrumented-python-packages
+
 keywords:
   - apm
   - python
+  - flask
+
 installPlans:
   - setup-python-agent

--- a/quickstarts/python/gevent/config.yml
+++ b/quickstarts/python/gevent/config.yml
@@ -1,11 +1,14 @@
 id: 30e39b88-ad5f-4850-b4e6-d9960bceece6
 name: gevent
+title: gevent
+
+# gevent should be lowercase.
+
 description: |
   ## What is gevent?
 
-  Python networking library for coroutine operations through a libev or libuv
+  gevent is a Python networking library for coroutine operations through a libev or libuv
   API.
-
 
   ## Get started!
 
@@ -14,13 +17,15 @@ description: |
   ## More info
 
   Check out the [documentation](https://docs.newrelic.com/docs/agents/python-agent/) to learn more about New Relic monitoring for gevent.
+
 summary: |
-  Monitor gevent with New Relic's Python agent
+  This quickstart automatically instruments gevent with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts.
+
 logo: logo.svg
 level: New Relic
 authors:
   - New Relic
-title: gevent
+
 documentation:
   - name: gevent installation docs
     description: |
@@ -31,5 +36,7 @@ documentation:
 keywords:
   - apm
   - python
+  - gevent
+
 installPlans:
   - setup-python-agent

--- a/quickstarts/python/httplib2/config.yml
+++ b/quickstarts/python/httplib2/config.yml
@@ -1,11 +1,13 @@
 id: 6bab5c37-1444-4d47-a87a-80edbe316c46
 name: httplib2
+title: httplib2
+
+# httplib2 should be lowercase.
+
 description: |
   ## What is httplib2?
 
-  Lightweight HTTP client for Python with straightforward usage and full feature
-  support.
-
+  httplib2 is a lightweight HTTP client library for Python. httplib2 supports many features left out of other HTTP libraries.
 
   ## Get started!
 
@@ -14,22 +16,25 @@ description: |
   ## More info
 
   Check out the [documentation](https://docs.newrelic.com/docs/agents/python-agent/) to learn more about New Relic monitoring for httplib2.
+
 summary: |
-  Monitor httplib2 with New Relic's Python agent
+  This quickstart automatically instruments httplib2 with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts.
+
 logo: logo.svg
 level: New Relic
 authors:
   - New Relic
-title: httplib2
+
 documentation:
   - name: httplib2 installation docs
     description: |
-      Lightweight HTTP client for Python with straightforward usage and full
-      feature support.
+       httplib2 is a lightweight HTTP client library for Python. httplib2 supports many features left out of other HTTP libraries.
     url: >-
       https://docs.newrelic.com/docs/agents/python-agent/getting-started/instrumented-python-packages
 keywords:
   - apm
   - python
+  - httplib2
+
 installPlans:
   - setup-python-agent

--- a/quickstarts/python/mako/config.yml
+++ b/quickstarts/python/mako/config.yml
@@ -1,19 +1,38 @@
 id: 594f92b6-9996-4328-af75-129329a36a2c
 name: mako
-description: "## What is mako?\n\nMako is a template library written in Python.\n\n## Get started!\n\nLeverage community expertise and instantly get value out of your telemetry data. This quickstart automatically instruments mako with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts. Further leverage New Relic's APM capabilities by setting up [errors inbox](https://docs.newrelic.com/docs/apm/apm-ui-pages/errors-inbox/errors-inbox/), [transaction tracing](https://docs.newrelic.com/docs/apm/transactions/transaction-traces/introduction-transaction-traces/), and [service maps](https://docs.newrelic.com/docs/understand-dependencies/understand-system-dependencies/service-maps/introduction-service-maps/).\n\n## More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/agents/python-agent/) to learn more about New Relic monitoring for mako."
-summary: Monitor mako with New Relic's Python agent
+title: Mako
+
+description: |
+  ## What is Mako?
+
+  Mako is a template library written in Python.
+
+  ## Get started!
+
+  Leverage community expertise and instantly get value out of your telemetry data. This quickstart automatically instruments mako with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts. Further leverage New Relic's APM capabilities by setting up [errors inbox](https://docs.newrelic.com/docs/apm/apm-ui-pages/errors-inbox/errors-inbox/), [transaction tracing](https://docs.newrelic.com/docs/apm/transactions/transaction-traces/introduction-transaction-traces/), and [service maps](https://docs.newrelic.com/docs/understand-dependencies/understand-system-dependencies/service-maps/introduction-service-maps/).
+
+  ## More info
+
+  Check out the [documentation](https://docs.newrelic.com/docs/agents/python-agent/) to learn more about New Relic monitoring for Mako.
+
+summary: |
+  This quickstart automatically instruments mako with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts.
+
 logo: logo.svg
 level: New Relic
 authors:
   - New Relic
-title: mako
+
 documentation:
-  - name: mako installation docs
+  - name: Mako installation docs
     description: Mako is a template library written in Python.
     url: >-
       https://docs.newrelic.com/docs/agents/python-agent/getting-started/instrumented-python-packages
+
 keywords:
   - apm
   - python
+  - mako
+
 installPlans:
   - setup-python-agent

--- a/quickstarts/python/pylibmc/config.yml
+++ b/quickstarts/python/pylibmc/config.yml
@@ -1,19 +1,41 @@
 id: 50b770b5-03a3-4e0e-b981-c2df9ac18d53
 name: pylibmc
-description: "## What is pylibmc?\n\nPylibmc is a Python client for memcached written in C.\n\n## Get started!\n\nLeverage community expertise and instantly get value out of your telemetry data. This quickstart automatically instruments pylibmc with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts. Further leverage New Relic's APM capabilities by setting up [errors inbox](https://docs.newrelic.com/docs/apm/apm-ui-pages/errors-inbox/errors-inbox/), [transaction tracing](https://docs.newrelic.com/docs/apm/transactions/transaction-traces/introduction-transaction-traces/), and [service maps](https://docs.newrelic.com/docs/understand-dependencies/understand-system-dependencies/service-maps/introduction-service-maps/).\n\n## More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/agents/python-agent/) to learn more about New Relic monitoring for pylibmc."
-summary: Monitor pylibmc with New Relic's Python agent
+title: pylibmc
+
+# pylibmc should be lowercase.
+
+description: |
+  ## What is pylibmc?
+
+  Pylibmc is a Python client for memcached written in C.
+
+  ## Get started!
+
+  Leverage community expertise and instantly get value out of your telemetry data. This quickstart automatically instruments pylibmc with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts. Further leverage New Relic's APM capabilities by setting up [errors inbox](https://docs.newrelic.com/docs/apm/apm-ui-pages/errors-inbox/errors-inbox/), [transaction tracing](https://docs.newrelic.com/docs/apm/transactions/transaction-traces/introduction-transaction-traces/), and [service maps](https://docs.newrelic.com/docs/understand-dependencies/understand-system-dependencies/service-maps/introduction-service-maps/).
+
+  ## More info
+
+  Check out the [documentation](https://docs.newrelic.com/docs/agents/python-agent/) to learn more about New Relic monitoring for pylibmc.
+
+
+summary: |
+  This quickstart automatically instruments pylibmc with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts.
+
 logo: logo.svg
 level: New Relic
 authors:
   - New Relic
-title: pylibmc
+
 documentation:
   - name: pylibmc installation docs
-    description: Pylibmc is a Python client for memcached written in C.
+    description: pylibmc is a Python client for memcached written in C.
     url: >-
       https://docs.newrelic.com/docs/agents/python-agent/getting-started/instrumented-python-packages
+
 keywords:
   - apm
   - python
+  - pylibmc
+
 installPlans:
   - setup-python-agent

--- a/quickstarts/python/pylibmc/config.yml
+++ b/quickstarts/python/pylibmc/config.yml
@@ -7,7 +7,7 @@ title: pylibmc
 description: |
   ## What is pylibmc?
 
-  Pylibmc is a Python client for memcached written in C.
+  pylibmc is a Python client for memcached written in C.
 
   ## Get started!
 

--- a/quickstarts/python/pyramid/config.yml
+++ b/quickstarts/python/pyramid/config.yml
@@ -1,23 +1,23 @@
 id: 02f1dc20-9034-405b-90c1-8ad1bbf7755e
 name: pyramid
-title: pyramid
+title: Pyramid
 
 description: |
-  ## What is pyramid?
+  ## What is Pyramid?
 
   Pyramid is an open source and minimalistic web framework written in Python and
   is based on WSGI.
 
   ## Get started!
 
-  Leverage community expertise and instantly get value out of your telemetry data. This quickstart automatically instruments pyramid with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts. Further leverage New Relic's APM capabilities by setting up [errors inbox](https://docs.newrelic.com/docs/apm/apm-ui-pages/errors-inbox/errors-inbox/), [transaction tracing](https://docs.newrelic.com/docs/apm/transactions/transaction-traces/introduction-transaction-traces/), and [service maps](https://docs.newrelic.com/docs/understand-dependencies/understand-system-dependencies/service-maps/introduction-service-maps/).
+  Leverage community expertise and instantly get value out of your telemetry data. This quickstart automatically instruments Pyramid with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts. Further leverage New Relic's APM capabilities by setting up [errors inbox](https://docs.newrelic.com/docs/apm/apm-ui-pages/errors-inbox/errors-inbox/), [transaction tracing](https://docs.newrelic.com/docs/apm/transactions/transaction-traces/introduction-transaction-traces/), and [service maps](https://docs.newrelic.com/docs/understand-dependencies/understand-system-dependencies/service-maps/introduction-service-maps/).
 
   ## More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/agents/python-agent/) to learn more about New Relic monitoring for pyramid.
+  Check out the [documentation](https://docs.newrelic.com/docs/agents/python-agent/) to learn more about New Relic monitoring for Pyramid.
 
 summary: |
-  This quickstart automatically instruments pyramid with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts.
+  This quickstart automatically instruments Pyramid with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts.
 
 logo: logo.svg
 level: New Relic

--- a/quickstarts/python/pyramid/config.yml
+++ b/quickstarts/python/pyramid/config.yml
@@ -1,11 +1,12 @@
 id: 02f1dc20-9034-405b-90c1-8ad1bbf7755e
 name: pyramid
+title: pyramid
+
 description: |
   ## What is pyramid?
 
   Pyramid is an open source and minimalistic web framework written in Python and
   is based on WSGI.
-
 
   ## Get started!
 
@@ -14,22 +15,28 @@ description: |
   ## More info
 
   Check out the [documentation](https://docs.newrelic.com/docs/agents/python-agent/) to learn more about New Relic monitoring for pyramid.
+
 summary: |
-  Monitor pyramid with New Relic's Python agent
+  This quickstart automatically instruments pyramid with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts.
+
 logo: logo.svg
 level: New Relic
 authors:
   - New Relic
-title: pyramid
+
 documentation:
-  - name: pyramid installation docs
+  - name: Pyramid installation docs
     description: |
       Pyramid is an open source and minimalistic web framework written in Python
       and is based on WSGI.
     url: >-
       https://docs.newrelic.com/docs/agents/python-agent/getting-started/instrumented-python-packages
+
 keywords:
   - apm
   - python
+  - pyramid
+  - WSGI
+
 installPlans:
   - setup-python-agent

--- a/quickstarts/python/tornado/config.yml
+++ b/quickstarts/python/tornado/config.yml
@@ -1,21 +1,36 @@
 id: 47934616-fc0c-4e02-8b25-0a92d3f43928
 name: tornado
-description: "## What is tornado?\n\nPython web application framework built for asynchronous networking operations.\n\n## Get started!\n\nLeverage community expertise and instantly get value out of your telemetry data. This quickstart automatically instruments tornado with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts. Further leverage New Relic's APM capabilities by setting up [errors inbox](https://docs.newrelic.com/docs/apm/apm-ui-pages/errors-inbox/errors-inbox/), [transaction tracing](https://docs.newrelic.com/docs/apm/transactions/transaction-traces/introduction-transaction-traces/), and [service maps](https://docs.newrelic.com/docs/understand-dependencies/understand-system-dependencies/service-maps/introduction-service-maps/).\n\n## More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/agents/python-agent/) to learn more about New Relic monitoring for tornado."
-summary: Monitor tornado with New Relic's Python agent
+title: Tornado
+
+description: |
+  ## What is tornado?
+
+  Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed. By using non-blocking network I/O, Tornado can scale to tens of thousands of open connections, making it ideal for long polling, WebSockets, and other applications that require a long-lived connection to each user.
+
+  ## Get started!
+
+  Leverage community expertise and instantly get value out of your telemetry data. This quickstart automatically instruments tornado with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts. Further leverage New Relic's APM capabilities by setting up [errors inbox](https://docs.newrelic.com/docs/apm/apm-ui-pages/errors-inbox/errors-inbox/), [transaction tracing](https://docs.newrelic.com/docs/apm/transactions/transaction-traces/introduction-transaction-traces/), and [service maps](https://docs.newrelic.com/docs/understand-dependencies/understand-system-dependencies/service-maps/introduction-service-maps/).\n\n## More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/agents/python-agent/) to learn more about New Relic monitoring for tornado."
+
+summary: |
+   This quickstart automatically instruments tornado with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts.
+
 logo: logo.svg
 level: New Relic
 authors:
   - New Relic
-title: tornado
+
 documentation:
-  - name: tornado installation docs
+  - name: Tornado installation docs
     description: |
       Python web application framework built for asynchronous networking
       operations.
     url: >-
       https://docs.newrelic.com/docs/agents/python-agent/getting-started/instrumented-python-packages
+
 keywords:
   - apm
   - python
+  - tornado
+
 installPlans:
   - setup-python-agent

--- a/quickstarts/python/twisted/config.yml
+++ b/quickstarts/python/twisted/config.yml
@@ -1,19 +1,38 @@
 id: f697c86c-385f-40e9-83d2-c01215045912
 name: twisted
-description: "## What is twisted?\n\nAn event-based framework for internet applications written in Python.\n\n## Get started!\n\nLeverage community expertise and instantly get value out of your telemetry data. This quickstart automatically instruments twisted with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts. Further leverage New Relic's APM capabilities by setting up [errors inbox](https://docs.newrelic.com/docs/apm/apm-ui-pages/errors-inbox/errors-inbox/), [transaction tracing](https://docs.newrelic.com/docs/apm/transactions/transaction-traces/introduction-transaction-traces/), and [service maps](https://docs.newrelic.com/docs/understand-dependencies/understand-system-dependencies/service-maps/introduction-service-maps/).\n\n## More info\n\nCheck out the [documentation](https://docs.newrelic.com/docs/agents/python-agent/) to learn more about New Relic monitoring for twisted."
-summary: Monitor twisted with New Relic's Python agent
+title: Twisted
+
+description: |
+  ## What is Twisted?
+
+  Twisted is an event-based framework for internet applications written in Python. It supports CPython 3.6+ and PyPy3.
+
+  ## Get started!
+
+  Leverage community expertise and instantly get value out of your telemetry data. This quickstart automatically instruments twisted with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts. Further leverage New Relic's APM capabilities by setting up [errors inbox](https://docs.newrelic.com/docs/apm/apm-ui-pages/errors-inbox/errors-inbox/), [transaction tracing](https://docs.newrelic.com/docs/apm/transactions/transaction-traces/introduction-transaction-traces/), and [service maps](https://docs.newrelic.com/docs/understand-dependencies/understand-system-dependencies/service-maps/introduction-service-maps/).
+
+  ## More info
+
+  Check out the [documentation](https://docs.newrelic.com/docs/agents/python-agent/) to learn more about New Relic monitoring for twisted.
+
+summary: |
+   This quickstart automatically instruments twisted with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts.
+
 logo: logo.svg
 level: New Relic
 authors:
   - New Relic
-title: twisted
+
 documentation:
-  - name: twisted installation docs
+  - name: Twisted installation docs
     description: An event-based framework for internet applications written in Python.
     url: >-
       https://docs.newrelic.com/docs/agents/python-agent/getting-started/instrumented-python-packages
+
 keywords:
   - apm
   - python
+  - twisted
+
 installPlans:
   - setup-python-agent

--- a/quickstarts/python/web2py/config.yml
+++ b/quickstarts/python/web2py/config.yml
@@ -1,11 +1,13 @@
 id: 272f1fcb-624f-41be-8ae3-19f552b15d7c
 name: web2py
+title: web2py
+
+# web2py should be lowercase.
+
 description: |
   ## What is web2py?
 
-  Open source, Python-based web application framework that enables development
-  via browser.
-
+  Web2py is an open-source web application framework and allows web developers to program dynamic web content using Python. Web2py is designed to help reduce tedious web development tasks, such as developing web forms from scratch, although a web developer may build a form from scratch if required.
 
   ## Get started!
 
@@ -14,22 +16,26 @@ description: |
   ## More info
 
   Check out the [documentation](https://docs.newrelic.com/docs/agents/python-agent/) to learn more about New Relic monitoring for web2py.
+
 summary: |
-  Monitor web2py with New Relic's Python agent
+  This quickstart automatically instruments web2py with the New Relic Python agent, and allows you to instantly monitor your Python application with out-of-the-box dashboards and alerts.
+
 logo: logo.svg
 level: New Relic
 authors:
   - New Relic
-title: web2py
+
 documentation:
   - name: web2py installation docs
     description: |
-      Open source, Python-based web application framework that enables
-      development via browser.
+       Web2py is an open-source web application framework and allows web developers to program dynamic web content using Python.
     url: >-
       https://docs.newrelic.com/docs/agents/python-agent/getting-started/instrumented-python-packages
+
 keywords:
   - apm
   - python
+  - web2py
+
 installPlans:
   - setup-python-agent

--- a/quickstarts/python/webpy/config.yml
+++ b/quickstarts/python/webpy/config.yml
@@ -5,27 +5,27 @@ title: webpy
 # webpy should be lowercase.
 
 description: |
-  ## Why monitor Webpy?
+  ## Why monitor webpy?
 
-  Webpy is a web framework for Python that is as simple as it is powerful. It offers useful debug features and automatically reloads after code changes. Integrate New Relic’s Python agent with your Webpy app to monitor your app’s performance metrics in real time.
+  webpy is a web framework for Python that is as simple as it is powerful. It offers useful debug features and automatically reloads after code changes. Integrate New Relic’s Python agent with your webpy app to monitor your app’s performance metrics in real time.
 
-  ## Webpy quickstart highlights
+  ## webpy quickstart highlights
 
-  The New Relic Webpy quickstart has the following features:
+  The New Relic webpy quickstart has the following features:
 
   - Dashboards: Our dashboards provide you a clear overview of transactions, errors, and the virtual machine. The dashboards also help you monitor other key indicators like top 10 failed transactions, latest errors, and more.
   - Alerts: Get instant alerts like Apdex score, memory usage, high CPU utilizations, and transaction errors.
 
-  ## New Relic + Webpy = Optimum performance monitoring
+  ## New Relic + webpy = Optimum performance monitoring
 
-  New Relic’s Webpy quickstart automatically instruments your Webpy app with the [New Relic Python agent](https://docs.newrelic.com/docs/apm/agents/python-agent/getting-started/introduction-new-relic-python/) and allows you to monitor your Python application with practical dashboards and alerts. In particular, the dashboards provide you with interactive visualizations to easily explore your data, understand context, and resolve issues faster. With flexible options for custom instrumentation and APIs, our Python agent offers multiple building blocks for you to create and share customized dashboards.
+  New Relic’s webpy quickstart automatically instruments your webpy app with the [New Relic Python agent](https://docs.newrelic.com/docs/apm/agents/python-agent/getting-started/introduction-new-relic-python/) and allows you to monitor your Python application with practical dashboards and alerts. In particular, the dashboards provide you with interactive visualizations to easily explore your data, understand context, and resolve issues faster. With flexible options for custom instrumentation and APIs, our Python agent offers multiple building blocks for you to create and share customized dashboards.
 
-  Monitoring Webpy with New Relic’s Python agent provides instant alerts on Apdex score and transaction errors. You can track key transactions, examine database query traces, and get a high-level summary of your app’s performance. You also have the ability to view logs and infrastructure data as well as bring them together to make troubleshooting easier and more efficient.
+  Monitoring webpy with New Relic’s Python agent provides instant alerts on Apdex score and transaction errors. You can track key transactions, examine database query traces, and get a high-level summary of your app’s performance. You also have the ability to view logs and infrastructure data as well as bring them together to make troubleshooting easier and more efficient.
 
-  Install the New Relic Webpy quickstart to effectively monitor your Webpy app’s performance metrics with our Python agent. This quickstart gives you the tools to address issues that may arise when using Webpy.
+  Install the New Relic webpy quickstart to effectively monitor your webpy app’s performance metrics with our Python agent. This quickstart gives you the tools to address issues that may arise when using webpy.
 
 summary: |
-  Monitoring Webpy is critical to ensure that you detect incidents and respond to them quickly. Install the New Relic Webpy quickstart to proactively track your Webpy key performance metrics.
+  Monitoring webpy is critical to ensure that you detect incidents and respond to them quickly. Install the New Relic webpy quickstart to proactively track your webpy key performance metrics.
 
 logo: logo.svg
 level: New Relic

--- a/quickstarts/python/webpy/config.yml
+++ b/quickstarts/python/webpy/config.yml
@@ -1,5 +1,9 @@
 id: 535f37ab-3b88-471d-b107-266f39d28819
 name: webpy
+title: webpy
+
+# webpy should be lowercase.
+
 description: |
   ## Why monitor Webpy?
 
@@ -8,30 +12,37 @@ description: |
   ## Webpy quickstart highlights
 
   The New Relic Webpy quickstart has the following features:
-  Dashboards: Our dashboards provide you a clear overview of transactions, errors, and the virtual machine. The dashboards also help you monitor other key indicators like top 10 failed transactions, latest errors, and more.
-  Alerts: Get instant alerts like Apdex score, memory usage, high CPU utilizations, and transaction errors.
+
+  - Dashboards: Our dashboards provide you a clear overview of transactions, errors, and the virtual machine. The dashboards also help you monitor other key indicators like top 10 failed transactions, latest errors, and more.
+  - Alerts: Get instant alerts like Apdex score, memory usage, high CPU utilizations, and transaction errors.
 
   ## New Relic + Webpy = Optimum performance monitoring
 
   New Relic’s Webpy quickstart automatically instruments your Webpy app with the [New Relic Python agent](https://docs.newrelic.com/docs/apm/agents/python-agent/getting-started/introduction-new-relic-python/) and allows you to monitor your Python application with practical dashboards and alerts. In particular, the dashboards provide you with interactive visualizations to easily explore your data, understand context, and resolve issues faster. With flexible options for custom instrumentation and APIs, our Python agent offers multiple building blocks for you to create and share customized dashboards.
+
   Monitoring Webpy with New Relic’s Python agent provides instant alerts on Apdex score and transaction errors. You can track key transactions, examine database query traces, and get a high-level summary of your app’s performance. You also have the ability to view logs and infrastructure data as well as bring them together to make troubleshooting easier and more efficient.
+
   Install the New Relic Webpy quickstart to effectively monitor your Webpy app’s performance metrics with our Python agent. This quickstart gives you the tools to address issues that may arise when using Webpy.
 
-summary: | 
-  Monitoring Webpy is critical to ensure that you detect incidents and respond to them quickly. Download the New Relic Webpy quickstart to proactively track your Webpy key performance metrics.
+summary: |
+  Monitoring Webpy is critical to ensure that you detect incidents and respond to them quickly. Install the New Relic Webpy quickstart to proactively track your Webpy key performance metrics.
+
 logo: logo.svg
 level: New Relic
 authors:
   - New Relic
   - Emil Hammarstrand
-title: webpy
+
 documentation:
   - name: webpy installation docs
-    description: Webpy is a web framework for Python that is as simple as it is powerful.
+    description: webpy is a web framework for Python that is as simple as it is powerful.
     url: >-
       https://docs.newrelic.com/docs/agents/python-agent/getting-started/instrumented-python-packages
+
 keywords:
   - apm
   - python
+  - webpy
+
 installPlans:
   - setup-python-agent

--- a/quickstarts/ruby/net-http/config.yml
+++ b/quickstarts/ruby/net-http/config.yml
@@ -1,5 +1,9 @@
 id: 932f757b-98aa-460c-8ce8-bbab9c2cbf09
 name: net-http
+title: Net::HTTP
+
+# the double colons are required in Net::HTTP
+
 description: |
   ## What is Net::HTTP?
 
@@ -14,14 +18,16 @@ description: |
   ## More info
 
   Check out the [documentation](https://docs.newrelic.com/docs/agents/ruby-agent/) to learn more about New Relic monitoring for Net::HTTP.
+
 summary: |
-  Monitor Net::HTTP with New Relic's Ruby agent
+   This quickstart automatically instruments Net::HTTP with the New Relic Ruby agent and allows you to instantly monitor your Ruby application with out-of-the-box dashboards and alerts.
+
 logo: logo.svg
 level: New Relic
 authors:
   - New Relic
   - Emil Hammarstrand
-title: Net::HTTP
+
 documentation:
   - name: Net::HTTP installation docs
     description: |
@@ -29,8 +35,11 @@ documentation:
       user-agents.
     url: >-
       https://docs.newrelic.com/docs/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks
+
 installPlans:
   - setup-ruby-agent
+
 keywords:
   - apm
   - ruby
+  - Net::HTTP


### PR DESCRIPTION
This PR fixes numerous problems with quickstarts including:

- misc typos and line formatting issues
- titles that should be sentence case
- removes "quickstarts" from titles as it's redundant 
