### PR TITLE
Fixing 'Network Routers and Switches' alert condition

### DIFF
--- a/alert-policies/network-routers-and-switches/average-transmit-violation.yml
+++ b/alert-policies/network-routers-and-switches/average-transmit-violation.yml
@@ -5,7 +5,7 @@ description: |+
 type: STATIC
 
 nrql:
-  query: "average(kentik.snmp.IfOutUtilization) FACET device_name, if_interface_name, if_Alias WHERE metricName = 'kentik.snmp.IfOutUtilization' AND entity.type in ('ROUTER','SWITCH') and if_Type like 'ethernetcsmacd'"
+  query: "FROM METRIC SELECT average(kentik.snmp.IfOutUtilization) FACET device_name, if_interface_name, if_Alias WHERE metricName = 'kentik.snmp.IfOutUtilization' AND entity.type in ('ROUTER','SWITCH') and if_Type like 'ethernetcsmacd'"
 
 valueFunction: SINGLE_VALUE 
 


### PR DESCRIPTION
## Description
One of the alert conditions for the _Network Routers and Switches_ quickstart was missing some necessary parts of it's NRQL query. This was causing errors in the UI when attempting to install the conditions (see screenshot below)

## Screenshot(s)
![Screenshot 2023-03-28 at 14 55 50](https://user-images.githubusercontent.com/1946433/228379147-f5681328-ee1e-43fb-9bf0-1d9bbb042140.png)


## Related Issue(s)
- NR-102600