### PR TITLE
NR84487: Nextcloud - removed hyperlink

### DIFF
--- a/quickstarts/nextcloud/config.yml
+++ b/quickstarts/nextcloud/config.yml
@@ -8,7 +8,7 @@ description: |
   Control, monitor and secure all the data of Nextcloud with Infrastructure monitoring agent and Prometheus open metric integration to view a thorough Nextcloud server dashboard that contains a high-level overview of their app's performance. 
   - Assist teams in creating architectural maps, tracking down all the issues fast, and observing the Apdex of the app.
   - Maintain a quick throughput and low latency.
-  - Control over the workflow of [Nextcloud](https://nextcloud.com/) .
+  - Control over the workflow of Nextcloud.
   - Check the health of the dependencies such as database, application, server.
   - Give specific results to help with the problems.
   ### What’s included?


### PR DESCRIPTION
Ticket: https://issues.newrelic.com/browse/NR-84487 
Description: In the [Public IO page](https://newrelic.com/instant-observability/nextcloud), I have removed a hyperlink to the Nextcloud.

![image](https://user-images.githubusercontent.com/101187392/215797651-dd36b647-4373-41d3-8f8b-cb724aedcdae.png)

# Summary

A concise description of the changes being introduced. Please review the pre-merge checklist section to validate this pull request is ready for review and merge. **If it is not ready, please mark the pull request as a draft.**

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->
## Pre merge checklist

<!-- THIS CHECKLIST MUST BE FULLY COMPLETE OR YOUR PR WILL NOT BE MERGED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you include an InstallPlan and Documentation reference?
- [ ] Are all documentation links publically accessible?
- [ ] Did you check your descriptive content for [voice and tone](https://docs.newrelic.com/docs/style-guide/writing-strategies/voice-strategies-docs-sound-new-relic/)? 
- [ ] Did you check your descriptive content for spelling and grammar errors?

### Dashboards 

- [ ] Does the PR contain a screenshot for each of your dashboards?
- [ ] Do your screenshots show data?
- [ ] Has the [sanitization script](https://github.com/newrelic/newrelic-quickstarts/blob/main/CONTRIBUTING.md#dashboards) been run on each dashboard?

### Alerts

- [ ] Did you check that your alerts actually work?
