### PR TITLE
chore(apigee api): Added install plans

### DIFF
--- a/install/third-party/apigee-api/install.yml
+++ b/install/third-party/apigee-api/install.yml
@@ -1,0 +1,15 @@
+id: third-party-apigee-api
+name: Apigee API Distributed Tracing
+title: Apigee API Distributed Tracing
+description: |
+  Monitor Apigee API Flows with New Relic's Trace API.
+
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: link
+  destination:
+    url: https://github.com/newrelic-experimental/apigee-distributed-tracing
+

--- a/quickstarts/gcp/apigee-api/config.yml
+++ b/quickstarts/gcp/apigee-api/config.yml
@@ -28,3 +28,6 @@ documentation:
     description: |
       Installation and configuration instructions
     url: https://github.com/newrelic-experimental/apigee-distributed-tracing
+
+installPlans:
+  - third-party-apigee-api    


### PR DESCRIPTION
# Summary

Here for “Apigee API quickstart” shows See Installation docs , so for that I have added install plans (third-party-apigee-api) then it can redirect to signup-page before seeing the installation docs. Added “apigee-api” folder in third-party and also added install plans in apigee-api config.yml file.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [x] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?

