### PR TITLE
fixup broken install plans

### DIFF
--- a/install/apm/dotnet/multi-os/install.yml
+++ b/install/apm/dotnet/multi-os/install.yml
@@ -9,12 +9,6 @@ target:
   os:
     - linux
     - windows
-  context: |
-    ###### WARNING
-    Using the command will automatically restart all systemd services that run .NET applications after installation.
-
-    ###### INFO
-    This installation only supports services managed by systemd. If you are hosting your .NET application differently then check out our other .NET installation options.
 
 install:
   mode: targetedInstall

--- a/install/apm/dotnet/windows-only/install.yml
+++ b/install/apm/dotnet/windows-only/install.yml
@@ -8,12 +8,6 @@ target:
   destination: application
   os:
     - windows
-  context: |
-    ###### WARNING
-    Using the command will automatically restart all systemd services that run .NET applications after installation.
-
-    ###### INFO
-    This installation only supports services managed by systemd. If you are hosting your .NET application differently then check out our other .NET installation options.
 
 install:
   mode: targetedInstall

--- a/install/apm/php/targeted-install/install.yml
+++ b/install/apm/php/targeted-install/install.yml
@@ -8,12 +8,6 @@ target:
   destination: application
   os:
     - linux
-  context: |
-    ###### WARNING
-    Using the command will require a restart of php-fpm, nginx, or apache depending on the service that is detected. You will be given the option to allow the installer to perform this action for you, or you can restart manually.
-
-    ###### INFO
-    This single-command will instrument PHP applications on linux systems with php-fpm, nginx, or apache. For other environments, please see our PHP standard installation.
 
 install:
   mode: targetedInstall

--- a/install/on-host-integration/apache/install.yml
+++ b/install/on-host-integration/apache/install.yml
@@ -7,7 +7,7 @@ description: |
   As part of this integration we will install the New Relic Infrastructure agent.
 
 target:
-  type: on-host-integration
+  type: on_host_integration
   destination: host
 
 install:

--- a/install/on-host-integration/cassandra/install.yml
+++ b/install/on-host-integration/cassandra/install.yml
@@ -7,7 +7,7 @@ description: |
   As part of this integration we will install the New Relic Infrastructure agent.
 
 target:
-  type: on-host-integration
+  type: on_host_integration
   destination: host
 
 install:

--- a/install/on-host-integration/couchbase/install.yml
+++ b/install/on-host-integration/couchbase/install.yml
@@ -7,7 +7,7 @@ description: |
   As part of this integration we will install the New Relic Infrastructure agent.
 
 target:
-  type: on-host-integration
+  type: on_host_integration
   destination: host
 
 install:

--- a/install/on-host-integration/elasticsearch/install.yml
+++ b/install/on-host-integration/elasticsearch/install.yml
@@ -7,7 +7,7 @@ description: |
   As part of this integration we will install the New Relic Infrastructure agent.
 
 target:
-  type: on-host-integration
+  type: on_host_integration
   destination: host
 
 install:

--- a/install/on-host-integration/haproxy/install.yml
+++ b/install/on-host-integration/haproxy/install.yml
@@ -7,7 +7,7 @@ description: |
   As part of this integration we will install the New Relic Infrastructure agent.
 
 target:
-  type: on-host-integration
+  type: on_host_integration
   destination: host
 
 install:

--- a/install/on-host-integration/hashicorp-consul/install.yml
+++ b/install/on-host-integration/hashicorp-consul/install.yml
@@ -7,7 +7,7 @@ description: |
   As part of this integration we will install the New Relic Infrastructure agent.
 
 target:
-  type: on-host-integration
+  type: on_host_integration
   destination: host
 
 install:

--- a/install/on-host-integration/jmx/install.yml
+++ b/install/on-host-integration/jmx/install.yml
@@ -5,7 +5,7 @@ description: |
   The New Relic JMX integration allows users to monitor any application that exposes metrics with JMX. The integration includes a default collection file that automatically collects key metrics from the JVM. You can also customize your metric collection with YAML files to collect any subset of metrics.
 
 target:
-  type: on-host-integration
+  type: on_host_integration
   destination: host
 
 install:

