### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Contribute your own quickstart to the New Relic One catalog by following the ste
       - `rabbitmq01.png`
       - `rabbitmq02.png`
 
-- The `images` folder should contain images you want to display within a markdown widget on your Dashboard. An example of this would be the [Python quickstart](https://github.com/newrelic/newrelic-quickstarts/blob/main/quickstarts/python/python/dashboards/python.png) which includes image widgets defined using markdown. For more information on this see our docs on [creating widgets containing markdown text](https://docs.newrelic.com/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard/#markdown)
+- The `images` folder should contain images you want to display within a markdown widget on your Dashboard. An example of this would be the [Python quickstart](https://github.com/newrelic/newrelic-quickstarts/blob/main/quickstarts/python/python/dashboards/python/python.png) which includes image widgets defined using markdown. For more information on this see our docs on [creating widgets containing markdown text](https://docs.newrelic.com/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard/#markdown)
 
 - When adding alerts to your quickstart, [using NerdGraph](https://developer.newrelic.com/contribute-to-quickstarts/query-alerts-for-quickstart/) can assist you with adding existing alert configurations to your yaml files.
 


### PR DESCRIPTION
# Summary

Reading through the Quickstart docs I noticed the `Python quickstart` link led to a 404. So now the change leads it to new-relic-quickstarts/quickstarts/python/python/dashboards/python/python.png which are the images later described.

<img width="1446" alt="Screen Shot 2022-06-15 at 10 23 50 AM" src="https://user-images.githubusercontent.com/57972448/173888177-efff6220-cde8-4c77-b6b5-672f7bd8926e.png">
<img width="1446" alt="Screen Shot 2022-06-15 at 10 27 36 AM" src="https://user-images.githubusercontent.com/57972448/173888851-0842c37f-ad01-49bf-8629-ee302ff85530.png">

