### PR TITLE
Added Installplans for victorops

### DIFF
--- a/install/third-party/victorops/install.yml
+++ b/install/third-party/victorops/install.yml
@@ -5,7 +5,6 @@ description: |
     Get notified via VictorOps when incidents are opened, acknowledged, or closed.
     Notifications can include charts about the incident.
 
-
 target:
   type: integration
   destination: cloud

--- a/install/third-party/victorops/install.yml
+++ b/install/third-party/victorops/install.yml
@@ -1,0 +1,16 @@
+id: third-party-victorops
+name: VictorOps
+title: VictorOps
+description: |
+    Get notified via VictorOps when incidents are opened, acknowledged, or closed.
+    Notifications can include charts about the incident.
+
+
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: link
+  destination:
+    url: https://docs.newrelic.com/docs/alerts/new-relic-alerts/managing-notification-channels/notification-channels-control-where-send-alerts

--- a/quickstarts/victorops/config.yml
+++ b/quickstarts/victorops/config.yml
@@ -36,3 +36,6 @@ keywords:
   - support
   - site reliability
   - SRE
+
+installPlans:
+  - third-party-victorops


### PR DESCRIPTION
# Summary

Here for “victorops quickstart” shows See Installation docs , so for that I have added install plans (third-party-victorops) then it can redirect to signup-page before seeing the installation docs. Added “victorops” folder in third-party and also added install plans in victorops config.yml file.

 
<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [x] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?


