### PR TITLE
Remove Trend Micro from AWS category

### DIFF
--- a/data-sources/trendmicro-cloudone-conformity/config.yml
+++ b/data-sources/trendmicro-cloudone-conformity/config.yml
@@ -25,4 +25,3 @@ keywords:
   - newrelic partner
 categoryTerms:
   - newrelic partner
-  - aws


### PR DESCRIPTION
# Summary

After further discussion, we want to remove the `Trend Micro` data source from the AWS category. We'll leave it in `Partner` for now.