### PR TITLE
chore: added d.ts file for utils directory for global typing

### DIFF
--- a/utils/check_dashboard_name_uniqueness.ts
+++ b/utils/check_dashboard_name_uniqueness.ts
@@ -1,23 +1,16 @@
 import * as glob from 'glob';
 import * as path from 'path';
+
 import {
+  cleanQuickstartName,
+  getMatchingNames,
   readQuickstartFile,
   removeRepoPathPrefix,
-  getMatchingNames,
-  cleanQuickstartName,
 } from './helpers';
 
 interface DashboardNamesAndPaths {
   name: string;
   path: string;
-}
-
-// TODO: move this to a types file when we convert other scripts to typescript
-interface DashboardConfigs {
-  path: string;
-  contents: {
-    name: string;
-  }[];
 }
 
 /** Returns any quickstart dashboards with matching names and their filepaths */

--- a/utils/tsconfig.json
+++ b/utils/tsconfig.json
@@ -8,6 +8,9 @@
     "allowSyntheticDefaultImports": true,
     "noImplicitAny": true
   },
+  "paths": {
+    "*": ["types/*.d.ts"]
+  },
   "include": ["./**/*"],
   "exclude": ["./node_modules/"]
 }

--- a/utils/utils.d.ts
+++ b/utils/utils.d.ts
@@ -1,0 +1,13 @@
+/**
+ * This file is for reused types and interfaces along the utils/ directory.
+ *
+ * Feel free to add function signatures, interfaces, types or namespaces here
+ * to use throughout the utils directory.
+ */
+
+interface DashboardConfigs {
+  path: string;
+  contents: {
+    name: string;
+  }[];
+}


### PR DESCRIPTION
### Summary
Quick PR for configuring scoped types in `.d.ts` file for reusable interfaces/types/namespaces