### PR TITLE
chore: preview-links only triggered on PR open

### DIFF
--- a/.github/workflows/preview-links.yml
+++ b/.github/workflows/preview-links.yml
@@ -4,6 +4,7 @@ on:
   pull_request_target:
     branches:
       - main
+    types: [opened]
 
 defaults:
   run:
@@ -35,7 +36,7 @@ jobs:
         run: |
           yarn create-preview-links "$PR_URL" "$PR_NUMBER"
 
-      - name: Comment 
+      - name: Comment
         if: steps.links.outputs.comment != ''
         env:
           COMMENT: ${{ steps.links.outputs.comment }}


### PR DESCRIPTION
# Summary

[This workflow](https://github.com/newrelic/newrelic-quickstarts/blob/31fa6aca5762ff00cb496ec2e589186a784715ea/.github/workflows/pr-open.yml#L7) only runs once when a PR is created, so I think this is all we need for this change.