### PR TITLE
Added install plans for Synthetics User Flow check

### DIFF
--- a/install/third-party/user-flow/install.yml
+++ b/install/third-party/user-flow/install.yml
@@ -1,0 +1,14 @@
+id: third-party-synthetics-user-flow
+name: Synthetics User Flow check
+title: Synthetics User Flow check
+description: |
+    Develop your own customised Synthetics check with a fully scriptable browser test.
+
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: link
+  destination:
+    url: https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/getting-started/get-started-synthetic-monitoring/

--- a/quickstarts/synthetics/user-flow/config.yml
+++ b/quickstarts/synthetics/user-flow/config.yml
@@ -41,6 +41,9 @@ documentation:
     url: https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/getting-started/get-started-synthetic-monitoring/
     description: Get started with synthetic monitoring
 
+installPlans:
+  - third-party-synthetics-user-flow
+
 # Content / Design
 icon: logo.svg
 website: https://www.newrelic.com


### PR DESCRIPTION
# Summary

Here for “Synthetics User Flow check quickstart” shows See Installation docs , so for that I have added install plans (third-party-synthetics-user-flow) then it can redirect to signup-page before seeing the installation docs. Added “user-flow” folder in third-party and also added install plans in user-flow config.yml file.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [x] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?


