### PR TITLE
Fix nrql for tidbcloud active connection

### DIFF
--- a/dashboards/tidbcloud/dashboard.json
+++ b/dashboards/tidbcloud/dashboard.json
@@ -279,7 +279,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT sum(`tidb_cloud.db_active_connections`) as 'Active Connection' FROM Metric SINCE 24 HOURS AGO TIMESERIES WHERE project_name IN ({{project_name}}) AND cluster_id IN ({{cluster_id}}) AND cluster_name IN ({{cluster_name}}) AND instance IN ({{instance}})"
+                "query": "SELECT (average(`tidb_cloud.db_active_connections`) * cardinality(`tidb_cloud.db_active_connections`)) AS 'Active Connection' FROM Metric SINCE 24 HOURS AGO TIMESERIES WHERE project_name IN ({{project_name}}) AND cluster_id IN ({{cluster_id}}) AND cluster_name IN ({{cluster_name}}) AND instance IN ({{instance}})"
               }
             ],
             "nullValues": {


### PR DESCRIPTION
# Summary

This PR fixes nrql used by the active connection panel.

It uses `average * cardinality` instead of `sum` to get correct aggregated results.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->

## Pre merge checklist

<!-- THIS CHECKLIST MUST BE FULLY COMPLETE OR YOUR PR WILL NOT BE MERGED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you include a Data source and Documentation reference?
- [ ] Are all documentation links publicly accessible?
- [ ] Did you check your descriptive content for [voice and tone](https://docs.newrelic.com/docs/style-guide/writing-strategies/voice-strategies-docs-sound-new-relic/)?
- [ ] Did you check your descriptive content for spelling and grammar errors?
- [ ] Did you review your content with a subject matter expert? (e.g. a Browser agent quickstart is reviewed with a member of the Browser Agent team)

### Dashboards

- [ ] Does the PR contain a screenshot for each of your dashboards?
- [ ] Do your screenshots show data?
- [ ] Has the [sanitization script](https://github.com/newrelic/newrelic-quickstarts/blob/main/CONTRIBUTING.md#dashboards) been run on each dashboard?

### Alerts

- [ ] Did you check that your alerts actually work?
