### PR TITLE
Add expirationDuration to coredns alert

### DIFF
--- a/quickstarts/kubernetes/coredns/alerts/coredns-panics.yml
+++ b/quickstarts/kubernetes/coredns/alerts/coredns-panics.yml
@@ -34,7 +34,7 @@ expiration:
   # Open "Loss of Signal" violation if signal is lost (Default: false)
   openViolationOnExpiration: false
   # Time in seconds; Max value: 172800 (48hrs), null if closeViolationsOnExpiration and openViolationOnExpiration are both 'false'
-  expirationDuration:
+  expirationDuration: 300 
 
 # Advanced Signal Settings
 signal:


### PR DESCRIPTION
# Summary

The `coredns-panics` alert on the CoreDNS quickstart was throwing errors during installation. This was do to not having the `expirationDuration` set. 
After this is merge, the alerts should install without issue.