### PR TITLE
chore(Amazon EKS on AWS Fargate): Added install plans

### DIFF
--- a/install/third-party/amazon-eks-on-aws-fargate/install.yml
+++ b/install/third-party/amazon-eks-on-aws-fargate/install.yml
@@ -1,0 +1,15 @@
+id: third-party-amazon-eks-on-aws-fargate
+name: Amazon EKS on AWS Fargate
+title: Amazon EKS on AWS Fargate
+description:
+  Telemetry from Kube State Metrics, Kubelet, and cAdvisor for full
+  observability of Kubernetes clusters running on EKS in Fargate.
+
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: link
+  destination:
+    url: https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/installation/install-fargate-integration/

--- a/quickstarts/aws/amazon-eks-on-aws-fargate/config.yml
+++ b/quickstarts/aws/amazon-eks-on-aws-fargate/config.yml
@@ -23,3 +23,5 @@ keywords:
   - amazon web services
   - kubernetes
   - k8s
+installPlans:
+  - third-party-amazon-eks-on-aws-fargate


### PR DESCRIPTION
# Summary

Here for “Amazon EKS on AWS Fargate quickstart” shows See Installation docs , so for that I have added install plans (third-party-amazon-eks-on-aws-fargate) then it can redirect to signup-page before seeing the installation docs. Added “amazon-eks-on-aws-fargate” folder in third-party and also added install plans in amazon-eks-on-aws-fargate config.yml file.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [x] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?

