### PR TITLE
chore(sagemaker): Added install plans

### DIFF
--- a/install/third-party/sagemaker/install.yml
+++ b/install/third-party/sagemaker/install.yml
@@ -1,0 +1,14 @@
+id: third-party-amazon-sagemaker
+name: Amazon SageMaker
+title: Amazon SageMaker
+description: |
+  Use this integration to quickly monitor your Amazon SageMaker metrics and objects (sent to AWS CloudWatch) and view them as entities and dashboards in New Relic One.
+  
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: link
+  destination:
+    url: https://docs.newrelic.com/docs/mlops/integrations/aws-sagemaker-mlops-integration/

--- a/quickstarts/mlops/sagemaker/config.yml
+++ b/quickstarts/mlops/sagemaker/config.yml
@@ -30,6 +30,8 @@ keywords:
 
 # Reference to install plans located under /install directory
 # Allows us to construct reusable "install plans" and just use their ID in the quickstart config
+installPlans:
+  - third-party-amazon-sagemaker
 
 documentation:
   - name: Sagemaker Docs


### PR DESCRIPTION
# Summary

Here for “amazon-sagemaker quickstart” shows See Installation docs , so for that I have added install plans (third-party-amazon-sagemaker) then it can redirect to signup-page before seeing the installation docs. Added “sagemaker” folder in third-party and also added install plans in sagemaker config.yml file.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [x] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?

