### PR TITLE
Update Harbor quickstart with author field

### DIFF
--- a/quickstarts/harbor/config.yml
+++ b/quickstarts/harbor/config.yml
@@ -46,6 +46,9 @@ documentation:
     url: https://goharbor.io/docs/2.3.0/administration/metrics/
     description: Learn more about the Prometheus metrics available for Harbor
 
+authors:
+  - pyrotechnics-io
+
 # Content / Design
 icon: logo.svg
 website: https://goharbor.io/


### PR DESCRIPTION
# Summary

The Harbor quickstart is missing an authors field, this adds one.
