### PR TITLE
refactor(Teams-cs): Added install plans for microsoft teams for codestream

### DIFF
--- a/install/third-party/teams-cs/install.yml
+++ b/install/third-party/teams-cs/install.yml
@@ -1,0 +1,14 @@
+id: third-party-microsoft-teams-for-codestream
+name: Microsoft Teams for CodeStream
+title: Microsoft Teams for CodeStream
+description: |
+  Guide to help you get set up using New Relic's Microsoft Teams for CodeStream.  
+  
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: link
+  destination:
+    url: https://docs.newrelic.com/docs/codestream/codestream-integrations/msteams-integration/

--- a/quickstarts/codestream/teams-cs/config.yml
+++ b/quickstarts/codestream/teams-cs/config.yml
@@ -23,6 +23,9 @@ keywords:
   - microsoft
   - teams
 
+installPlans:
+  - third-party-microsoft-teams-for-codestream
+
 documentation:
   - name: Teams for CodeStream integration docs
     url: https://docs.newrelic.com/docs/codestream/codestream-integrations/msteams-integration/


### PR DESCRIPTION
# Summary
Here for “Microsoft teams for codestream quickstart” shows See Installation docs , so for that I have added install plans (third-party-microsoft-teams-for-codestream) then it can redirect to signup-page before seeing the installation docs. Added “ teams-cs” folder in third-party and also added install plans in teams-cs config.yml file.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [x] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?
