### PR TITLE
Filter out removed files during PR validation

### DIFF
--- a/utils/__tests__/create-validate-pr-quickstarts.test.js
+++ b/utils/__tests__/create-validate-pr-quickstarts.test.js
@@ -138,4 +138,14 @@ describe('create-validate-pr-quickstarts', () => {
     const hasErrored = await createValidateQuickstarts('url', 'token');
     expect(hasErrored).toBe(false);
   });
+
+  test('does not process removed file', async () => {
+    const files = mockGithubAPIFiles([validQuickstartFilename]);
+    files[0].status = 'removed';
+    githubHelpers.fetchPaginatedGHResults.mockResolvedValueOnce(files);
+    githubHelpers.filterQuickstartConfigFiles.mockReturnValueOnce(files);
+
+    const hasErrored = await createValidateQuickstarts('url', 'token');
+    expect(hasErrored).toBe(false);
+  });
 });

--- a/utils/create-validate-data-sources.ts
+++ b/utils/create-validate-data-sources.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import {
   fetchPaginatedGHResults,
   filterOutTestFiles,
+  isFileRemoved,
 } from './lib/github-api-helpers';
 import { chunk, translateMutationErrors } from './lib/nr-graphql-helpers';
 import { passedProcessArguments, prop } from './lib/helpers';
