### PR TITLE
Added install plans for Trace and Span API

### DIFF
--- a/install/third-party/trace/install.yml
+++ b/install/third-party/trace/install.yml
@@ -1,0 +1,14 @@
+id: third-party-trace-and-span-api
+name: Trace and Span API
+title: Trace and Span API
+description: |
+    Our Trace API is used to send distributed tracing data to New Relic: either in our own generic format or the Zipkin data format. This API is also how trace data from some of our integrations and exporters is reported to New Relic.
+
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: link
+  destination:
+    url: https://docs.newrelic.com/docs/distributed-tracing/trace-api/introduction-trace-api/

--- a/quickstarts/apis/trace/config.yml
+++ b/quickstarts/apis/trace/config.yml
@@ -15,7 +15,8 @@ documentation:
       Our Trace API is used to send distributed tracing data to New Relic: either in our own generic format or the Zipkin data format. This API is also how trace data from some of our integrations and exporters is reported to New Relic.
     url: >-
       https://docs.newrelic.com/docs/distributed-tracing/trace-api/introduction-trace-api/
-
+installPlans:
+  - third-party-trace-and-span-api
 keywords:
   - tracing
   - span


### PR DESCRIPTION
# Summary


Here for Trace and Span API quickstart” shows See Installation docs , so for that I have added install plans (third-party-trace-and-span-api) then it can redirect to signup-page before seeing the installation docs. Added “trace” folder in third-party and also added install plans in trace config.yml file.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [x] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?


