### PR TITLE
fix: handle when quickstarts are removed

### DIFF
--- a/utils/__tests__/validate_install_quickstart_plans.test.js
+++ b/utils/__tests__/validate_install_quickstart_plans.test.js
@@ -46,7 +46,7 @@ describe('Action: validate install plan id', () => {
     expect(global.console.error).not.toHaveBeenCalled();
   });
 
-  test.only(`succeeds when valid quickstart doesn't contain any install plan`, () => {
+  test(`succeeds when valid quickstart doesn't contain any install plan`, () => {
     const files = mockGithubAPIFiles([validQuickstartWithoutInstallPlan]);
     githubHelpers.filterQuickstartConfigFiles.mockReturnValueOnce(files);
 
@@ -80,5 +80,15 @@ describe('Action: validate install plan id', () => {
 
     validateInstallPlanIds(files);
     expect(global.console.error).toHaveBeenCalledTimes(5);
+  });
+
+  test('does not fail for deleted quickstart', () => {
+    const removedQuickstartFilename = 'fake-removed-quickstart/config.yml';
+    const files = mockGithubAPIFiles([removedQuickstartFilename]);
+    files[0].status = 'removed';
+    githubHelpers.filterQuickstartConfigFiles.mockReturnValueOnce(files);
+
+    validateInstallPlanIds(files);
+    expect(global.console.error).toHaveBeenCalledTimes(0);
   });
 });

--- a/utils/validate-quickstart-install-plans.js
+++ b/utils/validate-quickstart-install-plans.js
@@ -64,8 +64,11 @@ const getInstallPlansNoMatches = (configInstallPlanFiles, installPlanIds) => {
  */
 const validateInstallPlanIds = (githubFiles) => {
   const configFiles = filterQuickstartConfigFiles(githubFiles);
+  const existingConfigFiles = configFiles.filter(
+    (cf) => cf.status !== 'removed'
+  ); // Filter out deleted files
 
-  const configInstallPlansFiles = getConfigInstallPlans(configFiles);
+  const configInstallPlansFiles = getConfigInstallPlans(existingConfigFiles);
 
   const installPlanIds = getAllInstallPlanIds();
 


### PR DESCRIPTION
# Summary
The `Validate install plan ids` workflow was failing when a quickstart was deleted as part of the pull request. That was because it tried to read a file that doesn't exist. These changes filter out files with the status of `removed` from the Github API response before the files are read from the filesystem.

Full integration test on my fork [here](https://github.com/aswanson-nr/newrelic-quickstarts/pull/18)
Closes #749 