@@ -27,6 +28,7 @@ const main = async () => {
   const files = await fetchPaginatedGHResults(GITHUB_API_URL, githubToken);
 
   const dataSources = filterOutTestFiles(files)
+    .filter((file) => !isFileRemoved(file))
     .map(prop('filename'))
     .filter((filename) => DATA_SOURCE_CONFIG_REGEXP.test(filename))
     .map((filename) => path.dirname(filename).replace('data-sources/', ''))

--- a/utils/create-validate-data-sources.ts
+++ b/utils/create-validate-data-sources.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import {
   fetchPaginatedGHResults,
   filterOutTestFiles,
-  isFileRemoved,
+  isNotRemoved,
 } from './lib/github-api-helpers';
 import { chunk, translateMutationErrors } from './lib/nr-graphql-helpers';
 import { passedProcessArguments, prop } from './lib/helpers';
@@ -28,7 +28,7 @@ const main = async () => {
   const files = await fetchPaginatedGHResults(GITHUB_API_URL, githubToken);
 
   const dataSources = filterOutTestFiles(files)
-    .filter((file) => !isFileRemoved(file))
+    .filter(isNotRemoved)
     .map(prop('filename'))
     .filter((filename) => DATA_SOURCE_CONFIG_REGEXP.test(filename))
     .map((filename) => path.dirname(filename).replace('data-sources/', ''))

--- a/utils/create-validate-install-plans.ts
+++ b/utils/create-validate-install-plans.ts
@@ -2,6 +2,7 @@ import { prop, passedProcessArguments } from './lib/helpers';
 import {
   fetchPaginatedGHResults,
   filterOutTestFiles,
+  isFileRemoved,
 } from './lib/github-api-helpers';
 import { translateMutationErrors, chunk } from './lib/nr-graphql-helpers';
 import { recordNerdGraphResponse, CUSTOM_EVENT } from './newrelic/customEvent';
@@ -43,6 +44,7 @@ const main = async () => {
 
   // Get all install-plan mutation variables
   const plans = filterOutTestFiles(files)
+    .filter((file) => !isFileRemoved(file))
     .map(prop('filename'))
     .filter((filename) => INSTALL_CONFIG_REGEXP.test(filename))
     .map((filename) => getInstallPlanId(filename))

--- a/utils/create-validate-install-plans.ts
+++ b/utils/create-validate-install-plans.ts
@@ -2,7 +2,7 @@ import { prop, passedProcessArguments } from './lib/helpers';
 import {
   fetchPaginatedGHResults,
   filterOutTestFiles,
-  isFileRemoved,
+  isNotRemoved,
 } from './lib/github-api-helpers';
 import { translateMutationErrors, chunk } from './lib/nr-graphql-helpers';
 import { recordNerdGraphResponse, CUSTOM_EVENT } from './newrelic/customEvent';
@@ -44,7 +44,7 @@ const main = async () => {
 
   // Get all install-plan mutation variables
   const plans = filterOutTestFiles(files)
-    .filter((file) => !isFileRemoved(file))
+    .filter(isNotRemoved)
     .map(prop('filename'))
     .filter((filename) => INSTALL_CONFIG_REGEXP.test(filename))
     .map((filename) => getInstallPlanId(filename))

--- a/utils/create_validate_pr_quickstarts.ts
+++ b/utils/create_validate_pr_quickstarts.ts
@@ -1,7 +1,7 @@
 import {
   fetchPaginatedGHResults,
   filterOutTestFiles,
-  isFileRemoved,
+  isNotRemoved,
 } from './lib/github-api-helpers';
 import { translateMutationErrors, chunk } from './lib/nr-graphql-helpers';
 
@@ -64,7 +64,7 @@ export const createValidateQuickstarts = async (
 
   // Get all quickstart mutation variables
   const quickstarts = filterOutTestFiles(files)
-    .filter((file) => !isFileRemoved(file))
+    .filter(isNotRemoved)
     .map(prop('filename'))
     .filter(
       (filePath) =>

--- a/utils/create_validate_pr_quickstarts.ts
+++ b/utils/create_validate_pr_quickstarts.ts
@@ -1,6 +1,7 @@
 import {
   fetchPaginatedGHResults,
   filterOutTestFiles,
+  isFileRemoved,
 } from './lib/github-api-helpers';
 import { translateMutationErrors, chunk } from './lib/nr-graphql-helpers';
 
@@ -63,6 +64,7 @@ export const createValidateQuickstarts = async (
 
   // Get all quickstart mutation variables
   const quickstarts = filterOutTestFiles(files)
+    .filter((file) => !isFileRemoved(file))
     .map(prop('filename'))
     .filter(
       (filePath) =>

--- a/utils/lib/github-api-helpers.ts
+++ b/utils/lib/github-api-helpers.ts
@@ -121,3 +121,11 @@ export const filterDataSources = (
     DATA_SOURCE_CONFIG_REGEXP.test(filename)
   );
 };
+
+/**
+ * Returns whether a file was removed during a pull request
+ * @param file the results from Github API
+ * @returns files from Github API excluding removed files
+ */
+export const isFileRemoved = (file: GithubAPIPullRequestFile): boolean =>
+  file.status === 'removed';

--- a/utils/lib/github-api-helpers.ts
+++ b/utils/lib/github-api-helpers.ts
@@ -123,9 +123,9 @@ export const filterDataSources = (
 };
 
 /**
- * Returns whether a file was removed during a pull request
+ * Returns whether a file exists or was removed during a pull request
  * @param file the results from Github API
- * @returns files from Github API excluding removed files
+ * @returns a boolean indicating whether the file exists
  */
-export const isFileRemoved = (file: GithubAPIPullRequestFile): boolean =>
-  file.status === 'removed';
+export const isNotRemoved = (file: GithubAPIPullRequestFile): boolean =>
+  file.status !== 'removed';

--- a/utils/validate-quickstart-install-plans.ts
+++ b/utils/validate-quickstart-install-plans.ts
@@ -2,7 +2,8 @@ import {
   fetchPaginatedGHResults,
   filterQuickstartConfigFiles,
   filterOutTestFiles,
-  GithubAPIPullRequestFile
+  GithubAPIPullRequestFile,
+  isNotRemoved,
 } from './lib/github-api-helpers';
 
 import Quickstart from './lib/Quickstart';
@@ -12,34 +13,41 @@ import { passedProcessArguments } from './lib/helpers';
 /**
  * Main validation logic ensuring install plans specified in config files actually exist
  */
-export const validateInstallPlanIds = (githubFiles: GithubAPIPullRequestFile[]) => {
-  const configFiles: GithubAPIPullRequestFile[] = filterQuickstartConfigFiles(githubFiles);
-  const existingConfigFiles: GithubAPIPullRequestFile[] = configFiles.filter(
-    (cf: GithubAPIPullRequestFile) => cf.status !== 'removed'
-  ); // Filter out deleted files
+export const validateInstallPlanIds = (
+  githubFiles: GithubAPIPullRequestFile[]
+) => {
+  const configFiles: GithubAPIPullRequestFile[] =
+    filterQuickstartConfigFiles(githubFiles);
+  const existingConfigFiles: GithubAPIPullRequestFile[] =
+    configFiles.filter(isNotRemoved); // Filter out deleted files
 
   const quickstarts = existingConfigFiles.map(
     ({ filename }) => new Quickstart(filename)
   );
 
-  const quickstartsWithInvalidInstall = quickstarts.map(quickstart => {
-    const invalidIds = quickstart.config.installPlans?.filter(installPlanId => {
-      return !(new InstallPlan(installPlanId).isValid);
-    }) ?? [];
+  const quickstartsWithInvalidInstall = quickstarts
+    .map((quickstart) => {
+      const invalidIds =
+        quickstart.config.installPlans?.filter((installPlanId) => {
+          return !new InstallPlan(installPlanId).isValid;
+        }) ?? [];
 
-    return {
-      quickstart,
-      invalidInstallPlans: invalidIds,
-    }
-  }).filter(q => q.invalidInstallPlans.length > 0);
- 
+      return {
+        quickstart,
+        invalidInstallPlans: invalidIds,
+      };
+    })
+    .filter((q) => q.invalidInstallPlans.length > 0);
+
   if (quickstartsWithInvalidInstall.length > 0) {
     console.error(
       `ERROR: Found install plans with no corresponding install plan id.\n`
     );
     console.error(`An install plan id must match an existing install plan id.`);
     quickstartsWithInvalidInstall.forEach((m) =>
-      console.error(`- ${m.invalidInstallPlans.join(', ')} in ${m.quickstart.configPath}`)
+      console.error(
+        `- ${m.invalidInstallPlans.join(', ')} in ${m.quickstart.configPath}`
+      )
     );
     console.error(
       `\nPlease change to an existing install plan id or remove the ids.`
@@ -52,17 +60,14 @@ export const validateInstallPlanIds = (githubFiles: GithubAPIPullRequestFile[]) 
 };
 
 const main = async () => {
-  const [ GITHUB_API_URL ] = passedProcessArguments();
+  const [GITHUB_API_URL] = passedProcessArguments();
   const githubToken = process.env.GITHUB_TOKEN;
-  
+
   if (!githubToken) {
     console.error('GITHUB_TOKEN is not defined.');
     process.exit(1);
   }
-  const files = await fetchPaginatedGHResults(
-    GITHUB_API_URL,
-    githubToken
-  );
+  const files = await fetchPaginatedGHResults(GITHUB_API_URL, githubToken);
   validateInstallPlanIds(filterOutTestFiles(files));
 };
 


### PR DESCRIPTION
# Summary

Removed files were not being filtered out during validation, which can cause errors when the scripts attempt to read the file on disc.
This updates the logic for quickstart, install plan, and data-source validation.
