### PR TITLE
Update description for setup-pomi

### DIFF
--- a/install/pomi/install.yml
+++ b/install/pomi/install.yml
@@ -1,7 +1,7 @@
 id: setup-pomi
 name: Prometheus OpenMetrics integration
-title: Prometheus OpenMetrics integration (POMI)
-description: Using the Prometheus OpenMetrics integration, you can scrape your Docker containers and import them to New Relic to store and visualize your data.
+title: Prometheus OpenMetrics integration (Docker)
+description: Using the Prometheus OpenMetrics integration, you can scrape your Docker containers and import Prometheus metrics into New Relic for storage and visualization.
 
 target:
   type: integration

--- a/install/pomi/install.yml
+++ b/install/pomi/install.yml
@@ -1,7 +1,7 @@
 id: setup-pomi
 name: Prometheus OpenMetrics integration
 title: Prometheus OpenMetrics integration (POMI)
-description: Using the Prometheus OpenMetrics integration, you can scrape your Kubernetes Pods and import them to New Relic to store and visualize your data.
+description: Using the Prometheus OpenMetrics integration, you can scrape your Docker containers and import them to New Relic to store and visualize your data.
 
 target:
   type: integration


### PR DESCRIPTION
Updating the description for the `setup-pomi` install plan to drop K8s support and make it Docker-only.

# Summary

Updating the description for the `setup-pomi` install plan.
