### PR TITLE
chore: Re-enable CLI install for Postgres, RabbitMQ, MongoDB, Consul

### DIFF
--- a/install/on-host-integration/hashicorp-consul/install.yml
+++ b/install/on-host-integration/hashicorp-consul/install.yml
@@ -11,6 +11,11 @@ target:
   destination: host
 
 install:
+  mode: targetedInstall
+  destination:
+    recipeName: hashicorp-consul-open-source-integration
+
+fallback:
   mode: link
   destination:
     url: https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/hashicorp-consul-monitoring-integration/#install

--- a/install/on-host-integration/mongodb/install.yml
+++ b/install/on-host-integration/mongodb/install.yml
@@ -11,6 +11,11 @@ target:
   destination: host
 
 install:
+  mode: targetedInstall
+  destination:
+    recipeName: mongodb-open-source-integration
+
+fallback:
   mode: link
   destination:
     url: https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/mongodb-monitoring-integration/#install

--- a/install/on-host-integration/postgres/install.yml
+++ b/install/on-host-integration/postgres/install.yml
@@ -11,6 +11,11 @@ target:
   destination: host
 
 install:
+  mode: targetedInstall
+  destination:
+    recipeName: postgres-open-source-integration
+
+fallback:
   mode: link
   destination:
     url: https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/postgresql-monitoring-integration/#install

--- a/install/on-host-integration/rabbitmq/install.yml
+++ b/install/on-host-integration/rabbitmq/install.yml
@@ -11,6 +11,11 @@ target:
   destination: host
 
 install:
+  mode: targetedInstall
+  destination:
+    recipeName: rabbitmq-open-source-integration
+
+fallback:
   mode: link
   destination:
     url: https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/rabbitmq-monitoring-integration/#install


### PR DESCRIPTION
Re-enable CLI install for Postgres, RabbitMQ, MongoDB, Consul after recipe refactor.