### PR TITLE
chore: Favor showing openai qs in add data

### DIFF
--- a/data-sources/openai/config.yaml
+++ b/data-sources/openai/config.yaml
@@ -9,8 +9,6 @@ install:
       url: https://github.com/newrelic/openai-api-monitoring
 
 keywords:
-  - NR1_addData
-  - NR1_sys
   - openai
   - gpt
   - gpt3

--- a/quickstarts/openai/config.yaml
+++ b/quickstarts/openai/config.yaml
@@ -7,15 +7,15 @@ description: |
   ## Monitor your GPT-3 and GPT-4 Application Usage in New Relic
 
   With the GPT integration, you'll have the ability to seamlessly monitor OpenAI completion queries and simultaneously log useful statistics in a New Relic customizable dashboard about your requests.
-  
+
   By adding just two lines of code, users can gain access to key performance metrics such as cost, response time, and sample inputs/outputs. The dashboard also allows users to track total requests, average token/requests, and model names. 
-  
+
   With New Relic's fully customizable dashboard, users can add additional metrics based on their specific business requirements and needs. 
-  
+
   Overall, New Relic's OpenAI integration provides real-time metrics around GPT applications to help businesses optimize usage, reduce costs, and achieve better results.
 
 summary: |
-  Seamlessly monitor your usage of OpenAI’s GPT Series APIs using New Relic’s dashboard. You'll get access to real-time metrics that can help you optimize usage, reduce costs, and achieve better results. 
+  Seamlessly monitor your usage of OpenAI’s GPT Series APIs using New Relic’s dashboard. You'll get access to real-time metrics that can help you optimize usage, reduce costs, and achieve better results.
 
 icon: openai-logo.svg
 
@@ -26,19 +26,21 @@ authors:
   - Yogev Kriger
 
 documentation:
-  - name: Monitor OpenAI 
+  - name: Monitor OpenAI
     description: |
       A lightweight tool to monitor your OpenAI workload.
     url: >-
       https://github.com/newrelic/openai-api-monitoring
 
 keywords:
+  - NR1_addData
+  - NR1_sys
   - featured
   - openai
   - ai
   - gpt
-  - mlops 
-    
+  - mlops
+
 installPlans:
   - setup-openai
 


### PR DESCRIPTION
This PR switches to showing the openai quickstart in Add data and Select your stack over the data source