### PR TITLE
fix: [mssql-queryplan] remove reference to custom visualization

### DIFF
--- a/dashboards/mssql-queryplan/mssql-queryplan.json
+++ b/dashboards/mssql-queryplan/mssql-queryplan.json
@@ -566,23 +566,6 @@
               ]
             },
             "linkedEntityGuids": null
-          },
-          {
-            "visualization": {
-              "id": "81c7560f-ef3d-47bc-a2a4-71bc3da680e1.sql-plans"
-            },
-            "layout": {
-              "column": 1,
-              "row": 13,
-              "height": 5,
-              "width": 12
-            },
-            "title": "SQL Query Plans",
-            "rawConfiguration": {
-              "accountId": 0,
-              "compactDetails": false
-            },
-            "linkedEntityGuids": null
           }
         ]
       }


### PR DESCRIPTION
# Summary

As the referenced custom viz requires manual deploy, this widget was causing a 404 error.
