### PR TITLE
Mlosier/handle dashboard multiple datasources

### DIFF
--- a/.github/workflows/reusable.quickstart_submission.yml
+++ b/.github/workflows/reusable.quickstart_submission.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v2
         # Ensure we have the most recent commit to `main`
         with:
-          ref: 'main'
+          ref: "main"
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@v2
         # Ensure we have the most recent commit to `main`
         with:
-          ref: 'main'
+          ref: "main"
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@v2
         # Ensure we have the most recent commit to `main`
         with:
-          ref: 'main'
+          ref: "main"
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -123,7 +123,7 @@ jobs:
         uses: actions/checkout@v2
         # Ensure we have the most recent commit to `main`
         with:
-          ref: 'main'
+          ref: "main"
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -143,32 +143,32 @@ jobs:
         run: |
           URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/$PR_NUMBER/files"
           cd utils && yarn set-dashboards-required-datasources "$URL"
-set-alert-policy-required-datasources:
-  needs: [submit-quickstarts]
-  name: Set alert policy requierd datasources
-  runs-on: ubuntu-latest
-  steps:
-    - name: Checkout repo
-      uses: actions/checkout@v2
-      # Ensure we have the most recent commit to `main`
-      with:
-        ref: 'main'
-        fetch-depth: 0
+  set-alert-policy-required-datasources:
+    needs: [submit-quickstarts]
+    name: Set alert policy requierd datasources
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        # Ensure we have the most recent commit to `main`
+        with:
+          ref: "main"
+          fetch-depth: 0
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v2
-      with:
-        node-version: 16
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
 
-    - name: Install dependencies
-      run: cd utils && yarn install --frozen-lockfile
+      - name: Install dependencies
+        run: cd utils && yarn install --frozen-lockfile
 
-    - name: Update dashboards with required datasources from quickstarts
-      env:
-        NR_API_URL: ${{ secrets.nr-api-url }}
-        NR_API_TOKEN: ${{ secrets.nr-api-token }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NEW_RELIC_LICENSE_KEY: ${{ secrets.nr-license-key }}
-      run: |
-        URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/$PR_NUMBER/files"
-        cd utils && yarn set-alert-policy-required-datasources "$URL"
+      - name: Update dashboards with required datasources from quickstarts
+        env:
+          NR_API_URL: ${{ secrets.nr-api-url }}
+          NR_API_TOKEN: ${{ secrets.nr-api-token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_RELIC_LICENSE_KEY: ${{ secrets.nr-license-key }}
+        run: |
+          URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/$PR_NUMBER/files"
+          cd utils && yarn set-alert-policy-required-datasources "$URL"

--- a/utils/__tests__/set-dashboard-required-datasources.test.js
+++ b/utils/__tests__/set-dashboard-required-datasources.test.js
@@ -37,6 +37,9 @@ const mockGithubAPIFiles = (filenames) =>
 const validQuickstartFilename =
   'utils/mock_files/quickstarts/mock-quickstart-2/config.yml';
 
+const quickstartWithMultipleDataSourcesFilename =
+  'utils/mock_files/quickstarts/mock-quickstart-3/config.yml';
+
 const mockSubmitSetRequiredDataSourcesResult = {
   data: {
     nr1CatalogSetRequiredDataSourcesForDashboardTemplate: {
@@ -106,5 +109,23 @@ describe('set-dashboards-required-datasources', () => {
     );
 
     expect(console.error).toHaveBeenCalledWith(`- ${mockError.message}`);
+  });
+
+  test('succeeds but skips quickstart if there are multiple datasources', async () => {
+    const files = mockGithubAPIFiles([
+      quickstartWithMultipleDataSourcesFilename,
+    ]);
+    githubHelpers.fetchPaginatedGHResults.mockResolvedValueOnce(files);
+    githubHelpers.filterQuickstartConfigFiles.mockReturnValueOnce(files);
+
+    jest.spyOn(Dashboard, 'submitSetRequiredDataSourcesMutation');
+
+    const hasErrored = await setDashboardsRequiredDataSources('url', 'token');
+    expect(hasErrored).toBe(false);
+    expect(console.error).toHaveBeenCalledWith(
+      `Multiple Quickstart data sources detected for Quickstart: Template Quickstart, Dashboards must be updated manually`
+    );
+
+    expect(Dashboard.submitSetRequiredDataSourcesMutation).not.toBeCalled();
   });
 });


### PR DESCRIPTION
# Summary

Updates the `set-dashboards-required-datasources` workflow to skip over quickstarts that have multiple datasources. Skipping for this reason produces an error log line and custom event so that required datasources can be manually assigned.


