### PR TITLE
fix: changes name to match title for URL consistency

### DIFF
--- a/quickstarts/gigamon/config.yml
+++ b/quickstarts/gigamon/config.yml
@@ -1,6 +1,6 @@
 id: d6b36ecf-bf99-475c-938f-370153db8e70
 name: gigamon-newrelic
-title: Gigamon
+title: gigamon-newrelic
 
 description: |
   Gigamon helps the world’s leading organizations run fast, stay secure and innovate. We provide the industry’s first elastic visibility and analytics fabric, which closes the cloud visibility gap by enabling cloud tools to see the network and network tools to see the cloud. With visibility across their entire hybrid cloud network, organizations can improve customer experience, eliminate security blind spots, and reduce cost and complexity. Gigamon has been awarded over 90 technology patents and enjoys world-class customer satisfaction with more than 4,000 organizations, including over 80 percent of the Fortune 100 and hundreds of government and educational organizations worldwide.


### PR DESCRIPTION
To ensure the URL isn't broken for Gigamon, on the I/O site I'm reverting the title to match the name until we resolve #957 

```
Previous: 'https://newrelic.com/instant-observability/gigamon-newrelic/d6b36ecf-bf99-475c-938f-370153db8e70'
Now: 'https://newrelic.com/instant-observability/gigamon/d6b36ecf-bf99-475c-938f-370153db8e70'
```