### PR TITLE
Generate pull request preview links

### DIFF
--- a/.github/workflows/preview-links.yml
+++ b/.github/workflows/preview-links.yml
@@ -33,8 +33,6 @@ jobs:
           yarn create-preview-links ${{ github.event.pull_request.url }} ${{ github.event.pull_request.number }}
 
       - name: Comment 
+        if: steps.links.outputs.comment != ''
         run: |
-          if [[ '${{ steps.links.outputs.comment }}' != '' ]]; then
-              echo "Detected comment, posting to pull request"
           gh pr comment ${{github.event.pull_request.number}} --body ${{ steps.links.outputs.comment }}
-          fi

--- a/.github/workflows/preview-links.yml
+++ b/.github/workflows/preview-links.yml
@@ -1,0 +1,40 @@
+name: Preview links
+
+on:
+  pull_request_target:
+    branches:
+      - main
+
+defaults:
+  run:
+    working-directory: utils
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Create preview links
+        id: links
+        run: |
+          yarn create-preview-links ${{ github.event.pull_request.url }} ${{ github.event.pull_request.number }}
+
+      - name: Comment 
+        run: |
+          if [[ '${{ steps.links.outputs.comment }}' != '' ]]; then
+              echo "Detected comment, posting to pull request"
+          gh pr comment ${{github.event.pull_request.number}} --body ${{ steps.links.outputs.comment }}
+          fi

--- a/utils/__tests__/create-preview-links.test.ts
+++ b/utils/__tests__/create-preview-links.test.ts
@@ -1,0 +1,152 @@
+'use strict';
+const {
+  mockGitHubResponseFilenames,
+  addFilenameObject,
+} = require('./test-utilities');
+
+const ghHelpers = require('../github-api-helpers');
+
+const {
+  generatePreviewComment,
+  createComment,
+  createPreviewLink,
+  getQuickstartsFromPRFiles,
+} = require('../create-preview-links');
+
+jest.mock('../github-api-helpers');
+jest.spyOn(console, 'error').mockImplementation(() => {});
+jest.spyOn(console, 'log');
+
+const expectCommentHeading = `### Click the link(s) below to view a preview of your changes on newrelic.com/instant-observability<br/><br/>`;
+const previewLink = `https://newrelic.com/instant-observability/preview`;
+
+describe('create-preview-links', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('getQuickstartsFromPRFiles', () => {
+    test('returns an array of quickstart local paths', async () => {
+      ghHelpers.fetchPaginatedGHResults.mockReturnValueOnce([
+        { filename: 'quickstarts/apache/config.yml' },
+        { filename: 'quickstarts/nested/test/dashboards/test-dash/dash.json' },
+        { filename: 'quickstarts/apache/logo.svg' },
+      ]);
+
+      const quickstarts = await getQuickstartsFromPRFiles(
+        'testurl',
+        'testtoken'
+      );
+      expect(quickstarts).toHaveLength(2);
+      expect(quickstarts).toEqual(['apache', 'nested/test']);
+    });
+  });
+
+  describe('createPreviewLink', () => {
+    test('Generates link based on pull request number and quickstart local path', () => {
+      const link = createPreviewLink('40', 'apache');
+      expect(link).toEqual(
+        'https://newrelic.com/instant-observability/preview?pr=40&quickstart=apache'
+      );
+    });
+
+    test('Generates link based on pull request number and nested quickstart local path', () => {
+      const link = createPreviewLink('40', 'deeply/nested/quickstart');
+      expect(link).toEqual(
+        'https://newrelic.com/instant-observability/preview?pr=40&quickstart=deeply%2Fnested%2Fquickstart'
+      );
+    });
+  });
+
+  describe('createComment', () => {
+    test('creates comment for 1 quickstart', () => {
+      const quickstarts = [{ path: 'apache', link: 'testlink' }];
+      expect(createComment(quickstarts)).toEqual(
+        `${expectCommentHeading}- [apache](testlink)`
+      );
+    });
+
+    test('creates comment for multiple quickstarts', () => {
+      const quickstarts = [
+        { path: 'apache', link: 'testlink' },
+        { path: 'deeply/nested/quickstart', link: 'testlink2' },
+        { path: 'other/quickstart', link: 'testlink3' },
+      ];
+      expect(createComment(quickstarts)).toEqual(
+        `${expectCommentHeading}- [apache](testlink)<br/>- [deeply/nested/quickstart](testlink2)<br/>- [other/quickstart](testlink3)`
+      );
+    });
+  });
+
+  describe('generatePreviewComment', () => {
+    test('returns false when token is not provided', async () => {
+      const res = await generatePreviewComment('testurl', 'testnumber');
+      expect(res).toBe(false);
+    });
+
+    test('returns false when prURL is not provided', async () => {
+      const res = await generatePreviewComment(
+        undefined,
+        'testnumber',
+        'testtoken'
+      );
+      expect(res).toBe(false);
+    });
+
+    test('returns false when prNumber is not provided', async () => {
+      const res = await generatePreviewComment(
+        'testurl',
+        undefined,
+        'testtoken'
+      );
+      expect(res).toBe(false);
+    });
+
+    test('fails when Github API call errors', async () => {
+      ghHelpers.fetchPaginatedGHResults.mockRejectedValue(
+        new Error('test API down')
+      );
+
+      const res = await generatePreviewComment(
+        'testurl',
+        'testnumber',
+        'testtoken'
+      );
+      expect(res).toBe(false);
+    });
+
+    test('does not set Github workflow output when there are no quickstart changes', async () => {
+      ghHelpers.fetchPaginatedGHResults.mockReturnValueOnce([
+        { filename: 'utils/test-script.js' },
+        { filename: 'data-sources/test/config.yml' },
+      ]);
+
+      const res = await generatePreviewComment(
+        'testurl',
+        'testnumber',
+        'testtoken'
+      );
+      expect(res).toBe(true);
+      expect(console.log).toHaveBeenCalledWith(
+        'No quickstarts found, skipping preview'
+      );
+    });
+
+    test('sets Github workflow output when there are quickstart changes', async () => {
+      ghHelpers.fetchPaginatedGHResults.mockReturnValueOnce([
+        { filename: 'quickstarts/apache/config.yml' },
+        { filename: 'quickstarts/nested/test/dashboards/test-dash/dash.json' },
+        { filename: 'quickstarts/apache/logo.svg' },
+        { filename: 'utils/test-script.js' },
+      ]);
+
+      const expectComment = `${expectCommentHeading}- [apache](${previewLink}?pr=1&quickstart=apache)<br/>- [nested/test](${previewLink}?pr=1&quickstart=nested%2Ftest)`;
+
+      const res = await generatePreviewComment('testurl', '1', 'testtoken');
+      expect(res).toBe(true);
+      expect(console.log).toHaveBeenCalledWith(
+        `::set-output name=comment::${JSON.stringify(expectComment)}`
+      );
+    });
+  });
+});

