### PR TITLE
Add script aliases and fix typo

### DIFF
--- a/.github/workflows/reusable.quickstart_submission.yml
+++ b/.github/workflows/reusable.quickstart_submission.yml
@@ -143,9 +143,10 @@ jobs:
         run: |
           URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/$PR_NUMBER/files"
           cd utils && yarn set-dashboards-required-datasources "$URL"
+
   set-alert-policy-required-datasources:
     needs: [submit-quickstarts]
-    name: Set alert policy requierd datasources
+    name: Set alert policy required datasources
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo

--- a/utils/package.json
+++ b/utils/package.json
@@ -21,7 +21,9 @@
     "dashboard-helper": "ts-node dashboard-helper.ts",
     "generate-schema-docs": "ts-node graphql-schemas/generate-schema-docs.js",
     "preview": "ts-node preview.ts",
-    "create-preview-links": "ts-node create-preview-links.ts"
+    "create-preview-links": "ts-node create-preview-links.ts",
+    "set-alert-policy-required-datasources": "ts-node set-alert-policy-required-datasources.ts",
+    "set-dashboards-required-datasources": "ts-node set-dashboards-required-datasources.ts"
   },
   "dependencies": {
     "@actions/core": "^1.9.1",


### PR DESCRIPTION
# Summary
The latest run of "Update quickstarts" [failed](https://github.com/newrelic/newrelic-quickstarts/actions/runs/3851426408/jobs/6562606655). No need to rerun it since the PR that kicked it off had no content changes.

Looks like we are missing some scripts in the `package.json` for the new workflows, I added those and fixed a typo.