### PR TITLE
Migration script for alert policies

### DIFF
--- a/utils/migration_scripts/move-alerts.ts
+++ b/utils/migration_scripts/move-alerts.ts
@@ -1,0 +1,36 @@
+import * as path from 'path';
+import * as fs from 'fs';
+
+import { findMainQuickstartConfigFiles } from '../helpers';
+
+const DIR_PATH = path.resolve(__dirname, '../../alert-policies');
+
+/** if a top-level `alert-policies` doesn't exist, create it */
+const setupAlertPolicyDir = () => {
+  if (!fs.existsSync(DIR_PATH)) {
+    fs.mkdirSync(DIR_PATH);
+  }
+};
+
+const main = () => {
+  // find all alerts with alert conditions
+  const quickstartsWithAlerts = findMainQuickstartConfigFiles()
+    .map(path.dirname)
+    .filter((dir) => fs.existsSync(path.join(dir, 'alerts')));
+
+  // make an alert-policy directory for each quickstart
+  // move the alert conditions into the new directory
+  setupAlertPolicyDir();
+  for (const quickstartDirName of quickstartsWithAlerts) {
+    const oldAlertsDir = path.join(quickstartDirName, 'alerts');
+    const newAlertPolicyDir = path.join(DIR_PATH, quickstartDirName);
+    // FIXME: this is not working as intended...
+    fs.cpSync(oldAlertsDir, newAlertPolicyDir, { recursive: true });
+  }
+
+  // remove the `---` from the top / bottom of the condition files
+  // update the quickstart config files to reference the policy
+  // remove the alerts from the quickstart directory
+};
+
+main();

--- a/utils/migration_scripts/move-alerts.ts
+++ b/utils/migration_scripts/move-alerts.ts
@@ -1,5 +1,8 @@
 import * as path from 'path';
 import * as fs from 'fs';
+import * as glob from 'glob';
+
+import { RmDirOptions } from 'fs';
 
 import { findMainQuickstartConfigFiles } from '../helpers';
 
@@ -13,24 +16,61 @@ const setupAlertPolicyDir = () => {
 };
 
 const main = () => {
+  setupAlertPolicyDir();
+
   // find all alerts with alert conditions
   const quickstartsWithAlerts = findMainQuickstartConfigFiles()
     .map(path.dirname)
     .filter((dir) => fs.existsSync(path.join(dir, 'alerts')));
 
   // make an alert-policy directory for each quickstart
-  // move the alert conditions into the new directory
-  setupAlertPolicyDir();
-  for (const quickstartDirName of quickstartsWithAlerts) {
-    const oldAlertsDir = path.join(quickstartDirName, 'alerts');
-    const newAlertPolicyDir = path.join(DIR_PATH, quickstartDirName);
-    // FIXME: this is not working as intended...
+  // copy the alert conditions into the new directory
+  const newAlertPolicyDirs = quickstartsWithAlerts.map((quickstartDirPath) => {
+    const quickstartName = path.basename(quickstartDirPath);
+    const oldAlertsDir = path.join(quickstartDirPath, 'alerts');
+    const newAlertPolicyDir = path.join(DIR_PATH, quickstartName);
+
     fs.cpSync(oldAlertsDir, newAlertPolicyDir, { recursive: true });
-  }
+
+    return newAlertPolicyDir;
+  });
 
   // remove the `---` from the top / bottom of the condition files
-  // update the quickstart config files to reference the policy
-  // remove the alerts from the quickstart directory
+  for (const alertPolicyDir of newAlertPolicyDirs) {
+    for (const filename of fs.readdirSync(alertPolicyDir)) {
+      const filepath = path.join(alertPolicyDir, filename);
+      const fileContent = fs.readFileSync(filepath, { encoding: 'utf8' });
+      const updatedFile = fileContent.replace(/---\n/g, '');
+
+      fs.writeFileSync(filepath, updatedFile, 'utf8');
+    }
+  }
+
+  for (const quickstartDirPath of quickstartsWithAlerts) {
+    // update the quickstart config files to reference the policy
+    const filePaths = glob.sync(path.join('/', quickstartDirPath, 'config.*'));
+
+    if (!Array.isArray(filePaths) || filePaths.length === 0) {
+      return;
+    }
+
+    const configFilePath = filePaths.pop();
+
+    const quickstartName = path.basename(quickstartDirPath);
+    const rawConfig = fs.readFileSync(configFilePath!, { encoding: 'utf-8' });
+    const updatedConfig = rawConfig.concat(
+      '\nalert-policies:\n  - ',
+      quickstartName
+    );
+
+    fs.writeFileSync(configFilePath!, updatedConfig, 'utf-8');
+
+    // remove the alerts from the quickstart directory
+    fs.rmdirSync(path.join('/', quickstartDirPath, 'alerts/'), {
+      recursive: true,
+      force: true,
+    } as RmDirOptions);
+  }
 };
 
 main();


### PR DESCRIPTION
## Description

Creates a script that does the following:

1. Creates a new `alert-policies/` top-level directory
2. Creates a sub-directory for every quickstart _that has at least one alert condition_
3. Updates the quickstart configurations to reference those directories
4. Removes the old `alerts/` directory in each quickstart

This PR is just for the _script_ that updates this stuff. We'll want to move the content when the rest of this epic is complete.

## Related Issue(s)

- NR-14177
