### PR TITLE
fix(vpc): update VPC Flow Logs to use new install plan

### DIFF
--- a/install/aws/aws-vpc-flow-logs/install.yml
+++ b/install/aws/aws-vpc-flow-logs/install.yml
@@ -1,0 +1,19 @@
+id: aws-vpc-flow-logs
+name: AWS-VPC-Flow-Logs
+title: AWS VPC Flow Logs via Kinesis Data Firehose
+description: |
+  AWS VPC Flow Log monitoring via Kinesis Data Firehose helps you reduce the friction of sending logs to New Relic. With VPC flow logs from across your AWS estates, you can quickly understand key insights for performance analytics and troubleshooting network connectivity.
+target:
+  type: integration
+  destination: cloud
+
+install:
+  mode: nerdlet
+  destination:
+    nerdletId: network-performance-monitoring.setup-vpc-flow
+
+fallback:
+  mode: link
+  destination:
+    url: >-
+      https://docs.newrelic.com/docs/network-performance-monitoring/setup-performance-monitoring/cloud-flow-logs/aws-vpc-flow-log-monitoring/

--- a/install/aws/aws-vpc-flow-logs/install.yml
+++ b/install/aws/aws-vpc-flow-logs/install.yml
@@ -1,8 +1,8 @@
 id: aws-vpc-flow-logs
 name: AWS-VPC-Flow-Logs
-title: AWS VPC Flow Logs via Kinesis Data Firehose
+title: Amazon VPC Flow Logs via Kinesis Data Firehose
 description: |
-  AWS VPC Flow Log monitoring via Kinesis Data Firehose helps you reduce the friction of sending logs to New Relic. With VPC flow logs from across your AWS estates, you can quickly understand key insights for performance analytics and troubleshooting network connectivity.
+  Amazon VPC Flow Log monitoring via Kinesis Data Firehose helps you reduce the friction of sending logs to New Relic. With VPC flow logs from across your AWS estates, you can quickly understand key insights for performance analytics and troubleshooting network connectivity.
 target:
   type: integration
   destination: cloud

--- a/quickstarts/aws/aws-vpc-flow-logs/config.yml
+++ b/quickstarts/aws/aws-vpc-flow-logs/config.yml
@@ -1,34 +1,34 @@
 id: 61d2ff67-f519-492c-a8de-6019b47d5bb2
 slug: aws-vpc-flow-logs
 description: |-
-  ## What is AWS VPC Flow Logs monitoring via Kinesis Data Firehose?
+  ## What is Amazon VPC Flow Logs monitoring via Kinesis Data Firehose?
 
   Enables you to capture information about the IP traffic going to and from
-  network interfaces in your AWS VPC. Kinesis Data Firehose helps you reduce
+  network interfaces in your Amazon VPC. Kinesis Data Firehose helps you reduce
   the friction of sending logs to New Relic. With VPC flow logs from across
-  your AWS estates, you can quickly understand key insights for performance
+  your Amazon estates, you can quickly understand key insights for performance
   analytics and troubleshooting network connectivity.
 
   ### Get started!
 
-  Start monitoring AWS VPC Flow Logs by connecting Amazon Web Services (AWS) to New Relic!
+  Start monitoring Amazon VPC Flow Logs by connecting Amazon Web Services (AWS) to New Relic!
 
