### PR TITLE
fix: move input into env variables

### DIFF
--- a/.github/workflows/preview-links.yml
+++ b/.github/workflows/preview-links.yml
@@ -11,6 +11,7 @@ defaults:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  PR_NUMBER: ${{ github.event.pull_request.number }}
 
 jobs:
   generate:
@@ -29,10 +30,14 @@ jobs:
 
       - name: Create preview links
         id: links
+        env:
+          PR_URL: ${{ github.event.pull_request.url }}
         run: |
-          yarn create-preview-links ${{ github.event.pull_request.url }} ${{ github.event.pull_request.number }}
+          yarn create-preview-links "$PR_URL" "$PR_NUMBER"
 
       - name: Comment 
         if: steps.links.outputs.comment != ''
+        env:
+          COMMENT: ${{ steps.links.outputs.comment }}
         run: |
-          gh pr comment ${{github.event.pull_request.number}} --body ${{ steps.links.outputs.comment }}
+          gh pr comment "$PR_NUMBER" --body "$COMMENT"


### PR DESCRIPTION
# Summary
* Moves the pull request url, pull request number, and generated comment into environment variables to prevent command injection

