### PR TITLE
fix install plan validation

### DIFF
--- a/.github/workflows/validate_install_plans.yml
+++ b/.github/workflows/validate_install_plans.yml
@@ -47,7 +47,7 @@ jobs:
           NEW_RELIC_APP_NAME: ${{ secrets.NEW_RELIC_APP_NAME }}
           NEW_RELIC_HOST: staging-collector.newrelic.com
           NODE_ENV: production
-        run: 
+        run: |
           URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${{ steps.get_pr_number.outputs.pr-number }}/files"
           DRY_RUN=true
           cd utils && yarn create-validate-install-plans $URL $DRY_RUN


### PR DESCRIPTION
# Summary

* with multi line blocks, needed the pipe operator. Previously, this
step was always passing despite failures that should have been occurring
during validation.

Relates to: #995 
