### PR TITLE
Fix quickstart submission logic

### DIFF
--- a/utils/create_validate_pr_quickstarts.ts
+++ b/utils/create_validate_pr_quickstarts.ts
@@ -56,7 +56,7 @@ const main = async () => {
   const invalidQuickstarts = quickstarts
     .map((qs) => {
       qs.validate();
-      return (qs.isValid ? qs : undefined);
+      return !qs.isValid ? qs : undefined;
     })
     .filter(Boolean);
 


### PR DESCRIPTION
# Summary

The check for invalid components was adding valid quickstarts to the array of invalid ones, this reverses that logic to work as we expected.