-  Check out our AWS VPC Flow Logs documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's network monitoring capabilities.
+  Check out our Amazon VPC Flow Logs documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's network monitoring capabilities.
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/network-performance-monitoring/setup-performance-monitoring/cloud-flow-logs/aws-vpc-flow-log-monitoring/) to learn more about New Relic monitoring for AWS VPC Flow Logs.
+  Check out the [documentation](https://docs.newrelic.com/docs/network-performance-monitoring/setup-performance-monitoring/cloud-flow-logs/aws-vpc-flow-log-monitoring/) to learn more about New Relic monitoring for Amazon VPC Flow Logs.
 summary: |-
-  Monitor AWS VPC Flow Logs by connecting to New Relic via Kinesis Data Firehose
+  Monitor Amazon VPC Flow Logs by connecting to New Relic via Kinesis Data Firehose
 icon: logo.svg
 level: New Relic
 authors:
   - New Relic
-title: AWS VPC Flow Logs
+title: Amazon VPC Flow Logs
 documentation:
-  - name: AWS VPC Flow Logs installation docs
+  - name: Amazon VPC Flow Logs installation docs
     description: |
-      Monitor AWS VPC Flow Logs by connecting AWS to New Relic.
+      Monitor Amazon VPC Flow Logs by connecting AWS to New Relic.
     url: >-
       https://docs.newrelic.com/docs/network-performance-monitoring/setup-performance-monitoring/cloud-flow-logs/aws-vpc-flow-log-monitoring/
 keywords:

--- a/quickstarts/aws/aws-vpc-flow-logs/config.yml
+++ b/quickstarts/aws/aws-vpc-flow-logs/config.yml
@@ -1,23 +1,25 @@
 id: 61d2ff67-f519-492c-a8de-6019b47d5bb2
 slug: aws-vpc-flow-logs
 description: |-
-  ## What is AWS VPC Flow Logs?
+  ## What is AWS VPC Flow Logs monitoring via Kinesis Data Firehose?
 
   Enables you to capture information about the IP traffic going to and from
-  network interfaces in your AWS VPC.
-
+  network interfaces in your AWS VPC. Kinesis Data Firehose helps you reduce
+  the friction of sending logs to New Relic. With VPC flow logs from across
+  your AWS estates, you can quickly understand key insights for performance
+  analytics and troubleshooting network connectivity.
 
   ### Get started!
 
   Start monitoring AWS VPC Flow Logs by connecting Amazon Web Services (AWS) to New Relic!
 
-  Check out our AWS VPC Flow Logs documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's infrastructure monitoring capabilities.
+  Check out our AWS VPC Flow Logs documentation to instrument your cloud service and manage the stability, scalability, and reliability of your systems with New Relic's network monitoring capabilities.
 
   ### More info
 
-  Check out the [documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-vpc-flow-logs-monitoring-integration/) to learn more about New Relic monitoring for AWS VPC Flow Logs.
+  Check out the [documentation](https://docs.newrelic.com/docs/network-performance-monitoring/setup-performance-monitoring/cloud-flow-logs/aws-vpc-flow-log-monitoring/) to learn more about New Relic monitoring for AWS VPC Flow Logs.
 summary: |-
-  Monitor AWS VPC Flow Logs by connecting AWS to New Relic
+  Monitor AWS VPC Flow Logs by connecting to New Relic via Kinesis Data Firehose
 icon: logo.svg
 level: New Relic
 authors:
@@ -28,11 +30,15 @@ documentation:
     description: |
       Monitor AWS VPC Flow Logs by connecting AWS to New Relic.
     url: >-
-      https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-vpc-flow-logs-monitoring-integration/
+      https://docs.newrelic.com/docs/network-performance-monitoring/setup-performance-monitoring/cloud-flow-logs/aws-vpc-flow-log-monitoring/
 keywords:
   - aws
   - amazon web services
+  - vpc flow logs
+  - cloud flow logs
+  - kinesis firehose
+  - kinesis data firehose
   - networking
 
 installPlans:
-  - aws-infrastructure-monitoring
+  - aws-vpc-flow-logs


### PR DESCRIPTION
# Summary

We [released](https://newrelic.com/blog/nerdlog/amazon-vpc-flow-logs) a new capability for our AWS VPC Flow Logs integration today and need to update the quickstart to use the in-product setup wizard. I've added a _new_ install plan that points to our setup wizard (with a fallback to docs) as well as updated some of the language and documentation links.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- This CHECKLIST SHOULD BE SUBMITTED FULLY COMPLETE WITH THE PR. IF NOT COMPLETE
THE PR REVIEW WILL BE DELAYED -->

- [X] Did you check you NRQL syntax? - Does it work?
- [X] Did you check your dashboard image quality? -  Do they look good?
- [X] Did you check that your alerts actually work?
- [X] Did you include an InstallPlan and Documentation reference?
- [X] Did you check your descriptive content for voice, tone, spelling and grammar errors?
- [X] Did you attach images of your dashboards to the PR so we can see them working?

### Screenshots

Attach images of any visual changes, such as a dashboard here.
