### PR TITLE
Added install plans for Video agent for Chromecast

### DIFF
--- a/install/third-party/video-chromecast/install.yml
+++ b/install/third-party/video-chromecast/install.yml
@@ -1,0 +1,14 @@
+id: third-party-video-chromecast
+name: Video agent for Chromecast
+title: Video agent for Chromecast
+description: |
+  Agent to monitor video applications for Chromecast devices.
+
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: link
+  destination:
+    url: https://github.com/newrelic/video-caf-js

--- a/quickstarts/video/video-chromecast/config.yml
+++ b/quickstarts/video/video-chromecast/config.yml
@@ -17,3 +17,5 @@ documentation:
     url: https://github.com/newrelic/video-caf-js
     description: Agent to monitor video applications for Chromecast.
 icon: logo.svg
+installPlans:
+  - third-party-video-chromecast


### PR DESCRIPTION
# Summary


Here for “Video agent for Chromecast quickstart” shows See Installation docs , so for that I have added install plans (third-party-video-chromecast) then it can redirect to signup-page before seeing the installation docs. Added “video-chromecast” folder in third-party and also added install plans in video-chromecast config.yml file.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [x] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?


