### PR TITLE
Deleted local tags widget from calico

### DIFF
--- a/dashboards/calico/calico.json
+++ b/dashboards/calico/calico.json
@@ -404,7 +404,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT sum(chains) FROM ( FROM Metric SELECT latest(felix_iptables_chains) AS 'chains'  FACET instance, ip_version, table  LIMIT MAX) FACET instance, concat('ip_version: ',ip_version) WHERE instrumentation.name = 'remote-write'"
+                "query": "SELECT sum(chains) FROM ( FROM Metric SELECT latest(felix_iptables_chains) AS 'chains' FACET instance, ip_version, table where instrumentation.name = 'remote-write' LIMIT MAX ) FACET instance, concat('ip_version: ',ip_version)"
               }
             ],
             "platformOptions": {

--- a/dashboards/calico/calico.json
+++ b/dashboards/calico/calico.json
@@ -439,6 +439,12 @@
             ],
             "platformOptions": {
               "ignoreTimeRange": false
+            },
+	    "units": {
+              "unit": "COUNT"
+            },
+            "yAxisLeft": {
+              "zero": true
             }
           }
         },

--- a/dashboards/calico/calico.json
+++ b/dashboards/calico/calico.json
@@ -12,7 +12,7 @@
             "column": 1,
             "row": 1,
             "width": 2,
-            "height": 8
+            "height": 7
           },
           "linkedEntityGuids": null,
           "visualization": {
@@ -27,7 +27,7 @@
           "layout": {
             "column": 3,
             "row": 1,
-            "width": 4,
+            "width": 5,
             "height": 4
           },
           "linkedEntityGuids": null,
@@ -61,9 +61,9 @@
         {
           "title": "Active  Local Selectors",
           "layout": {
-            "column": 7,
+            "column": 8,
             "row": 1,
-            "width": 3,
+            "width": 5,
             "height": 4
           },
           "linkedEntityGuids": null,
@@ -95,48 +95,12 @@
           }
         },
         {
-          "title": "Active Local Tags",
-          "layout": {
-            "column": 10,
-            "row": 1,
-            "width": 3,
-            "height": 4
-          },
-          "linkedEntityGuids": null,
-          "visualization": {
-            "id": "viz.line"
-          },
-          "rawConfiguration": {
-            "facet": {
-              "showOtherSeries": false
-            },
-            "legend": {
-              "enabled": true
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 0,
-                "query": "SELECT latest(felix_active_local_tags) FROM Metric facet instance TIMESERIES WHERE instrumentation.name = 'remote-write'"
-              }
-            ],
-            "platformOptions": {
-              "ignoreTimeRange": false
-            },
-            "units": {
-              "unit": "COUNT"
-            },
-            "yAxisLeft": {
-              "zero": true
-            }
-          }
-        },
-        {
           "title": "Active Policies",
           "layout": {
             "column": 3,
             "row": 5,
             "width": 5,
-            "height": 4
+            "height": 3
           },
           "linkedEntityGuids": null,
           "visualization": {
@@ -172,7 +136,7 @@
             "column": 8,
             "row": 5,
             "width": 5,
-            "height": 4
+            "height": 3
           },
           "linkedEntityGuids": null,
           "visualization": {
@@ -188,7 +152,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT latest(felix_ipsets_calico)  FROM Metric facet instance,ip_version TIMESERIES WHERE instrumentation.name = 'remote-write'"
+                "query": "SELECT latest(felix_ipsets_calico) FROM Metric facet instance,ip_version TIMESERIES WHERE instrumentation.name = 'remote-write'"
               }
             ],
             "platformOptions": {
@@ -206,7 +170,7 @@
           "title": "Cluster Workload Endpoints",
           "layout": {
             "column": 1,
-            "row": 9,
+            "row": 8,
             "width": 4,
             "height": 3
           },
@@ -242,7 +206,7 @@
           "title": "Cluster Host Endpoints",
           "layout": {
             "column": 5,
-            "row": 9,
+            "row": 8,
             "width": 4,
             "height": 3
           },
@@ -278,7 +242,7 @@
           "title": "IP Set Command Failures",
           "layout": {
             "column": 9,
-            "row": 9,
+            "row": 8,
             "width": 4,
             "height": 3
           },
@@ -314,7 +278,7 @@
           "title": "Dataplane Failed Updates",
           "layout": {
             "column": 1,
-            "row": 12,
+            "row": 11,
             "width": 4,
             "height": 3
           },
@@ -350,7 +314,7 @@
           "title": "Felix Resyncing Datastore",
           "layout": {
             "column": 5,
-            "row": 12,
+            "row": 11,
             "width": 4,
             "height": 3
           },
@@ -386,7 +350,7 @@
           "title": "Clusters Hosts",
           "layout": {
             "column": 9,
-            "row": 12,
+            "row": 11,
             "width": 4,
             "height": 3
           },
@@ -475,12 +439,6 @@
             ],
             "platformOptions": {
               "ignoreTimeRange": false
-            },
-            "units": {
-              "unit": "COUNT"
-            },
-            "yAxisLeft": {
-              "zero": true
             }
           }
         },
@@ -584,7 +542,7 @@
             "platformOptions": {
               "ignoreTimeRange": false
             },
-            "units": {
+	    "units": {
               "unit": "COUNT"
             },
             "yAxisLeft": {


### PR DESCRIPTION
# Summary
Deleted local tags widget 
As per latest Calico source code, this metric has been deleted.
https://github.com/projectcalico/calico/commit/46c954f21ca5057a50afed0ee94f81737107082a#diff-c98e45a80bc6858972684cf22e5007c61169de0475ee52e95309599eecfcdb9fL24 



- [x] Did you check you NRQL syntax? - Does it work?
- [x] Did you include an InstallPlan and Documentation reference?
- [x] Are all documentation links publically accessible?
- [x] Did you check your descriptive content for [voice and tone](https://docs.newrelic.com/docs/style-guide/writing-strategies/voice-strategies-docs-sound-new-relic/)? 
- [x] Did you check your descriptive content for spelling and grammar errors?


