### PR TITLE
refactor(Split): Added install plans for split

### DIFF
--- a/install/third-party/split/install.yml
+++ b/install/third-party/split/install.yml
@@ -1,0 +1,15 @@
+id: third-party-split
+name: Split
+title: Split
+description: |
+  A feature delivery platform that powers feature flag management, software
+  experimentation, and continuous delivery.
+  
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: link
+  destination:
+    url: https://www.split.io/blog/querying-split-impressions-in-new-relic-for-more-insight-into-your-metrics/

--- a/quickstarts/split/config.yml
+++ b/quickstarts/split/config.yml
@@ -11,6 +11,8 @@ level: Community
 authors:
   - Split
 title: Split
+installPlans:
+  - third-party-split
 documentation:
   - name: Split installation docs
     description: |


### PR DESCRIPTION
# Summary
Here for “Split quickstart” shows See Installation docs , so for that I have added install plans (third-party-split) then it can redirect to signup-page before seeing the installation docs. Added “split” folder in third-party and also added install plans in split config.yml file.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [x] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?