--- a/utils/__tests__/helpers.test.js
+++ b/utils/__tests__/helpers.test.js
@@ -1,5 +1,9 @@
 'use strict';
 const helpers = require('../helpers');
+const {
+  mockGitHubResponseFilenames,
+  addFilenameObject,
+} = require('./test-utilities');
 
 describe('Action: validate images', () => {
   afterEach(() => {
@@ -74,5 +78,64 @@ describe('Action: validate images', () => {
       path: '/Users/lbrammer/Work/dev-exp/newrelic-quickstarts/quickstarts/java/cxf/dashboards/java.json',
     });
     expect(output).toHaveLength(4);
+  });
+
+  describe('getQuickstartFromFilename', () => {
+    test('getQuickstartFromFilename returns the quickstart an alert belongs to', () => {
+      const quickstartFromAlert = helpers.getQuickstartFromFilename(
+        'quickstarts/python/aiohttp/alerts/ApdexScore.yml'
+      );
+
+      expect(quickstartFromAlert).toEqual('python/aiohttp');
+    });
+
+    test('getQuickstartFromFilename returns the quickstart a dashboard belongs to', () => {
+      const quickstartFromDashboard = helpers.getQuickstartFromFilename(
+        'quickstarts/python/pysqlite/dashboards/python.json'
+      );
+
+      expect(quickstartFromDashboard).toEqual('python/pysqlite');
+    });
+
+    test('getQuickstartFromFilename returns the quickstart an icon belongs to', () => {
+      const quickstartFromIcon = helpers.getQuickstartFromFilename(
+        'quickstarts/python/pysqlite/logo.svg'
+      );
+
+      expect(quickstartFromIcon).toEqual('python/pysqlite');
+    });
+
+    test('getQuickstartFromFilename does not return non-quickstarts files', () => {
+      const mockQuickstart = helpers.getQuickstartFromFilename(
+        '.github/workflows/validate_packs.yml'
+      );
+
+      expect(mockQuickstart).toBeUndefined();
+    });
+
+    test('getQuickstartFromFilename does not return mock quickstarts', () => {
+      const mockQuickstart = helpers.getQuickstartFromFilename(
+        'utils/mock_files/mock-quickstart-1/config.yml'
+      );
+
+      expect(mockQuickstart).toBeUndefined();
+    });
+
+    test('buildUniqueQuickstartSet returns a list of unique quickstarts', () => {
+      const expectedUniqueQuickstartDirectories = new Set([
+        'foo/duplicate-directory-name',
+        'bar/duplicate-directory-name',
+        'python/aiohttp',
+        'test-quickstart-folder',
+        'test-quickstart-folder-2',
+        'python/pysqlite',
+      ]);
+
+      const uniqueQuickstarts = mockGitHubResponseFilenames
+        .map(addFilenameObject)
+        .reduce(helpers.buildUniqueQuickstartSet, new Set());
+
+      expect(uniqueQuickstarts).toEqual(expectedUniqueQuickstartDirectories);
+    });
   });
 });

