### PR TITLE
Add keywords for Node.js

### DIFF
--- a/quickstarts/node-js/node-js/config.yml
+++ b/quickstarts/node-js/node-js/config.yml
@@ -41,6 +41,8 @@ documentation:
 keywords:
   - apm
   - node.js
+  - nodejs
+  - node
   - language agent
   - most popular
 


### PR DESCRIPTION
# Summary

Adds some more variations of `node.js` to the Node.js quickstart keyword list to improve search results.
