### PR TITLE
fix: remove env call from pr-merged

### DIFF
--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -139,7 +139,7 @@ jobs:
     needs: [generate-uuid, get-pr-number]
     uses: ./.github/workflows/reusable.quickstart_submission.yml
     with:
-      pr-number: ${{ env.pr-number }}
+      pr-number: ${{ steps.get_pr_number.outputs.pr-number }}
       dry-run: false
     secrets:
       nr-api-url: ${{ secrets.NR_API_URL_STAGING }}
@@ -151,7 +151,7 @@ jobs:
     needs: [staging, get-pr-number]
     uses: ./.github/workflows/reusable.quickstart_submission.yml
     with:
-      pr-number: ${{ env.pr-number }}
+      pr-number: ${{ steps.get_pr_number.outputs.pr-number }}
       dry-run: false
     secrets:
       nr-api-url: ${{ secrets.NR_API_URL }}
@@ -163,7 +163,7 @@ jobs:
     needs: [staging, get-pr-number]
     uses: ./.github/workflows/reusable.quickstart_submission.yml
     with:
-      pr-number: ${{ env.pr-number }}
+      pr-number: ${{ steps.get_pr_number.outputs.pr-number }}
       dry-run: false
     secrets:
       nr-api-url: ${{ secrets.NR_API_URL_EU }}


### PR DESCRIPTION
env is not available in this place, so using the value from outputs.