### PR TITLE
chore:Added install plans for ansible quickstart

### DIFF
--- a/install/third-party/ansible/install.yml
+++ b/install/third-party/ansible/install.yml
@@ -1,0 +1,14 @@
+id: third-party-ansible
+name: Ansible
+title: Ansible
+description: 
+  New Relic Ansible playbook to deploy the New Relic Infrastructure agent and On Host Integrations throughout your environment.
+  
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: link
+  destination:
+    url: https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/config-management-tools/configure-new-relic-infrastructure-using-ansible

--- a/quickstarts/observability-as-code/ansible/config.yml
+++ b/quickstarts/observability-as-code/ansible/config.yml
@@ -41,6 +41,8 @@ keywords:
 
 # Reference to install plans located under /install directory
 # Allows us to construct reusable "install plans" and just use their ID in the quickstart config
+installPlans:
+  - third-party-ansible
 documentation:
   - name: Ansible installation docs
     description: |


### PR DESCRIPTION
# Summary

Here for "ansible quickstart" shows See Installation docs , so for that I have added install plans (third-party-ansible) then it can redirect to signup-page before seeing the installation docs. Added "ansible" folder in third-party and also added install plans in ansible config.yml file.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [x] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?