--- a/utils/__tests__/test-utilities.js
+++ b/utils/__tests__/test-utilities.js
@@ -1,0 +1,53 @@
+const mockFilenamesDuplicatedDirectory = [
+  'quickstarts/foo/duplicate-directory-name/config.yml',
+  'quickstarts/foo/duplicate-directory-name/alerts/baseline-alert.yml',
+  'quickstarts/bar/duplicate-directory-name/config.yml',
+  'quickstarts/bar/duplicate-directory-name/alerts/baseline-alert.yml',
+];
+
+const mockFilenamesTestQS1 = [
+  'quickstarts/test-quickstart-folder/alerts/baseline-alert.yml',
+  'quickstarts/test-quickstart-folder/alerts/static-alert.yml',
+  'quickstarts/test-quickstart-folder/config.yml',
+  'quickstarts/test-quickstart-folder/dashboards/my-dashboard.json',
+  'quickstarts/test-quickstart-folder/dashboards/my-dashboard.png',
+  'quickstarts/test-quickstart-folder/icon.jpeg',
+  'quickstarts/test-quickstart-folder/images/icon.jpeg',
+];
+const mockFilenamesTestQS2 = [
+  'quickstarts/test-quickstart-folder-2/logo.png',
+  'quickstarts/test-quickstart-folder-2/alerts/baseline-alert.yml',
+  'quickstarts/test-quickstart-folder-2/alerts/static-alert.yml',
+  'quickstarts/test-quickstart-folder-2/config.yml',
+  'quickstarts/test-quickstart-folder-2/dashboards/my-dashboard.json',
+  'quickstarts/test-quickstart-folder-2/dashboards/my-dashboard.png',
+  'quickstarts/test-quickstart-folder-2/icon.jpeg',
+  'quickstarts/test-quickstart-folder-2/images/icon.jpeg',
+  'quickstarts/test-quickstart-folder-2/logo.png',
+];
+
+const mockGitHubResponseFilenames = [
+  ...mockFilenamesDuplicatedDirectory,
+  ...mockFilenamesTestQS1,
+  ...mockFilenamesTestQS2,
+  'quickstarts/python/aiohttp/alerts/ApdexScore.yml',
+  'quickstarts/python/pysqlite/dashboards/python.json',
+  'quickstarts/python/pysqlite/logo.svg',
+  '.github/workflows/validate_packs.yml',
+  'utils/__tests__/validate_install_plans.test.js',
+  'utils/github-api-helpers.js',
+  'utils/helpers.js',
+  'utils/package.json',
+  'utils/validate-install-plan.js',
+  'utils/yarn.lock',
+];
+
+const addFilenameObject = (filename) => ({ filename });
+
+module.exports = {
+  mockFilenamesDuplicatedDirectory,
+  mockFilenamesTestQS1,
+  mockFilenamesTestQS2,
+  mockGitHubResponseFilenames,
+  addFilenameObject,
+};

