### PR TITLE
fix: renames netlify qs due to 404 url issue

### DIFF
--- a/quickstarts/netlify/config.yml
+++ b/quickstarts/netlify/config.yml
@@ -1,6 +1,6 @@
 id: 5861d7f5-26c0-43ad-bda8-c893c4b27b25
 # Name of the quickstart (required)
-name: netlify builds
+name: netlify
 
 # Displayed in the UI (required)
 title: Netlify builds


### PR DESCRIPTION
this PR sets the name of netlify builds back to netlify due to the issue without having a good way to handle URL redirects for name changes on the I/O site.