### PR TITLE
fix: k8s dashboard restart chart

### DIFF
--- a/quickstarts/kubernetes/kubernetes/dashboards/kubernetes/kubernetes.json
+++ b/quickstarts/kubernetes/kubernetes/dashboards/kubernetes/kubernetes.json
@@ -717,7 +717,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric select max(k8s.container.restartCount) AS 'Restart Count', latest(k8s.reason) AS 'Reason' where k8s.container.restartCount[latest] > 0 order by k8s.container.restartCount facet k8s.containerName AS 'Container Name', k8s.podName AS 'Pod Name', k8s.clusterName AS 'Cluster Name' since 30 minutes ago limit 1000"
+                "query": "FROM Metric select max(k8s.container.restartCount) AS 'Restart Count', latest(k8s.reason) AS 'Last Restart Reason' where k8s.container.restartCount[latest] > 0 AND k8s.reason IS NOT NULL order by k8s.container.restartCount facet k8s.containerName AS 'Container Name', k8s.podName AS 'Pod Name', k8s.clusterName AS 'Cluster Name' since 30 minutes ago limit 1000"
               }
             ]
           },


### PR DESCRIPTION
# Summary

Chart is currently showing all container with restarts despite if it happened in the timewindow selected, this also makes that the reason for the restarts appears empty .
This filter will avoid showing restarts that happened outside the time window, and because of that it will always show the latest restart reason.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [x] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [ ] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?

### Screenshots

Attach images of any visual changes, such as a dashboard here.
