### PR TITLE
Updating sanitize dashboards script for nested dashboards

### DIFF
--- a/utils/sanitize_dashboards.js
+++ b/utils/sanitize_dashboards.js
@@ -16,10 +16,25 @@ const sanitizeDashboard = (fileContent) => {
     .replace(/[\}\]]\,(?!\s*?[\{\[\"\'\w])/g, '}'); // Remove trailing commas if any left after json blocks
 };
 
+const checkDirForDashboardJson = (directory) => {
+    const files = fs.readdirSync(directory, {withFileTypes: true});
+    return {
+      directories: files.filter((file) => file.isDirectory()).map(file => path.resolve(directory, file.name)),
+      jsonFiles: files.filter((file) => file.name.includes('json')).map(file => path.resolve(directory, file.name))
+    };
+};
+
 pathsToSanitize.forEach((i) => {
   const directory = path.resolve('..', 'quickstarts', `${i}`, 'dashboards');
-  const files = fs.readdirSync(directory, { withFileTypes: true });
-  const jsonFiles = files.filter((file) => file.name.includes('.json'));
+  const files = checkDirForDashboardJson(directory);
+  let jsonFiles = files.jsonFiles;
+
+  for (let nestedDir of files.directories) {
+    let nestedFiles = checkDirForDashboardJson(nestedDir);
+    if(nestedFiles.jsonFiles.length > 0) {
+      jsonFiles = jsonFiles.concat(nestedFiles.jsonFiles);
+    }
+  }
 
   if (jsonFiles.length < 1) {
     console.log(
@@ -28,12 +43,11 @@ pathsToSanitize.forEach((i) => {
     return;
   }
 
-  for (let file of jsonFiles) {
-    const filePath = path.resolve(directory, file.name);
+  for (let filePath of jsonFiles) {
     const quickStart = fs.readFileSync(filePath, { encoding: 'utf8' });
     const cleanFile = sanitizeDashboard(quickStart);
 
-    if (cleanFile !== file) {
+    if (cleanFile !== quickStart) {
       fs.writeFile(filePath, cleanFile, { encoding: 'utf8' }, function (err) {
         if (err) {
           console.error(`Error updating ${filePath}`);


### PR DESCRIPTION
# Summary

After rebasing with upstream main, I noticed the dashboard directory structure changed and I was getting an error when running the sanitize script. My goal was to update the script to work with the new structure while continuing to work with the old. It merges any `.json` files found in nested directories under the top directory (only 1 level down). For example, `./kubernetes/coredns/` will check 
- `./kubernetes/coredns/` itself for `.json` files
- `./kubernetes/coredns/coredns-dashboard` for `.json` files

and merge results together.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] ~Did you check you NRQL syntax? - Does it work?~
- [ ] ~Did you check your dashboard image quality? -  Do they look good?~
- [ ] ~Did you check that your alerts actually work?~
- [ ] ~Did you include an InstallPlan and Documentation reference?~
- [ ] ~Did you check your descriptive content for voice, tone, spelling and grammar errors?~
- [ ] ~Did you attach images of your dashboards to the PR so we can see them working?~

### Screenshots

Attach images of any visual changes, such as a dashboard here.
