### PR TITLE
Fix mongodb prometheus dashboard limits (NR-105374)

### DIFF
--- a/dashboards/mongodb-prometheus/mongodb.json
+++ b/dashboards/mongodb-prometheus/mongodb.json
@@ -1500,7 +1500,7 @@
       ],
       "nrqlQuery": {
         "accountIds": [],
-        "query": "SELECT cluster FROM (FROM Metric SELECT count(*)  WHERE metricName='mongodb_dbstats_dataSize' limit max FACET mongodb_cluster_name AS 'cluster' ) ORDER BY cluster since 30 days ago"
+        "query": "SELECT cluster FROM (FROM Metric SELECT count(*)  WHERE metricName='mongodb_dbstats_dataSize' limit max FACET mongodb_cluster_name AS 'cluster' ) limit max ORDER BY cluster since 1 day ago"
       },
       "title": "Clusters",
       "type": "NRQL",
@@ -1519,7 +1519,7 @@
       ],
       "nrqlQuery": {
         "accountIds": [],
-        "query": "SELECT database FROM (FROM Metric SELECT count(*) limit max WHERE metricName='mongodb_dbstats_dataSize' FACET database  AS 'database' ) ORDER BY database"
+        "query": "SELECT database FROM (FROM Metric SELECT count(*) limit max WHERE metricName='mongodb_dbstats_dataSize' FACET database  AS 'database' ) limit max ORDER BY database since 1 day ago"
       },
       "title": "Databases",
       "type": "NRQL",
@@ -1538,7 +1538,7 @@
       ],
       "nrqlQuery": {
         "accountIds": [],
-        "query": "SELECT collection FROM (FROM Metric SELECT count(*) limit max WHERE metricName='mongodb_collstats_storageStats_count' FACET collection  AS 'collection' ) ORDER BY collection"
+        "query": "SELECT collection FROM (FROM Metric SELECT count(*) limit max WHERE metricName='mongodb_collstats_storageStats_count' FACET collection  AS 'collection' ) limit max ORDER BY collection since 1 day ago"
       },
       "title": "Collections",
       "type": "NRQL",
@@ -1557,7 +1557,7 @@
       ],
       "nrqlQuery": {
         "accountIds": [],
-        "query": "SELECT replica FROM (FROM Metric SELECT count(*) limit max WHERE metricName='mongodb_rs_members_health' FACET rs_nm  AS 'replica' ) ORDER BY replica"
+        "query": "SELECT replica FROM (FROM Metric SELECT count(*) limit max WHERE metricName='mongodb_rs_members_health' FACET rs_nm  AS 'replica' ) limit max ORDER BY replica since 1 day ago"
       },
       "title": "Replica Sets",
       "type": "NRQL",
@@ -1576,7 +1576,7 @@
       ],
       "nrqlQuery": {
         "accountIds": [],
-        "query": "SELECT member FROM (FROM Metric SELECT count(*) limit max WHERE metricName='mongodb_rs_members_health' FACET member_idx  AS 'member' ) ORDER BY member"
+        "query": "SELECT member FROM (FROM Metric SELECT count(*) limit max WHERE metricName='mongodb_rs_members_health' FACET member_idx  AS 'member' ) limit max ORDER BY member since 1 day ago"
       },
       "title": "Members",
       "type": "NRQL",


### PR DESCRIPTION
# Summary

This PR fixes queries for populating variables which in case customers have a lot of information wouldn't be populated correctly as the default query limit is 10 results.

It also adds a `since 1 day ago` to all variable queries to match the expiration period of mongo entities

