### PR TITLE
Trigger new build for core-web-vitals

### DIFF
--- a/quickstarts/core-web-vitals/config.yml
+++ b/quickstarts/core-web-vitals/config.yml
@@ -48,3 +48,4 @@ dashboards:
   # Authors of the quickstart (required)
 authors:
   - Darren Doyle
+


### PR DESCRIPTION
# Summary

The job to publish the latest changes to this quickstart failed due to issues in the pipeline. Those issues have been addressed and this PR is to trigger them again for the `core-web-vitals` quickstart to get those changes published.
