### PR TITLE
Fix dashboard helper output

### DIFF
--- a/utils/__tests__/create-validate-pr-quickstarts.test.js
+++ b/utils/__tests__/create-validate-pr-quickstarts.test.js
@@ -8,6 +8,7 @@ import * as githubHelpers from '../lib/github-api-helpers';
 
 jest.mock('@actions/core');
 jest.spyOn(global.console, 'error').mockImplementation(() => {});
+jest.spyOn(global.console, 'log').mockImplementation(() => {});
 
 jest.mock('../lib/github-api-helpers', () => ({
   ...jest.requireActual('../lib/github-api-helpers'),

--- a/utils/__tests__/dashboard-helper.test.js
+++ b/utils/__tests__/dashboard-helper.test.js
@@ -110,7 +110,10 @@ describe('dashboard-helper', () => {
         'raw-url/dashboards/cool-dash/cool-dash.json',
         { headers: { authorization: 'token token' } }
       );
-      expect(core.setOutput).toHaveBeenCalledWith('comment', '### The PR checks have run and found the following warnings:%0A%0A| Warning | Filepath | Line # | %0A| --- | --- | --- | %0A| \"permissions\" field should not be used | dashboards/cool-dash/cool-dash.json | 2 |%0A%0AReference the [Contributing Docs for Dashboards](https://github.com/newrelic/newrelic-quickstarts/blob/main/CONTRIBUTING.md#dashboards) for more information. %0A');
+      expect(core.setOutput).toHaveBeenCalledWith(
+        'comment',
+        '### The PR checks have run and found the following warnings:\n\n| Warning | Filepath | Line # | \n| --- | --- | --- | \n| "permissions" field should not be used | dashboards/cool-dash/cool-dash.json | 2 |\n\nReference the [Contributing Docs for Dashboards](https://github.com/newrelic/newrelic-quickstarts/blob/main/CONTRIBUTING.md#dashboards) for more information. \n'
+      );
     });
 
     test('handles network error;', async () => {

--- a/utils/__tests__/set-dashboard-required-datasources.test.js
+++ b/utils/__tests__/set-dashboard-required-datasources.test.js
@@ -6,6 +6,7 @@ import * as nrGraphQlHelpers from '../lib/nr-graphql-helpers';
 import { setDashboardsRequiredDataSources } from '../set-dashboards-required-datasources';
 
 jest.spyOn(global.console, 'error').mockImplementation(() => {});
+jest.spyOn(global.console, 'log').mockImplementation(() => {});
 
 jest.mock('../lib/github-api-helpers', () => ({
   ...jest.requireActual('../lib/github-api-helpers'),

--- a/utils/dashboard-helper.ts
+++ b/utils/dashboard-helper.ts
@@ -28,7 +28,8 @@ export const checkLine = (line: string) => {
   return warningsFound;
 };
 
-const encodedNewline = '%0A';
+const encodedNewline = '\n';
+
 export const createWarningComment = (warnings: string[]) => {
   const commentMessage = [
     `### The PR checks have run and found the following warnings:${encodedNewline}`,


### PR DESCRIPTION
# Summary

The dashboard helper was outputting comments that were unreadable because the newlines were not being respected.
This appears to be due to us using the `actions/core` library to handle setting the output, we no longer need to use the encoded newline and can just make use of `\n` directly.
