### PR TITLE
refactor(Atlassian-jira-for-errors-inbox): Added install plans for Atlassian jira for errors inbox

### DIFF
--- a/install/third-party/jira-errors/install.yml
+++ b/install/third-party/jira-errors/install.yml
@@ -1,0 +1,14 @@
+id: third-party-jira-errors-inbox
+name: Atlassian Jira for Errors Inbox
+title: Atlassian Jira for Errors Inbox
+description: 
+  Integrated errors inbox with Atlassian Jira (cloud) to easily create tickets for your errors.
+  
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: link
+  destination:
+    url: https://docs.newrelic.com/docs/errors-inbox/errors-inbox/#jira

--- a/quickstarts/jira-errors/config.yml
+++ b/quickstarts/jira-errors/config.yml
@@ -32,7 +32,8 @@ keywords:
 
 # Reference to install plans located under /install directory
 # Allows us to construct reusable "install plans" and just use their ID in the quickstart config
-
+installPlans:
+  - third-party-jira-errors-inbox
 documentation:
   - name: How to Docs
     url: https://docs.newrelic.com/docs/errors-inbox/errors-inbox/#jira


### PR DESCRIPTION
# Summary
Here for “Atlassian jira for errors inbox quickstart” shows See Installation docs , so for that I have added install plans (third-party-jira-errors-inbox) then it can redirect to signup-page before seeing the installation docs. Added “jira-errors” folder in third-party and also added install plans in jira-errors config.yml file.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [x] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?
