### PR TITLE
Image validation fix

### DIFF
--- a/utils/validate_images.js
+++ b/utils/validate_images.js
@@ -53,7 +53,7 @@ const validateImageCounts = (quickstartDirs) => {
     );
 
     // Each dashboard is allowed MAX_NUM_IMG dashboards
-    if (screenshotPaths.length > MAX_NUM_IMG * dashboardCount) {
+    if (dashboardCount > 0 && screenshotPaths.length > MAX_NUM_IMG * dashboardCount) {
       screenshotDirectories.push({
         folder: quickstartDirName,
         dashboardCount,
@@ -62,7 +62,7 @@ const validateImageCounts = (quickstartDirs) => {
       });
     }
 
-    if (dashboardImagePaths.length > MAX_NUM_IMG * dashboardCount) {
+    if (dashboardCount > 0 && dashboardImagePaths.length > MAX_NUM_IMG * dashboardCount) {
       imagesDirectories.push({
         folder: quickstartDirName + DASHBOARD_IMAGES_PATH,
         dashboardCount,


### PR DESCRIPTION
## Summary

This PR adds an additional step in logic to confirm that the number of dashboards is greater than 0. If `dashboardCount` is `0`, the if statement would hit an incorrect truthy statement.
https://github.com/newrelic/newrelic-quickstarts/blob/2d60bc77b5e5963e6d22cf7700dfb827343911e8/utils/validate_images.js#L56

Above, no matter what the value of `screenshotPaths.length` is, it would equal `true` if `dashboardCount` is `0`

Update:
https://github.com/newrelic/newrelic-quickstarts/blob/fc50d87e4ce23ea7ffb5db75a88ff118cf5be206/utils/validate_images.js#L56