### PR TITLE
Added install plans for Alert Quality Management

### DIFF
--- a/install/third-party/oma-aqm/install.yml
+++ b/install/third-party/oma-aqm/install.yml
@@ -1,0 +1,14 @@
+id: third-party-alert-quality-management
+name: Alert Quality Management
+title: Alert Quality Management
+description: |
+  Reduce the volume of nuisance incidents with the Alert Quality Management dashboard and process.
+
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: link
+  destination:
+    url: https://docs.newrelic.com/docs/new-relic-solutions/observability-maturity/uptime-performance-reliability/aqm-implementation-guide/

--- a/quickstarts/oma-aqm/config.yml
+++ b/quickstarts/oma-aqm/config.yml
@@ -34,6 +34,9 @@ documentation:
     description: |
       The implementation guide will show you how to implement the AQM process, including the webhook required to generate the data that feeds this dashboard.
 
+installPlans:
+  - third-party-alert-quality-management
+
 # Content / Design
 icon: logo.svg
 website: https://www.newrelic.com


### PR DESCRIPTION
# Summary

Here for “Alert Quality Management quickstart” shows See Installation docs , so for that I have added install plans (third-party-alert-quality-management) then it can redirect to signup-page before seeing the installation docs. Added “oma-aqm” folder in third-party and also added install plans in oma-aqm config.yml file.


<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [x] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?