--- a/install/on-host-integration/kafka/install.yml
+++ b/install/on-host-integration/kafka/install.yml
@@ -5,7 +5,7 @@ description: |
   The New Relic Kafka on-host integration reports metrics and configuration data from your Kafka service. We instrument all the key elements of your cluster, including brokers (both ZooKeeper and Bootstrap), producers, consumers, and topics.
 
 target:
-  type: on-host-integration
+  type: on_host_integration
   destination: host
 
 install:

--- a/install/on-host-integration/memcached/install.yml
+++ b/install/on-host-integration/memcached/install.yml
@@ -7,7 +7,7 @@ description: |
   As part of this integration we will install the New Relic Infrastructure agent.
 
 target:
-  type: on-host-integration
+  type: on_host_integration
   destination: host
 
 install:

--- a/install/on-host-integration/mongodb/install.yml
+++ b/install/on-host-integration/mongodb/install.yml
@@ -7,7 +7,7 @@ description: |
   As part of this integration we will install the New Relic Infrastructure agent.
 
 target:
-  type: on-host-integration
+  type: on_host_integration
   destination: host
 
 install:

--- a/install/on-host-integration/mssql/install.yml
+++ b/install/on-host-integration/mssql/install.yml
@@ -7,7 +7,7 @@ description: |
   As part of this integration we will install the New Relic Infrastructure agent.
 
 target:
-  type: on-host-integration
+  type: on_host_integration
   destination: host
 
 install:

--- a/install/on-host-integration/mysql/install.yml
+++ b/install/on-host-integration/mysql/install.yml
@@ -7,12 +7,8 @@ description: |
   As part of this integration we will install the New Relic Infrastructure agent.
 
 target:
-  type: on-host-integration
+  type: on_host_integration
   destination: host
-  context: |-
-    To capture data from the MySQL integration, you need a MySql user with replication and select privileges.
-
-    More information regarding the prerequisites can be found at [https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/mysql-monitoring-integration/#req](https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/mysql-monitoring-integration/#req)
 
 install:
   mode: targetedInstall

--- a/install/on-host-integration/nagios/install.yml
+++ b/install/on-host-integration/nagios/install.yml
@@ -7,7 +7,7 @@ description: |
   As part of this integration we will install the New Relic Infrastructure agent.
 
 target:
-  type: on-host-integration
+  type: on_host_integration
   destination: host
 
 install:

--- a/install/on-host-integration/nginx/install.yml
+++ b/install/on-host-integration/nginx/install.yml
@@ -7,7 +7,7 @@ description: |
   As part of this integration we will install the New Relic Infrastructure agent.
 
 target:
-  type: on-host-integration
+  type: on_host_integration
   destination: host
 
 install:

--- a/install/on-host-integration/postgres/install.yml
+++ b/install/on-host-integration/postgres/install.yml
@@ -7,7 +7,7 @@ description: |
   As part of this integration we will install the New Relic Infrastructure agent.
 
 target:
-  type: on-host-integration
+  type: on_host_integration
   destination: host
 
 install:

--- a/install/on-host-integration/rabbitmq/install.yml
+++ b/install/on-host-integration/rabbitmq/install.yml
@@ -7,7 +7,7 @@ description: |
   As part of this integration we will install the New Relic Infrastructure agent.
 
 target:
-  type: on-host-integration
+  type: on_host_integration
   destination: host
 
 install:

--- a/install/on-host-integration/redis/install.yml
+++ b/install/on-host-integration/redis/install.yml
@@ -7,7 +7,7 @@ description: |
   As part of this integration we will install the New Relic Infrastructure agent.
 
 target:
-  type: on-host-integration
+  type: on_host_integration
   destination: host
 
 install:

--- a/install/on-host-integration/varnish/install.yml
+++ b/install/on-host-integration/varnish/install.yml
@@ -7,7 +7,7 @@ description: |
   As part of this integration we will install the New Relic Infrastructure agent.
 
 target:
-  type: on-host-integration
+  type: on_host_integration
   destination: host
 
 install:


### PR DESCRIPTION
## Summary
This PR contains changes to fix the [recent workflow failure](https://github.com/newrelic/newrelic-quickstarts/runs/5779399220?check_suite_focus=true) we saw. The particular errors are install plans having a `target.context` field, and the `target.type` value we submit to the API -- `ON-HOST-INTEGRATION` -- being incorrect.

Changes:
* remove `target.context` field
* change `target.type` value of `on-host-integration` to `on_host_integration`

## Links
Resolves: #995 