### PR TITLE
refactor(Camel): Added install plans for apache camel java agent extension

### DIFF
--- a/install/third-party/camel/install.yml
+++ b/install/third-party/camel/install.yml
@@ -1,0 +1,15 @@
+id: third-party-camel
+name: Apache Camel Java Agent Extension
+title: Apache Camel Java Agent Extension
+description: |
+  Java agent extension to monitor instrumentation for the Apache Camel framework.
+  Once installed, the instrumentation will enable visibility parts of your Camel flows up in transaction traces.
+  
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: link
+  destination:
+    url: https://github.com/newrelic-experimental/newrelic-java-camel

--- a/quickstarts/java/camel/config.yml
+++ b/quickstarts/java/camel/config.yml
@@ -29,6 +29,9 @@ keywords:
 authors:
   - New Relic Labs
 
+installPlans:
+  - third-party-camel
+
 documentation:
   - name: Java agent extension for Camel
     description: |

--- a/quickstarts/java/camel/config.yml
+++ b/quickstarts/java/camel/config.yml
@@ -31,7 +31,6 @@ authors:
 
 installPlans:
   - third-party-camel
-
 documentation:
   - name: Java agent extension for Camel
     description: |


### PR DESCRIPTION
# Summary
Here for “Apache Camel java agent extension quickstart” shows See Installation docs , so for that I have added install plans (third-party-camel) then it can redirect to signup-page before seeing the installation docs. Added “ camel” folder in third-party and also added install plans in camel config.yml file.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [x] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?
