### PR TITLE
Make data source publishing a dependency of quickstart publishing

### DIFF
--- a/.github/workflows/reusable.quickstart_submission.yml
+++ b/.github/workflows/reusable.quickstart_submission.yml
@@ -85,7 +85,7 @@ jobs:
           cd utils && yarn create-validate-data-sources "$URL" "$DRY_RUN"
 
   submit-quickstarts:
-    needs: [submit-install-plans]
+    needs: [submit-install-plans, submit-data-sources]
     name: Submit quickstarts
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Summary

In order to ensure that the required data sources are present in the catalog before attempting to use them in a quickstart, this sets the data source publishing job as a requirement of the quickstart publishing job.
