### PR TITLE
fix: Rename dashboards for better search behavior

### DIFF
--- a/quickstarts/oma-data-gov/dashboards/data-ingest-baseline/data-ingest-baseline.json
+++ b/quickstarts/oma-data-gov/dashboards/data-ingest-baseline/data-ingest-baseline.json
@@ -1,5 +1,5 @@
 {
-    "name": "Data Governance Baseline",
+    "name": "Data Ingest Governance Baseline",
     "description": null,
     "pages": [
       {

--- a/quickstarts/oma-data-gov/dashboards/data-ingest-entity-breakdown/data-ingest-entity-breakdown.json
+++ b/quickstarts/oma-data-gov/dashboards/data-ingest-entity-breakdown/data-ingest-entity-breakdown.json
@@ -1,5 +1,5 @@
 {
-    "name": "Data Governance Entity Breakdowns",
+    "name": "Data Ingest Governance Entity Breakdowns",
     "description": null,
     "pages": [
       {


### PR DESCRIPTION
# Summary

In the master dashboards list I would like these dashboards to show up when the user types in either the words "ingest" or "data ingest".
