### PR TITLE
fix: update golden signals to new install

### DIFF
--- a/quickstarts/golden-signals-web/config.yml
+++ b/quickstarts/golden-signals-web/config.yml
@@ -26,7 +26,17 @@ authors:
   - Alec Swanson
 
 installPlans:
-  - guided-install
+  - infra-agent-targeted 
+
+documentation:
+  - name: New Relic infrastructure agent
+    description: |
+      Learn how to monitor your hosts with New Relic.
+    url: https://docs.newrelic.com/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring/
+  - name: New Relic language agents
+    description: |
+      Learn how to get in-depth and relevant information about your running software in minutes.
+    url: https://docs.newrelic.com/docs/apm/new-relic-apm/getting-started/introduction-apm
 
 keywords:
   - golden signals


### PR DESCRIPTION
# Summary
* Move golden signals to the targeted infrastructure install plan
* This will allow user's to skip the installation if they already have
  their software monitored

