### PR TITLE
Added install plans for CollectD

### DIFF
--- a/install/third-party/collectd/install.yml
+++ b/install/third-party/collectd/install.yml
@@ -1,0 +1,13 @@
+id: third-party-collectd
+name: Collectd
+title: Collectd
+description: |
+  Get CollectD data into New Relic.
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: link
+  destination:
+    url: https://docs.newrelic.com/docs/integrations/host-integrations/open-source-host-integrations-list/collectd-open-source-integration

--- a/quickstarts/collectd/config.yml
+++ b/quickstarts/collectd/config.yml
@@ -23,6 +23,8 @@ documentation:
       and network infrastructure.
     url: >-
       https://docs.newrelic.com/docs/integrations/host-integrations/open-source-host-integrations-list/collectd-open-source-integration
+installPlans:
+  - third-party-collectd     
 keywords:
   - infrastructure
   - open source monitoring


### PR DESCRIPTION
# Summary

Here for “CollectD quickstart” shows See Installation docs , so for that I have added install plans (third-party-collectd) then it can redirect to signup-page before seeing the installation docs. Added “collectd” folder in third-party and also added install plans in collectd config.yml file.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [x] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?


