### PR TITLE
NR-20560 Added install plans for chef

### DIFF
--- a/install/third-party/chef/install.yml
+++ b/install/third-party/chef/install.yml
@@ -1,0 +1,14 @@
+id: third-party-chef
+name: Chef
+title: Chef
+description:
+  New Relic Chef recipe to deploy the New Relic Infrastructure agent and On Host Integrations throughout your environment.
+  
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: link
+  destination:
+    url: https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/config-management-tools/configure-new-relic-infrastructure-using-chef

--- a/quickstarts/observability-as-code/chef/config.yml
+++ b/quickstarts/observability-as-code/chef/config.yml
@@ -39,6 +39,8 @@ keywords:
 
 # Reference to install plans located under /install directory
 # Allows us to construct reusable "install plans" and just use their ID in the quickstart config
+installPlans:
+  - third-party-chef
 documentation:
   - name: Chef installation docs
     description: Chef is a configuration management tool written in Ruby and Erlang.


### PR DESCRIPTION
# Summary
Here for “chef quickstart” shows See Installation docs , so for that I have added install plans (third-party-chef) then it can redirect to signup-page before seeing the installation docs. Added “chef” folder in third-party and also added install plans in chef config.yml file.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [x] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?
