### PR TITLE
Change generate-schema-docs script back to .js extension

### DIFF
--- a/utils/package.json
+++ b/utils/package.json
@@ -17,7 +17,7 @@
     "validate-icons": "ts-node validate_icons.ts",
     "generate-uuids": "ts-node generate-uuids.ts",
     "sanitize-dashboard": "ts-node sanitize_dashboards.ts",
-    "generate-schema-docs": "ts-node graphql-schemas/generate-schema-docs.ts",
+    "generate-schema-docs": "ts-node graphql-schemas/generate-schema-docs.js",
     "preview": "ts-node preview.ts",
     "create-preview-links": "ts-node create-preview-links.ts"
   },


### PR DESCRIPTION
# Summary

Mistakenly changed this script to run .ts converted back to .js extension