### PR TITLE
Added install plans for Unix

### DIFF
--- a/install/third-party/unix/install.yml
+++ b/install/third-party/unix/install.yml
@@ -1,0 +1,15 @@
+id: third-party-unix
+name: Unix
+title: Unix
+description: |
+  The Unix monitoring integration allows for system-level monitoring of AIX,
+  Linux, macOS, Solaris/SunOS and other Unix-based servers.
+
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: link
+  destination:
+    url: https://docs.newrelic.com/docs/integrations/host-integrations/open-source-host-integrations-list/unix-monitoring-open-source-integration

--- a/quickstarts/unix/config.yml
+++ b/quickstarts/unix/config.yml
@@ -18,6 +18,8 @@ documentation:
       Linux, macOS, Solaris/SunOS and other Unix-based servers.
     url: >-
       https://docs.newrelic.com/docs/integrations/host-integrations/open-source-host-integrations-list/unix-monitoring-open-source-integration
+installPlans:
+  - third-party-unix     
 keywords:
   - os
   - operating system


### PR DESCRIPTION
# Summary

Here for “Unix quickstart” shows See Installation docs , so for that I have added install plans (third-party-unix) then it can redirect to signup-page before seeing the installation docs. Added “unix” folder in third-party and also added install plans in unix config.yml file.


<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [x] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?

