### PR TITLE
feat(prom-agent): duplicated data alert

### DIFF
--- a/alert-policies/prometheus-agent/DupMetrics.yml
+++ b/alert-policies/prometheus-agent/DupMetrics.yml
@@ -1,0 +1,27 @@
+name: Same target is scraped by different jobs
+
+description: |+
+  This alert is triggered when you have two or more jobs scraping the same instance in the same cluster
+type: STATIC
+nrql:
+  query: "FROM Metric select uniqueCount(job) facet instance, cluster_name"
+
+# Function used to aggregate the NRQL query value(s) for comparison to the terms.threshold (Default: SINGLE_VALUE)
+valueFunction: SINGLE_VALUE
+
+# List of Critical and Warning thresholds for the condition
+terms:
+  - priority: CRITICAL
+    # Operator used to compare against the threshold.
+    operator: ABOVE
+    # Value that triggers a violation
+    threshold: 1
+    # Time in seconds; 120 - 3600
+    thresholdDuration: 300
+    # How many data points must be in violation for the duration
+    thresholdOccurrences: ALL
+
+# Duration after which a violation automatically closes
+# Time in seconds; 300 - 2592000 (Default: 86400 [1 day])
+violationTimeLimitSeconds: 86400
+

--- a/alert-policies/prometheus-agent/DupMetrics.yml
+++ b/alert-policies/prometheus-agent/DupMetrics.yml
@@ -1,7 +1,7 @@
-name: Same target is scraped by different jobs
+name: A target is scraped by different jobs
 
 description: |+
-  This alert is triggered when you have two or more jobs scraping the same instance in the same cluster
+  This alert is triggered if two or more jobs scraping the same instance in the same cluster.
 type: STATIC
 nrql:
   query: "FROM Metric select uniqueCount(job) facet instance, cluster_name"

--- a/quickstarts/prometheus-agent/config.yml
+++ b/quickstarts/prometheus-agent/config.yml
@@ -36,5 +36,7 @@ keywords:
 
 dashboards:
   - prometheus-agent
+alertPolicies:
+  - prometheus-agent
 
 icon: logo.svg


### PR DESCRIPTION
# Summary

Due to a new version of the integrations filters, a target that was already scaped by a different job is scraped again. 
In order to prevent that and be notified in case of duplicated data, you can create an alert based on the following query:
```
FROM Metric select uniqueCount(job) facet instance, cluster_name limit 10 since 2 minutes ago
```
If any value is different from 1 then you have two or more jobs scraping the same instance in the same cluster.

https://github.com/newrelic/docs-website/pull/10553/files
### Alerts

- [ ] Did you check that your alerts actually work?
