### PR TITLE
Fix error output and update Etcd slug

### DIFF
--- a/quickstarts/etcd/config.yml
+++ b/quickstarts/etcd/config.yml
@@ -1,6 +1,6 @@
 id: 83b4ef64-9af6-4bec-9707-674fa82c2837
 # Sets the URL name of the quickstart on public I/O (required)
-slug: Etcd
+slug: etcd
 
 # Displayed in the UI (required)
 title: Etcd

--- a/utils/create_validate_pr_quickstarts.ts
+++ b/utils/create_validate_pr_quickstarts.ts
@@ -65,7 +65,7 @@ const main = async () => {
   }
 
   // Submit all of the mutations in chunks of 5
-  const results: (NerdGraphResponseWithLocalErrors<QuickstartMutationResponse> & {
+  let results: (NerdGraphResponseWithLocalErrors<QuickstartMutationResponse> & {
     name: string;
   })[] = [];
 
@@ -77,7 +77,8 @@ const main = async () => {
       const res = await Promise.all(
         c.map((quickstart) => quickstart.submitMutation(dryRun))
       );
-      results.concat(res);
+
+      results = [...results, ...res];
     } catch (err) {
       const error = err as Error;
 


### PR DESCRIPTION
# Summary

A bug in our error processing from nerdgraph caused errors to be dropped instead of printed to the console. This fixes that issue and updates the Etcd quickstart with a correct slug.
