### PR TITLE
refactor(Video-android): Added install plans for video agent for android

### DIFF
--- a/install/third-party/video-android/install.yml
+++ b/install/third-party/video-android/install.yml
@@ -1,0 +1,14 @@
+id: third-party-video-android
+name: Video agent for Android
+title: Video agent for Android
+description:
+  Agent to monitor video applications for Android.
+  
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: link
+  destination:
+    url: https://github.com/newrelic/video-agent-android

--- a/quickstarts/video/video-android/config.yml
+++ b/quickstarts/video/video-android/config.yml
@@ -12,6 +12,8 @@ keywords:
   - video
   - tracking
   - Android
+installPlans:
+  - third-party-video-android
 documentation:
   - name: Video Android. Installation Docs
     url: https://github.com/newrelic/video-agent-android


### PR DESCRIPTION
# Summary
Here for “Video agent for android quickstart” shows See Installation docs , so for that I have added install plans (third-party-video-android) then it can redirect to signup-page before seeing the installation docs. Added “video-android” folder in third-party and also added install plans in video-android config.yml file.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [x] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?
