### PR TITLE
Update error handling for Quickstart class

### DIFF
--- a/utils/lib/Quickstart.ts
+++ b/utils/lib/Quickstart.ts
@@ -98,7 +98,7 @@ class Quickstart {
 
       return yaml.load(file.toString('utf-8')) as QuickstartConfig;
     } catch (e) {
-      console.error('Unable to parse quickstart config', this.configPath, e);
+      console.error(`Unable to parse quickstart config at ${this.configPath}`);
       this.isValid = false;
 
       return this.config;

--- a/utils/preview.ts
+++ b/utils/preview.ts
@@ -40,7 +40,7 @@ const validateArgs = (identifier: string, configFile: string) => {
 
   if (!quickstart.isValid) {
     console.error(
-      `Could not find a config.yml or config.yaml for ${identifier}.`
+      `\n*** Could not find a config.yml or config.yaml for ${identifier}***\n`
     );
     process.exit(1);
   }


### PR DESCRIPTION
### Summary
Small update to quickstart class to help for cleaner error parsing.

This came up with fixing a bug in local quickstart preview

#### Before
```bash
jgregory$ yarn preview dotnet
yarn run v1.22.19
$ ts-node preview.ts dotnet
Unable to parse quickstart config /Users/jgregory/Developer/newrelic-external/newrelic-quickstarts/quickstarts/dotnet/ Error: EISDIR: illegal operation on a directory, read
    at Object.readSync (node:fs:727:3)
    at tryReadSync (node:fs:433:20)
    at Object.readFileSync (node:fs:479:19)
    at Quickstart.getConfigContent (/Users/jgregory/Developer/newrelic-external/newrelic-quickstarts/utils/lib/Quickstart.ts:97:31)
    at new Quickstart (/Users/jgregory/Developer/newrelic-external/newrelic-quickstarts/utils/lib/Quickstart.ts:76:24)
    at validateArgs (/Users/jgregory/Developer/newrelic-external/newrelic-quickstarts/utils/preview.ts:36:22)
    at /Users/jgregory/Developer/newrelic-external/newrelic-quickstarts/utils/preview.ts:76:3
    at Generator.next (<anonymous>)
    at /Users/jgregory/Developer/newrelic-external/newrelic-quickstarts/utils/preview.ts:8:71
    at new Promise (<anonymous>) {
  errno: -21,
  syscall: 'read',
  code: 'EISDIR'
}
Could not find a config.yml or config.yaml for dotnet.
error Command failed with exit code 1.
```

#### After
```bash
jgregory$ yarn preview dotnet
yarn run v1.22.19
$ ts-node preview.ts dotnet
Unable to parse quickstart config at /Users/jgregory/Developer/newrelic-external/newrelic-quickstarts/quickstarts/dotnet/

*** Could not find a config.yml or config.yaml for dotnet***

error Command failed with exit code 1.
```