### PR TITLE
Properly ignore installPlanStepId errors

### DIFF
--- a/utils/__tests__/create-validate-pr-quickstarts.test.js
+++ b/utils/__tests__/create-validate-pr-quickstarts.test.js
@@ -1,0 +1,115 @@
+'use strict';
+
+import { createValidateQuickstarts } from '../create_validate_pr_quickstarts';
+
+import Quickstart from '../lib/Quickstart';
+import InstallPlan from '../lib/InstallPlan';
+import * as githubHelpers from '../lib/github-api-helpers';
+
+jest.mock('@actions/core');
+jest.spyOn(global.console, 'error').mockImplementation(() => {});
+
+jest.mock('../lib/github-api-helpers', () => ({
+  ...jest.requireActual('../lib/github-api-helpers'),
+  filterQuickstartConfigFiles: jest.fn(),
+  fetchPaginatedGHResults: jest.fn(),
+}));
+
+jest.mock('../lib/Quickstart');
+jest.mock('../lib/InstallPlan');
+
+const validQuickstartFilename = 'quickstarts/mock-quickstart-2/config.yml';
+
+const mockNGQuickstartErr = (data) => ({
+  data,
+  errors: [
+    {
+      extensions: {
+        argumentPath: [`slug`],
+      },
+      message: `slug must be lowercase`,
+    },
+  ],
+});
+
+const mockNGInstallPlanErr = (data) => ({
+  data,
+  errors: [
+    {
+      extensions: {
+        argumentPath: [`installPlanStepIds`],
+      },
+      message: `contains an install plan step that does not exist`,
+    },
+  ],
+});
+
+const mockGithubAPIFiles = (filenames) =>
+  filenames.map((filename) => ({
+    sha: '',
+    filename: `${filename}`,
+    status: 'added',
+    additions: 0,
+    deletions: 0,
+    changes: 0,
+    blob_url: '',
+    raw_url: '',
+    contents_url: '',
+    patch: '',
+  }));
+
+describe('create-validate-pr-quickstarts', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('fails for nerdgraph validation error', async () => {
+    const files = mockGithubAPIFiles([validQuickstartFilename]);
+    githubHelpers.fetchPaginatedGHResults.mockResolvedValueOnce(files);
+    githubHelpers.filterQuickstartConfigFiles.mockReturnValueOnce(files);
+
+    Quickstart.mockImplementation(() => {
+      return {
+        config: {
+          installPlans: ['valid-id'],
+        },
+        isValid: true,
+        validate: jest.fn().mockImplementation(() => true),
+        submitMutation: jest
+          .fn()
+          .mockResolvedValueOnce(mockNGQuickstartErr({})),
+      };
+    });
+    InstallPlan.mockImplementationOnce(() => {
+      return { isValid: true };
+    });
+
+    const hasErrored = await createValidateQuickstarts('url', 'token');
+    expect(hasErrored).toBe(true);
+  });
+
+  test('does not fail for install plan id error', async () => {
+    const files = mockGithubAPIFiles([validQuickstartFilename]);
+    githubHelpers.fetchPaginatedGHResults.mockResolvedValueOnce(files);
+    githubHelpers.filterQuickstartConfigFiles.mockReturnValueOnce(files);
+
+    Quickstart.mockImplementation(() => {
+      return {
+        config: {
+          installPlans: ['valid-id'],
+        },
+        isValid: true,
+        validate: jest.fn().mockImplementation(() => true),
+        submitMutation: jest
+          .fn()
+          .mockResolvedValueOnce(mockNGInstallPlanErr({})),
+      };
+    });
+    InstallPlan.mockImplementationOnce(() => {
+      return { isValid: true };
+    });
+
+    const hasErrored = await createValidateQuickstarts('url', 'token');
+    expect(hasErrored).toBe(false);
+  });
+});

--- a/utils/__tests__/create-validate-pr-quickstarts.test.js
+++ b/utils/__tests__/create-validate-pr-quickstarts.test.js
@@ -63,6 +63,32 @@ describe('create-validate-pr-quickstarts', () => {
     jest.resetAllMocks();
   });
 
+  test('succeeds on happy path', async () => {
+    const files = mockGithubAPIFiles([validQuickstartFilename]);
+    githubHelpers.fetchPaginatedGHResults.mockResolvedValueOnce(files);
+    githubHelpers.filterQuickstartConfigFiles.mockReturnValueOnce(files);
+
+    Quickstart.mockImplementation(() => {
+      return {
+        config: {
+          installPlans: ['valid-id'],
+        },
+        isValid: true,
+        validate: jest.fn().mockImplementation(() => true),
+        submitMutation: jest.fn().mockResolvedValueOnce({
+          data: {},
+          errors: [],
+        }),
+      };
+    });
+    InstallPlan.mockImplementationOnce(() => {
+      return { isValid: true };
+    });
+
+    const hasErrored = await createValidateQuickstarts('url', 'token');
+    expect(hasErrored).toBe(false);
+  });
+
   test('fails for nerdgraph validation error', async () => {
     const files = mockGithubAPIFiles([validQuickstartFilename]);
     githubHelpers.fetchPaginatedGHResults.mockResolvedValueOnce(files);


### PR DESCRIPTION
# Summary

Some logic to ignore install plan step id errors was lost, this re-adds it.
These errors occur when a new quickstart is created along with its install plan because the database has no idea that the install plan is part of the PR.
