### PR TITLE
Quick fix for the quickstart template

### DIFF
--- a/_template/quickstarts/example-quickstart/config.yml
+++ b/_template/quickstarts/example-quickstart/config.yml
@@ -30,12 +30,17 @@ keywords:
 # Allows us to construct reusable "install plans" and just use their ID in the quickstart config
 installPlans:
   - example-install
-alerts:
+
+# Reference to alert policies to be included in this quickstart
+alertPolicies:
   - condition-a
   - condition-b
+
+# Reference to dashboards to be included in this quickstart
 dashboards:
   - dashboard-1
   - dashboard-2
+
 # Documentation references
 documentation:
   - name: Installation docs


### PR DESCRIPTION
# Summary

The quickstart template was using an incorrect field for alerts, this updates it to the correct field name.
