### PR TITLE
Fix NRQL parsing in sanitize dashboard script

### DIFF
--- a/utils/sanitize_dashboards.js
+++ b/utils/sanitize_dashboards.js
@@ -13,7 +13,7 @@ const sanitizeDashboard = (fileContent) => {
     .replace(/\"accountId\"\s*:\s*\d+/g, '"accountId": 0') // Anonymize account ID
     .replace(/\"linkedEntityGuids\"\s*:\s*\[([\t\n\r]*)?.*([\t\n\r]*)?\s*\]/g, '"linkedEntityGuids": null') // Set linkedEntityGuids to null
     .replace(/^.+\"permissions\".+\n?/gm, '') // Remove permissions
-    .replace(/[\}\)\]]\,(?!\s*?[\{\[\"\'\w])/g, '}'); // Remove trailing commas if any left after json blocks
+    .replace(/[\}\]]\,(?!\s*?[\{\[\"\'\w])/g, '}'); // Remove trailing commas if any left after json blocks
 };
 
 pathsToSanitize.forEach((i) => {


### PR DESCRIPTION
# Summary
We had an issue get through for a newly created dashboard, where the sanitize-dashboard script was removing commas within NRQL. It is only supposed to remove trailing slashes from the dashboard JSON. Looks like the regex for removing trailing commas is picking up the `),` in the NRQL. I tested removing `\)` from this [regex]( https://github.com/newrelic/newrelic-quickstarts/blob/main/utils/sanitize_dashboards.js#L16) and that seemed to do the trick. I can’t think of any situations where we would need to remove a trailing comma after a closing parentheses in json, so this seems like a change worth making.