### PR TITLE
Added install plans for Pulumi

### DIFF
--- a/install/third-party/pulumi/install.yml
+++ b/install/third-party/pulumi/install.yml
@@ -1,0 +1,14 @@
+id: third-party-pulumi
+name: Pulumi
+title: Pulumi
+description: |
+    Pulumi is a popular infrastructure-as-code software tool.
+    You use it to provision all kinds of infrastructure and services, including New Relic entities, dashboard, alerts and synthetics.
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: link
+  destination:
+    url: https://www.pulumi.com/registry/packages/newrelic/

--- a/quickstarts/observability-as-code/pulumi/config.yml
+++ b/quickstarts/observability-as-code/pulumi/config.yml
@@ -37,6 +37,8 @@ keywords:
 
 # Reference to install plans located under /install directory
 # Allows us to construct reusable "install plans" and just use their ID in the quickstart config
+installPlans:
+  - third-party-pulumi
 documentation:
   - name: Getting started with New Relic and Pulumi
     description: |


### PR DESCRIPTION
# Summary

Here for “Pulumi quickstart” shows See Installation docs , so for that I have added install plans (third-party-pulumi) then it can redirect to signup-page before seeing the installation docs. Added “pulumi” folder in third-party and also added install plans in pulumi config.yml file.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you check your dashboard image quality? -  Do they look good?
- [ ] Did you check that your alerts actually work?
- [x] Did you include an InstallPlan and Documentation reference?
- [ ] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [ ] Did you attach images of your dashboards to the PR so we can see them working?


