### PR TITLE
refactor(SIGNL4): Added install plans for signl4

### DIFF
--- a/install/third-party/signl4/install.yml
+++ b/install/third-party/signl4/install.yml
@@ -1,0 +1,15 @@
+id: third-party-signl4
+name: SIGNL4
+title: SIGNL4
+description: |
+  Mobile alerting SaaS that bridges the last mile from IT systems, machines, and
+  sensors to engineers, IT staff and workers in the field.
+  
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: link
+  destination:
+    url: https://www.signl4.com/blog/portfolio_item/new_relic_mobile_alerting/

--- a/quickstarts/signl4/config.yml
+++ b/quickstarts/signl4/config.yml
@@ -11,6 +11,8 @@ level: Community
 authors:
   - Signl4
 title: SIGNL4
+installPlans: 
+  - third-party-signl4
 documentation:
   - name: SIGNL4 installation docs
     description: |


### PR DESCRIPTION
# Summary
Here for “SIGNL4 quickstart” shows See Installation docs , so for that I have added install plans (third-party-signl4) then it can redirect to signup-page before seeing the installation docs. Added “signl4” folder in third-party and also added install plans in signl4 config.yml file.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [x] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?