--- a/utils/__tests__/validate_pr_quickstarts.test.js
+++ b/utils/__tests__/validate_pr_quickstarts.test.js
@@ -4,13 +4,16 @@ const path = require('path');
 const { expect } = require('@jest/globals');
 
 const {
-  getQuickstartFromFilename,
   getQuickstartConfigPaths,
   buildMutationVariables,
-  buildUniqueQuickstartSet,
   getGraphqlRequests,
   countErrors,
 } = require('../create_validate_pr_quickstarts');
+
+const {
+  mockGitHubResponseFilenames,
+  addFilenameObject,
+} = require('./test-utilities');
 
 const helpers = require('../helpers');
 
@@ -30,61 +33,6 @@ const buildFullQuickstartFilePaths = (relativePaths) => {
     return path.resolve(process.cwd(), `..${relativePath}`);
   });
 };
-
-const mockFilenamesDuplicatedDirectory = [
-  'quickstarts/foo/duplicate-directory-name/config.yml',
-  'quickstarts/foo/duplicate-directory-name/alerts/baseline-alert.yml',
-  'quickstarts/bar/duplicate-directory-name/config.yml',
-  'quickstarts/bar/duplicate-directory-name/alerts/baseline-alert.yml',
-];
-
-const mockFilenamesTestQS1 = [
-  'quickstarts/test-quickstart-folder/alerts/baseline-alert.yml',
-  'quickstarts/test-quickstart-folder/alerts/static-alert.yml',
-  'quickstarts/test-quickstart-folder/config.yml',
-  'quickstarts/test-quickstart-folder/dashboards/my-dashboard.json',
-  'quickstarts/test-quickstart-folder/dashboards/my-dashboard.png',
-  'quickstarts/test-quickstart-folder/icon.jpeg',
-  'quickstarts/test-quickstart-folder/images/icon.jpeg',
-];
-const mockFilenamesTestQS2 = [
-  'quickstarts/test-quickstart-folder-2/logo.png',
-  'quickstarts/test-quickstart-folder-2/alerts/baseline-alert.yml',
-  'quickstarts/test-quickstart-folder-2/alerts/static-alert.yml',
-  'quickstarts/test-quickstart-folder-2/config.yml',
-  'quickstarts/test-quickstart-folder-2/dashboards/my-dashboard.json',
-  'quickstarts/test-quickstart-folder-2/dashboards/my-dashboard.png',
-  'quickstarts/test-quickstart-folder-2/icon.jpeg',
-  'quickstarts/test-quickstart-folder-2/images/icon.jpeg',
-  'quickstarts/test-quickstart-folder-2/logo.png',
-];
-
-const mockGitHubResponseFilenames = [
-  ...mockFilenamesDuplicatedDirectory,
-  ...mockFilenamesTestQS1,
-  ...mockFilenamesTestQS2,
-  'quickstarts/python/aiohttp/alerts/ApdexScore.yml',
-  'quickstarts/python/pysqlite/dashboards/python.json',
-  'quickstarts/python/pysqlite/logo.svg',
-  '.github/workflows/validate_packs.yml',
-  'utils/__tests__/validate_install_plans.test.js',
-  'utils/github-api-helpers.js',
-  'utils/helpers.js',
-  'utils/package.json',
-  'utils/validate-install-plan.js',
-  'utils/yarn.lock',
-];
-
-const addFilenameObject = (filename) => ({ filename });
-
-const expectedUniqueQuickstartDirectories = new Set([
-  'foo/duplicate-directory-name',
-  'bar/duplicate-directory-name',
-  'python/aiohttp',
-  'test-quickstart-folder',
-  'test-quickstart-folder-2',
-  'python/pysqlite',
-]);
 
 const quickstartNames = new Set([
   'aws-ec2',
@@ -199,54 +147,6 @@ const expectedMockQuickstart4MutationInput = {
 describe('quickstart submission and validation', () => {
   afterEach(() => {
     jest.resetAllMocks();
-  });
-
-  test('getQuickstartFromFilename returns the quickstart an alert belongs to', () => {
-    const quickstartFromAlert = getQuickstartFromFilename(
-      'quickstarts/python/aiohttp/alerts/ApdexScore.yml'
-    );
-
-    expect(quickstartFromAlert).toEqual('python/aiohttp');
-  });
-
-  test('getQuickstartFromFilename returns the quickstart a dashboard belongs to', () => {
-    const quickstartFromDashboard = getQuickstartFromFilename(
-      'quickstarts/python/pysqlite/dashboards/python.json'
-    );
-
-    expect(quickstartFromDashboard).toEqual('python/pysqlite');
-  });
-
-  test('getQuickstartFromFilename returns the quickstart an icon belongs to', () => {
-    const quickstartFromIcon = getQuickstartFromFilename(
-      'quickstarts/python/pysqlite/logo.svg'
-    );
-
-    expect(quickstartFromIcon).toEqual('python/pysqlite');
-  });
-
-  test('getQuickstartFromFilename does not return non-quickstarts files', () => {
-    const mockQuickstart = getQuickstartFromFilename(
-      '.github/workflows/validate_packs.yml'
-    );
-
-    expect(mockQuickstart).toBeUndefined();
-  });
-
-  test('getQuickstartFromFilename does not return mock quickstarts', () => {
-    const mockQuickstart = getQuickstartFromFilename(
-      'utils/mock_files/mock-quickstart-1/config.yml'
-    );
-
-    expect(mockQuickstart).toBeUndefined();
-  });
-
-  test('buildUniqueQuickstartSet returns a list of unique quickstarts', () => {
-    const uniqueQuickstarts = mockGitHubResponseFilenames
-      .map(addFilenameObject)
-      .reduce(buildUniqueQuickstartSet, new Set());
-
-    expect(uniqueQuickstarts).toEqual(expectedUniqueQuickstartDirectories);
   });
 
   test('getQuickstartConfigPaths returns list of unique quickstart config filepaths', () => {

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -2,3 +2,6 @@ export const GITHUB_REPO_BASE_URL =
   'https://github.com/newrelic/newrelic-quickstarts/tree/main';
 export const GITHUB_RAW_BASE_URL =
   'https://raw.githubusercontent.com/newrelic/newrelic-quickstarts/main';
+
+export const IO_PREVIEW_PAGE_URL =
+  'https://newrelic.com/instant-observability/preview';

--- a/utils/create-preview-links.ts
+++ b/utils/create-preview-links.ts
@@ -1,0 +1,131 @@
+import { fetchPaginatedGHResults } from './github-api-helpers';
+import { buildUniqueQuickstartSet } from './helpers';
+import { IO_PREVIEW_PAGE_URL } from './constants';
+
+/**
+ * Retrieves the individual quickstarts changed or created in a pull request
+ * @param prURL - The Github API URL for a pull request
+ * @param token - A Github access token
+ * @returns The local file path for each quickstart. Ex: ['apache', 'aws/amazon-msk']
+ */
+export const getQuickstartsFromPRFiles = async (
+  prURL: string,
+  token: string
+): Promise<string[]> => {
+  const filesURL = `${prURL}/files`;
+
+  const files = await fetchPaginatedGHResults(filesURL, token);
+  const uniqueQuickstarts = files.reduce(
+    buildUniqueQuickstartSet,
+    new Set<string>()
+  );
+
+  return [...uniqueQuickstarts.values()];
+};
+
+/**
+ * Creates a link to the IO preview page for a particular quickstart
+ * @param prNumber - The Github pull request number
+ * @param quickstartPath - The local file path to a quickstart. Ex: 'apache' or 'aws/amazon-msk'
+ * @returns A URL to the IO preview page with the required parameters
+ */
+export const createPreviewLink = (
+  prNumber: string,
+  quickstartPath: string
+): string => {
+  const url = new URL(IO_PREVIEW_PAGE_URL);
+
+  url.searchParams.set('pr', prNumber);
+  url.searchParams.set('quickstart', quickstartPath);
+
+  return url.href;
+};
+
+/**
+ * Creates a string that includes links to each quickstart preview, used as a pull request comment
+ * @param quickstarts - An array of objects that include the local path for a quickstart and its associated preview link
+ * @returns A string to be used as a Github pull request comment
+ */
+export const createComment = (
+  quickstarts: { path: string; link: string }[]
+): string => {
+  const heading = `### Click the link(s) below to view a preview of your changes on newrelic.com/instant-observability<br/><br/>`;
+
+  const markdownLinks = quickstarts
+    .map((q) => `- [${q.path}](${q.link})`)
+    .join('<br/>');
+
+  return `${heading}${markdownLinks}`;
+};
+
+/**
+ * Executes this script to create a pull request comment with preview links for each quickstart in the pull request
+ * Requires the `GITHUB_TOKEN` environment variable to be set to a Github access token
+ * @param prURL - The Github API URL to the pull request
+ * @param prNumber - The Github pull request number
+ * @param token - A Github access token
+ */
+export const generatePreviewComment = async (
+  prURL: string | undefined,
+  prNumber: string | undefined,
+  token: string | undefined
+): Promise<boolean> => {
+  if (!token) {
+    console.error(`Missing GITHUB_TOKEN environment variable`);
+    return false;
+  }
+
+  if (!prURL || !prNumber) {
+    console.error(
+      `Missing arguments. Example: ts-node create-preview-links.ts <pull request url> <github token>`
+    );
+    return false;
+  }
+
+  try {
+    console.log(`Fetching PR: ${prURL}`);
+    const quickstarts = await getQuickstartsFromPRFiles(prURL, token);
+
+    console.log(`Found ${quickstarts.length} quickstarts`);
+    const links = quickstarts.map((q) => ({
+      path: q,
+      link: createPreviewLink(prNumber, q),
+    }));
+
+    if (links.length > 0) {
+      const comment = JSON.stringify(createComment(links));
+      console.log(`::set-output name=comment::${comment}`);
+    } else {
+      console.log(`No quickstarts found, skipping preview`);
+    }
+  } catch (err) {
+    console.error(err);
+    return false;
+  }
+
+  return true;
+};
+
+/**
+ * Gathers environment variables and arguments, then executes the script
+ */
+const main = async () => {
+  const isSuccess = await generatePreviewComment(
+    process.argv[2],
+    process.argv[3],
+    process.env.GITHUB_TOKEN
+  );
+
+  if (!isSuccess) {
+    process.exit(1);
+  }
+};
+
+/**
+ * This allows us to check if the script was invoked directly from the command line, i.e 'ts-node create-preview-link.ts', or if it was imported.
+ * This would be true if this was used in one of our GitHub workflows, but false when imported for use in a test.
+ * See here: https://nodejs.org/docs/latest/api/modules.html#modules_accessing_the_main_module
+ */
+if (require.main === module) {
+  main();
+}

--- a/utils/create-preview-links.ts
+++ b/utils/create-preview-links.ts
@@ -61,14 +61,14 @@ export const createComment = (
 /**
  * Executes this script to create a pull request comment with preview links for each quickstart in the pull request
  * Requires the `GITHUB_TOKEN` environment variable to be set to a Github access token
- * @param prURL - The Github API URL to the pull request
- * @param prNumber - The Github pull request number
- * @param token - A Github access token
+ * @param [prURL] - The Github API URL to the pull request
+ * @param [prNumber] - The Github pull request number
+ * @param [token] - A Github access token
  */
 export const generatePreviewComment = async (
-  prURL: string | undefined,
-  prNumber: string | undefined,
-  token: string | undefined
+  prURL?: string,
+  prNumber?: string,
+  token?: string
 ): Promise<boolean> => {
   if (!token) {
     console.error(`Missing GITHUB_TOKEN environment variable`);

--- a/utils/create_validate_pr_quickstarts.ts
+++ b/utils/create_validate_pr_quickstarts.ts
@@ -28,6 +28,7 @@ import {
   readQuickstartFile,
   removeRepoPathPrefix,
   passedProcessArguments,
+  buildUniqueQuickstartSet,
   FilePathAndContents,
 } from './helpers';
 import {
@@ -81,63 +82,6 @@ const SUPPORT_LEVEL_ENUMS: SupportLevelMap = {
  * this mock UUID allows for validation to take place knowing a different UUID will be used for the actual release.
  */
 const MOCK_UUID = '00000000-0000-0000-0000-000000000000';
-
-/**
- * Gets the unique base quickstart directory from a given file path.
- * e.g. filePath: 'quickstarts/python/aiohttp/alerts/ApdexScore.yml' + targetChild: 'alerts' = 'python/aiohttp'.
- * @param {String} filePath - Full file path of a file in a quickstart.
- * @param {String} targetChild - Node in file path that should be preceded by a base quickstart directory.
- * @return {String} Node in file path of the quickstart.
- */
-const getQuickstartNode = (
-  filePath: string,
-  targetChild: string | undefined
-): string => {
-  const splitFilePath = filePath.split('/');
-
-  const baseQuickstartDirectoryIndex =
-    splitFilePath.findIndex((path) => path === targetChild) - 1;
-
-  let uniqueQuickstartDirectory = splitFilePath[baseQuickstartDirectoryIndex];
-  let indexCounter = baseQuickstartDirectoryIndex;
-
-  while (indexCounter > 1) {
-    uniqueQuickstartDirectory = splitFilePath[indexCounter - 1].concat(
-      `/${uniqueQuickstartDirectory}`
-    );
-    indexCounter--;
-  }
-  return uniqueQuickstartDirectory;
-};
-
-/**
- * Identifies where in a given file path to look for a quickstart directory.
- * @param {String} filePath - Full file path of a file in a quickstart.
- * @return {String|undefined} Called function with arguments to determine the quickstart of a given file path.
- */
-export const getQuickstartFromFilename = (
-  filePath: string
-): string | undefined => {
-  if (!filePath.includes('quickstarts/')) {
-    return undefined;
-  }
-
-  if (filePath.includes('/alerts/')) {
-    return getQuickstartNode(filePath, 'alerts');
-  }
-
-  if (filePath.includes('/dashboards/')) {
-    return getQuickstartNode(filePath, 'dashboards');
-  }
-
-  if (filePath.includes('/images/')) {
-    return getQuickstartNode(filePath, 'images');
-  }
-
-  const targetChildNode = filePath.split('/').pop();
-
-  return getQuickstartNode(filePath, targetChildNode);
-};
 
 /**
  * Looks up corresponding quickstart config files for quickstarts known to have changes in a PR.
@@ -372,20 +316,6 @@ const adaptQuickstartDocumentationInput = (
       description,
     };
   });
-
-/**
- * Reducer function that builds a set of unique quickstarts that were updated in a given PR.
- * @param {Set<string>} acc - A set of unique quickstarts being built by the reducer function.
- * @param {Object} curr - A result from the GitHub API.
- * @return {Set} A set of strings representing the unique quickstarts updated in a PR.
- */
-export const buildUniqueQuickstartSet = (
-  acc: Set<string>,
-  { filename }: { filename: string }
-): Set<string> => {
-  const quickstartFileName = getQuickstartFromFilename(filename);
-  return quickstartFileName ? acc.add(quickstartFileName) : acc;
-};
 
 /**
  * Creates GraphQL requests to be used in the SubmitQuickstartMetadata mutation.

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -184,3 +184,74 @@ export const cleanQuickstartName = (str: string): string =>
     .replace(/\s+/g, '-')
     .replace(/-+/, '-')
     .replace(/[^a-z0-9-]/g, '');
+
+/**
+ * Gets the unique base quickstart directory from a given file path.
+ * e.g. filePath: 'quickstarts/python/aiohttp/alerts/ApdexScore.yml' + targetChild: 'alerts' = 'python/aiohttp'.
+ * @param {String} filePath - Full file path of a file in a quickstart.
+ * @param {String} targetChild - Node in file path that should be preceded by a base quickstart directory.
+ * @return {String} Node in file path of the quickstart.
+ */
+const getQuickstartNode = (
+  filePath: string,
+  targetChild: string | undefined
+): string => {
+  const splitFilePath = filePath.split('/');
+
+  const baseQuickstartDirectoryIndex =
+    splitFilePath.findIndex((path) => path === targetChild) - 1;
+
+  let uniqueQuickstartDirectory = splitFilePath[baseQuickstartDirectoryIndex];
+  let indexCounter = baseQuickstartDirectoryIndex;
+
+  while (indexCounter > 1) {
+    uniqueQuickstartDirectory = splitFilePath[indexCounter - 1].concat(
+      `/${uniqueQuickstartDirectory}`
+    );
+    indexCounter--;
+  }
+  return uniqueQuickstartDirectory;
+};
+
+/**
+ * Identifies where in a given file path to look for a quickstart directory.
+ * @param {String} filePath - Full file path of a file in a quickstart.
+ * @return {String|undefined} Called function with arguments to determine the quickstart of a given file path.
+ */
+export const getQuickstartFromFilename = (
+  filePath: string
+): string | undefined => {
+  if (!filePath.includes('quickstarts/')) {
+    return undefined;
+  }
+
+  if (filePath.includes('/alerts/')) {
+    return getQuickstartNode(filePath, 'alerts');
+  }
+
+  if (filePath.includes('/dashboards/')) {
+    return getQuickstartNode(filePath, 'dashboards');
+  }
+
+  if (filePath.includes('/images/')) {
+    return getQuickstartNode(filePath, 'images');
+  }
+
+  const targetChildNode = filePath.split('/').pop();
+
+  return getQuickstartNode(filePath, targetChildNode);
+};
+
+/**
+ * Reducer function that builds a set of unique quickstarts that were updated in a given PR.
+ * @param {Set<string>} acc - A set of unique quickstarts being built by the reducer function.
+ * @param {Object} curr - A result from the GitHub API.
+ * @return {Set} A set of strings representing the unique quickstarts updated in a PR.
+ */
+export const buildUniqueQuickstartSet = (
+  acc: Set<string>,
+  { filename }: { filename: string }
+): Set<string> => {
+  const quickstartFileName = getQuickstartFromFilename(filename);
+  return quickstartFileName ? acc.add(quickstartFileName) : acc;
+};

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -188,18 +188,17 @@ export const cleanQuickstartName = (str: string): string =>
 /**
  * Gets the unique base quickstart directory from a given file path.
  * e.g. filePath: 'quickstarts/python/aiohttp/alerts/ApdexScore.yml' + targetChild: 'alerts' = 'python/aiohttp'.
- * @param {String} filePath - Full file path of a file in a quickstart.
- * @param {String} targetChild - Node in file path that should be preceded by a base quickstart directory.
- * @return {String} Node in file path of the quickstart.
+ * @param filePath - Full file path of a file in a quickstart.
+ * @param [targetChild] - Node in file path that should be preceded by a base quickstart directory.
+ * @return Node in file path of the quickstart.
  */
 const getQuickstartNode = (
   filePath: string,
-  targetChild: string | undefined
+  targetChild: string = ''
 ): string => {
   const splitFilePath = filePath.split('/');
 
-  const baseQuickstartDirectoryIndex =
-    splitFilePath.findIndex((path) => path === targetChild) - 1;
+  const baseQuickstartDirectoryIndex = splitFilePath.indexOf(targetChild) - 1;
 
   let uniqueQuickstartDirectory = splitFilePath[baseQuickstartDirectoryIndex];
   let indexCounter = baseQuickstartDirectoryIndex;
@@ -215,8 +214,8 @@ const getQuickstartNode = (
 
 /**
  * Identifies where in a given file path to look for a quickstart directory.
- * @param {String} filePath - Full file path of a file in a quickstart.
- * @return {String|undefined} Called function with arguments to determine the quickstart of a given file path.
+ * @param filePath - Full file path of a file in a quickstart.
+ * @return Called function with arguments to determine the quickstart of a given file path.
  */
 export const getQuickstartFromFilename = (
   filePath: string
@@ -244,9 +243,9 @@ export const getQuickstartFromFilename = (
 
 /**
  * Reducer function that builds a set of unique quickstarts that were updated in a given PR.
- * @param {Set<string>} acc - A set of unique quickstarts being built by the reducer function.
- * @param {Object} curr - A result from the GitHub API.
- * @return {Set} A set of strings representing the unique quickstarts updated in a PR.
+ * @param acc - A set of unique quickstarts being built by the reducer function.
+ * @param curr - A result from the GitHub API.
+ * @return A set of strings representing the unique quickstarts updated in a PR.
  */
 export const buildUniqueQuickstartSet = (
   acc: Set<string>,

--- a/utils/package.json
+++ b/utils/package.json
@@ -18,7 +18,8 @@
     "generate-uuids": "ts-node generate-uuids.js",
     "sanitize-dashboard": "ts-node sanitize_dashboards.js",
     "generate-schema-docs": "ts-node graphql-schemas/generate-schema-docs.js",
-    "preview": "ts-node preview.ts"
+    "preview": "ts-node preview.ts",
+    "create-preview-links": "ts-node create-preview-links.ts"
   },
   "dependencies": {
     "@actions/core": "^1.4.0",


### PR DESCRIPTION
# Summary
* Adds a workflow to generate links for pull request previews
* Adds script to create the links using the github API
* Moved some helper functions out of quickstart validation and into the general `helpers.ts`

## Testing
- [1 quickstart](https://github.com/aswanson-nr/newrelic-quickstarts/pull/23)
- [3 quickstarts](https://github.com/aswanson-nr/newrelic-quickstarts/pull/25)
- [no quickstarts](https://github.com/aswanson-nr/newrelic-quickstarts/pull/24)