### PR TITLE
Add PHP as data source to php quickstart

### DIFF
--- a/quickstarts/php/php/config.yml
+++ b/quickstarts/php/php/config.yml
@@ -62,6 +62,9 @@ keywords:
 installPlans:
   - php-agent
 
+dataSourceIds:
+  - php
+
 dashboards:
   - php
 alertPolicies:


### PR DESCRIPTION


Adding a PHP data source to the php quickstart for bug bash purposes. 