### PR TITLE
Added install plans for New Relic CLI

### DIFF
--- a/install/third-party/cli/install.yml
+++ b/install/third-party/cli/install.yml
@@ -1,0 +1,14 @@
+id: third-party-newrelic-cli
+name: New Relic CLI
+title: New Relic CLI
+description: |
+  Access the New Relic platform from the comfort of your terminal. You can use the New Relic CLI to manage entity tags, define workloads, record deployment markers, and much more. In short, you can use the CLI to automate common tasks in your DevOps workflow.
+
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: link
+  destination:
+    url: https://developer.newrelic.com/automate-workflows/get-started-new-relic-cli/

--- a/quickstarts/observability-as-code/cli/config.yml
+++ b/quickstarts/observability-as-code/cli/config.yml
@@ -21,5 +21,8 @@ documentation:
     url: >-
       https://developer.newrelic.com/automate-workflows/get-started-new-relic-cli/
 
+installPlans:
+  - third-party-newrelic-cli
+
 keywords:
   - automation


### PR DESCRIPTION
# Summary

Here for “New Relic CLI quickstart” shows See Installation docs , so for that I have added install plans (third-party-cli) then it can redirect to signup-page before seeing the installation docs. Added “cli” folder in third-party and also added install plans in cli config.yml file.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [x] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?


