### PR TITLE
Added install plans for Customer Experience Bottom of the funnel analysis

### DIFF
--- a/install/third-party/oma-bofu/install.yml
+++ b/install/third-party/oma-bofu/install.yml
@@ -1,0 +1,14 @@
+id: third-party-oma-bofu
+name: Customer Experience Bottom of the funnel analysis 
+title: Customer Experience Bottom of the funnel analysis 
+description: |
+  Use cart abandonment reduction techniques to improve completion rates of any user journey 
+
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: link
+  destination:
+    url: https://docs.newrelic.com/docs/new-relic-solutions/observability-maturity/customer-experience/bottom-funnel-analysis-customer-journey-guide

--- a/install/third-party/oma-bofu/install.yml
+++ b/install/third-party/oma-bofu/install.yml
@@ -1,4 +1,4 @@
-id: third-party-oma-bofu
+id: third-party-customer-experience-bottom-funnel-analysis
 name: Customer Experience Bottom of the funnel analysis 
 title: Customer Experience Bottom of the funnel analysis 
 description: |

--- a/quickstarts/oma-bofu/config.yml
+++ b/quickstarts/oma-bofu/config.yml
@@ -48,7 +48,7 @@ documentation:
     url: https://docs.newrelic.com/docs/new-relic-solutions/observability-maturity/customer-experience/bottom-funnel-analysis-customer-journey-guide
 
 installPlans:
-  - third-party-oma-bofu
+  - third-party-customer-experience-bottom-funnel-analysis
   
 # Content / Design
 icon: logo.svg

--- a/quickstarts/oma-bofu/config.yml
+++ b/quickstarts/oma-bofu/config.yml
@@ -47,6 +47,9 @@ documentation:
       Explains what bottom of the funnel analysis is and how to apply it
     url: https://docs.newrelic.com/docs/new-relic-solutions/observability-maturity/customer-experience/bottom-funnel-analysis-customer-journey-guide
 
+installPlans:
+  - third-party-oma-bofu
+  
 # Content / Design
 icon: logo.svg
 website: https://www.newrelic.com


### PR DESCRIPTION
# Summary

Here for “Customer Experience Bottom of the funnel analysis quickstart” shows See Installation docs , so for that I have added install plans (third-party-oma-bofu) then it can redirect to signup-page before seeing the installation docs. Added “oma-bofu” folder in third-party and also added install plans in oma-bofu config.yml file.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [x] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?

