### PR TITLE
Added install plans to Google Publisher Tags

### DIFF
--- a/install/third-party/ads-web-gpt/install.yml
+++ b/install/third-party/ads-web-gpt/install.yml
@@ -1,0 +1,13 @@
+id: third-party-ads-web-gpt
+name: Agent for Google Publisher Tags
+title: Agent for Google Publisher Tags
+description: |
+  Agent to monitor web applications using GPT.
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: link
+  destination:
+    url: https://github.com/newrelic/tracker-google-publisher-tags-js

--- a/quickstarts/ads/web/ads-web-gpt/config.yml
+++ b/quickstarts/ads/web/ads-web-gpt/config.yml
@@ -12,6 +12,8 @@ keywords:
   - ads
   - tracking
   - GPT
+installPlans:
+  - third-party-ads-web-gpt
 documentation:
   - name: GPT agent Installation Docs
     url: https://github.com/newrelic/tracker-google-publisher-tags-js


### PR DESCRIPTION
# Summary

Here for “Google Publisher Tags inbox quickstart” shows See Installation docs , so for that I have added install plans (third-party-ads-web-gpt) then it can redirect to signup-page before seeing the installation docs. Added “ads-web-gpt” folder in third-party and also added install plans in ads-web-gpt config.yml file.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [x] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?

