### PR TITLE
chore(AWS-Cloudwatch-plugin-for-Logs): Added install plans for AWS Cloudwatch plugin for Logs

### DIFF
--- a/install/third-party/aws-cloudwatch-plugin-for-logs/install.yml
+++ b/install/third-party/aws-cloudwatch-plugin-for-logs/install.yml
@@ -1,0 +1,14 @@
+id: third-party-aws-cloudwatch-plugin-for-logs
+name: AWS Cloudwatch plugin for Logs
+title: AWS Cloudwatch plugin for Logs
+description: 
+  Collect and manage log data coming in from Amazon's Cloudwatch observability framework.
+  
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: link
+  destination:
+    url:  https://docs.newrelic.com/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/aws-lambda-sending-cloudwatch-logs/

--- a/quickstarts/aws/aws-cloudwatch-plugin-for-logs/config.yml
+++ b/quickstarts/aws/aws-cloudwatch-plugin-for-logs/config.yml
@@ -7,6 +7,8 @@ icon: logo.svg
 level: New Relic
 authors:
   - New Relic
+installPlans:
+  - third-party-aws-cloudwatch-plugin-for-logs
 documentation:
   - name: AWS Cloudwatch plugin for Logs
     description: Collect and manage log data coming in from Amazon's Cloudwatch observability framework.


### PR DESCRIPTION
# Summary
Here for “AWS Cloudwatch plugin for Logs quickstart” shows See Installation docs , so for that I have added install plans (third-party-aws-cloudwatch-plugin-for-logs) then it can redirect to signup-page before seeing the installation docs. Added “aws-cloudwatch-plugin-for-logs” folder in third-party and also added install plans in aws-cloudwatch-plugin-for-logs config.yml file.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [x] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?
