### PR TITLE
refactor(Inet-oracle-driver): Added install plans for inet oracle driver

### DIFF
--- a/install/third-party/inet-oracle-driver/install.yml
+++ b/install/third-party/inet-oracle-driver/install.yml
@@ -1,0 +1,14 @@
+id: third-party-inet-oracle-driver
+name: Inet Oracle Driver (oranxo)
+title: Inet Oracle Driver (oranxo)
+description: 
+  Java driver built by Inet for managing Oracle database servers.  
+
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: link
+  destination:
+    url: https://docs.newrelic.com/docs/agents/java-agent/getting-started/compatibility-requirements-java-agent

--- a/quickstarts/oracle/inet-oracle-driver/config.yml
+++ b/quickstarts/oracle/inet-oracle-driver/config.yml
@@ -7,6 +7,8 @@ level: New Relic
 authors:
   - New Relic
 title: Inet Oracle Driver (oranxo)
+install plans:
+  -third-party-inet-oracle-driver
 documentation:
   - name: Inet Oracle Driver (oranxo) installation docs
     description: Java driver built by Inet for managing Oracle database servers.


### PR DESCRIPTION
# Summary
Here for “Inet-oracle-driver (oranxo) quickstart” shows See Installation docs , so for that I have added install plans (third-party-inet-oracle-driver) then it can redirect to signup-page before seeing the installation docs. Added “ inet-oracle-driver” folder in third-party and also added install plans in inet-oracle-driver config.yml file.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [x] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?
