### PR TITLE
fix fillOption for CoreDNS alerts

### DIFF
--- a/alert-policies/coredns/coredns-error-rate.yml
+++ b/alert-policies/coredns/coredns-error-rate.yml
@@ -55,9 +55,9 @@ signal:
   # Controls the duration of the time window used to evaluate the NRQL query
   aggregationWindow: 60 # seconds; 30 seconds <= x < 15 minutes
   # Option that determines the type of value that should be used to fill gaps (empty windows).
-  fillOption: NONE # defaults to STATIC
+  fillOption: STATIC # defaults to STATIC
   # If using the static fill option, this value is used for filling.
-  # fillValue: 0 # default
+  fillValue: 0 # default
   # This setting gathers data in overlapping time windows to smooth the chart line, making it easier to spot trends.
   slideBy: 30 # seconds
 

--- a/alert-policies/coredns/coredns-panic-rate.yml
+++ b/alert-policies/coredns/coredns-panic-rate.yml
@@ -55,7 +55,7 @@ signal:
   # Controls the duration of the time window used to evaluate the NRQL query
   aggregationWindow: 60 # seconds; 30 seconds <= x < 15 minutes
   # Option that determines the type of value that should be used to fill gaps (empty windows).
-  fillOption: NONE # defaults to STATIC
+  fillOption: STATIC # defaults to STATIC
   # If using the static fill option, this value is used for filling.
   fillValue: 0 # default
   # This setting gathers data in overlapping time windows to smooth the chart line, making it easier to spot trends.

--- a/alert-policies/coredns/coredns-request-duration.yml
+++ b/alert-policies/coredns/coredns-request-duration.yml
@@ -55,7 +55,7 @@ signal:
   # Controls the duration of the time window used to evaluate the NRQL query
   aggregationWindow: 60 # seconds; 30 seconds <= x < 15 minutes
   # Option that determines the type of value that should be used to fill gaps (empty windows).
-  fillOption: NONE # defaults to STATIC
+  fillOption: STATIC # defaults to STATIC
   # If using the static fill option, this value is used for filling.
   fillValue: 0 # default
   # This setting gathers data in overlapping time windows to smooth the chart line, making it easier to spot trends.

--- a/alert-policies/coredns/coredns-request-rate.yml
+++ b/alert-policies/coredns/coredns-request-rate.yml
@@ -55,7 +55,7 @@ signal:
   # Controls the duration of the time window used to evaluate the NRQL query
   aggregationWindow: 60 # seconds; 30 seconds <= x < 15 minutes
   # Option that determines the type of value that should be used to fill gaps (empty windows).
-  fillOption: NONE # defaults to STATIC
+  fillOption: STATIC # defaults to STATIC
   # If using the static fill option, this value is used for filling.
   fillValue: 0 # default
   # This setting gathers data in overlapping time windows to smooth the chart line, making it easier to spot trends.


### PR DESCRIPTION
# Summary

Alerts were erroring on import due to invalid `fillOption`.  

### Alerts

- [X] Did you check that your alerts actually work?
