### PR TITLE
Remove yaml document separators from template alerts

### DIFF
--- a/_template/alert-policies/example-alert-policy/baseline-alert.yml
+++ b/_template/alert-policies/example-alert-policy/baseline-alert.yml
@@ -1,4 +1,3 @@
----
 # Name of the alert
 name: Name of this alert condition
 

--- a/_template/alert-policies/example-alert-policy/static-alert.yml
+++ b/_template/alert-policies/example-alert-policy/static-alert.yml
@@ -1,4 +1,3 @@
----
 # Name of the alert
 name: Name of this alert condition
 


### PR DESCRIPTION
# Summary

Our template alerts had a `---` yaml document separator at the top, this allows you to define multiple "documents" per yaml file. We do not support this for alerts and require that there is one alert condition per file.
