### PR TITLE
Update Azure-based quickstarts that failed to submit previously

### DIFF
--- a/quickstarts/azure/azure-app-service-environment/config.yml
+++ b/quickstarts/azure/azure-app-service-environment/config.yml
@@ -1,5 +1,6 @@
 id: 35b73600-922b-49f9-9702-836771340372
 slug: azure-app-service-environment
+title: Azure App Service Environment
 description: |-
   ## What is Azure App Service Environment?
 
@@ -14,8 +15,8 @@ description: |-
   [New Relic Azure App Service Environment](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-app-service-environment-monitoring-integration/) monitoring quickstart empowers you to track the performance of Azure App Service Environment via different metrics including account bytes received, bytes sent, cpu percentage, disk queue length, memory percentage. 
 
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context and get valuable insights.
-  
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
   Monitoring Azure App Service Environment is critical to tracking the performance through key metrics. Install the New Relic Azure App Service Environment monitoring quickstart to get a pre-built dashboard tailored to monitor your Azure App Service Environment.
 icon: logo.png
@@ -23,7 +24,6 @@ level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Azure App Service Environment
 documentation:
   - name: Azure App Service Environment installation docs
     description: |
@@ -37,4 +37,4 @@ keywords:
 dashboards:
   - azure-app-service-environment
 dataSourceIds:
- - azure-monitor
+  - azure-monitor

--- a/quickstarts/azure/azure-app-service-plan/config.yml
+++ b/quickstarts/azure/azure-app-service-plan/config.yml
@@ -1,5 +1,6 @@
 id: 9dc69e3b-c6c6-4b3e-b832-0f1ceab6c17b
 slug: azure-app-service-plan
+title: Azure App Service Plan
 description: |-
   ## What is Azure App Service Plan?
 
@@ -12,10 +13,10 @@ description: |-
   ### Why monitor Azure App Service Plan with New Relic?
 
   [New Relic Azure App Service Plan](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-app-service-plan/) monitoring quickstart empowers you to track the performance of Azure App Service Plan via different metrics including bytes received, bytes sent, CPU percentage, disk queue length, memory percentage. 
-  
+
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context, and get valuable insights.
-  
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
   Monitoring Azure App Service Plan is critical to track the performance through via key metrics. Download New Relic Azure App Service Plan monitoring quickstart to get a pre-built dashboard tailored to monitor your Azure App Service Plan Service.
 icon: logo.png
@@ -23,7 +24,6 @@ level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Azure App Service Plan
 documentation:
   - name: Azure App Service Plan installation docs
     description: |

--- a/quickstarts/azure/azure-application-insights/config.yml
+++ b/quickstarts/azure/azure-application-insights/config.yml
@@ -1,5 +1,6 @@
 id: 53d48c5a-1f30-4793-b742-a04929bf1d4b
 slug: azure-application-insights
+title: Azure Application Insights
 description: |-
   ## What is Azure Application Insights?
 
@@ -12,10 +13,10 @@ description: |-
   ### Why monitor Azure Application Insights with New Relic?
 
   [New Relic Azure Application Insights](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-application-insights-monitoring-integration/) monitoring quickstart empowers you to track the performance of Azure Application Insights via different metrics including receiving response time, availability, dependency call failures	and browser exceptions.
-  
+
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context and get valuable insights.
-  
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
   Monitoring Azure Application Insights is critical to tracking the performance through key metrics. Install the New Relic Azure Application Insights monitoring quickstart to get a pre-built dashboard tailored to monitor your Azure Application Insights service.
 icon: logo.png
@@ -23,7 +24,6 @@ level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Azure Application Insights
 documentation:
   - name: Azure Application Insights installation docs.
     description: |
@@ -38,4 +38,4 @@ keywords:
 dashboards:
   - azure-application-insights
 dataSourceIds:
- - azure-monitor
+  - azure-monitor

--- a/quickstarts/azure/azure-automation-account/config.yml
+++ b/quickstarts/azure/azure-automation-account/config.yml
@@ -1,5 +1,6 @@
 id: b299cfaa-f5a4-4aea-9f0f-a7f3289b3d13
 slug: azure-automation-account
+title: Azure Automation Account
 description: |-
   ## What is Azure Automation Account?
 
@@ -12,10 +13,10 @@ description: |-
   ### Why monitor Azure Automation Account with New Relic?
 
   [New Relic Azure Automation Account](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-automation-account-monitoring-integration/) monitoring quickstart empowers you to track the performance of Azure Automation Account via different metrics including hybrid worker ping, total jobs, total update deployment machine runs and total update deployment runs.
-  
+
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context, and get valuable insights.
-  
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
   Monitoring Azure Automation Account is critical to tracking the performance through key metrics. Install the New Relic Azure Automation Account monitoring quickstart to get a pre-built dashboard tailored to monitor your Azure Automation Account Service.
 icon: logo.png
@@ -23,7 +24,6 @@ level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Azure Automation Account
 documentation:
   - name: Azure Automation Account installation docs
     description: |

--- a/quickstarts/azure/azure-cdn-profile/config.yml
+++ b/quickstarts/azure/azure-cdn-profile/config.yml
@@ -1,5 +1,6 @@
 id: 1eddac86-3ee3-42b9-aae3-ceebb4b42401
 slug: azure-cdn-profile
+title: Azure CDN profile
 description: |-
   ## What is Azure CDN profile?
 
@@ -13,10 +14,10 @@ description: |-
   ### Why monitor Azure CDN profile with New Relic?
 
   [New Relic Azure CDN profile](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-cdn-profile-monitoring-integration/) monitoring quickstart empowers you to track the performance of Azure CDN profile via different metrics including total latency, request count, byte hit ratio and response size. 
-  
+
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context, and get valuable insights.
-  
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
   Monitoring Azure CDN profile is critical to tracking the performance of the content via key metrics. Install the New Relic Azure CDN profile monitoring quickstart to get a pre-built dashboard tailored to monitor your Azure CDN profile service.
 icon: logo.png
@@ -24,7 +25,6 @@ level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Azure CDN profile
 documentation:
   - name: Azure CDN profile installation docs
     description: |

--- a/quickstarts/azure/azure-cloud-services/config.yml
+++ b/quickstarts/azure/azure-cloud-services/config.yml
@@ -1,5 +1,6 @@
 id: 9c966ae6-12e8-4147-9350-5b95efae8e30
 slug: azure-cloud-services
+title: Azure Cloud Services
 description: |-
   ## What is Azure Cloud Services?
 
@@ -12,10 +13,10 @@ description: |-
   ### Why monitor Azure Cloud Services with New Relic?
 
   [New Relic Azure Cloud Services](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-cloud-services-monitoring-integration/) monitoring quickstart empowers you to track the performance of Azure Cloud Services via different metrics including available memory bytes, disk read bytes, disk write bytes and more.
-  
+
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context, and get valuable insights.
-  
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
   Monitoring Azure Cloud Services is critical to tracking the performance through key metrics. Install the New Relic Azure Cloud Services monitoring quickstart to get a pre-built dashboard tailored to monitor your Azure Cloud Services.
 icon: logo.png
@@ -23,7 +24,6 @@ level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Azure Cloud Services
 documentation:
   - name: Azure Cloud Services installation docs
     description: |

--- a/quickstarts/azure/azure-cognitive-search/config.yml
+++ b/quickstarts/azure/azure-cognitive-search/config.yml
@@ -1,5 +1,6 @@
 id: 535361fa-6fe6-4283-a0fc-d7522bcb3d06
 slug: azure-cognitive-search
+title: Azure Cognitive Search
 description: |-
   ## What is Azure Cognitive Search?
 
@@ -12,10 +13,10 @@ description: |-
   ### Why monitor Azure Cognitive Search with New Relic?
 
   [New Relic Azure Cognitive Search](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-cognitive-search-monitoring-integration/) monitoring quickstart empowers you to track the performance of Azure Cognitive Search via different metrics including search latency, search queries per second, documents processed count, skill execution count and more.
-  
+
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context and get valuable insights.
-  
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
   Monitoring Azure Cognitive Search is critical to tracking the performance through key metrics. Install the New Relic Azure Cognitive Search monitoring quickstart to get a pre-built dashboard tailored to monitor your Azure Cognitive Search service.
 icon: logo.png
@@ -23,7 +24,6 @@ level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Azure Cognitive Search 
 documentation:
   - name: Azure Cognitive Search installation docs
     description: |

--- a/quickstarts/azure/azure-data-box-edge/config.yml
+++ b/quickstarts/azure/azure-data-box-edge/config.yml
@@ -1,5 +1,6 @@
 id: c852cbc9-bb73-4e6c-ac36-07e7b35c266d
 slug: azure-data-box-edge
+title: Azure Data Box Edge
 description: |-
   ## What is Azure Data Box Edge?
 
@@ -8,14 +9,14 @@ description: |-
   ### New Relic Azure Data Box Edge quickstart features
 
   A standard dashboard that tracks key indicators like total capacity, bytes uploaded to cloud, cloud read throughput, hyperV memory utilization and more.  It runs custom queries and visualizes the data immediately.
-  
+
   ### Why monitor Azure Data Box Edge with New Relic?
 
   [New Relic Azure Data Box Edge](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-data-box-edge-monitoring-integration/) monitoring quickstart empowers you to track the performance of Azure Data Box Edge via different metrics including total capacity, bytes uploaded to cloud, cloud read throughput, hyperV memory utilization and more. 
-  
+
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context and get valuable insights.
-  
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
   Monitoring Azure Data Box Edge is critical to tracking the performance through key metrics. Install the New Relic Azure Data Box Edge monitoring quickstart to get a pre-built dashboard tailored to monitor your Azure Data Box Edge service.
 icon: logo.png
@@ -23,9 +24,8 @@ level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Azure Data Box Edge
 documentation:
-  - name: Azure Data Box Edge installation docs 
+  - name: Azure Data Box Edge installation docs
     description: |
       Monitor Azure Data Box Edge by connecting Azure to New Relic.
     url: >-

--- a/quickstarts/azure/azure-data-explorer/config.yml
+++ b/quickstarts/azure/azure-data-explorer/config.yml
@@ -1,10 +1,11 @@
 id: 3953ee6f-6e6c-42f8-8d17-bcda79c08d15
 slug: azure-data-explorer
+title: Azure Data Explorer
 description: |-
   ## What is Azure Data Explorer?
 
   Azure Data Explorer is a fast, fully managed data analytics service for real-time analysis on large volumes of data streaming from applications, websites, IoT devices and more.
-  
+
   ### New Relic Azure Data Explorer quickstart features
 
   A standard dashboard that tracks key indicators like CPU utilization level, ingestion latency, ingestion result and query duration. It runs custom queries and visualizes the data immediately.
@@ -12,10 +13,10 @@ description: |-
   ### Why monitor Azure Data Explorer with New Relic?
 
   [New Relic Azure Data Explorer](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-data-explorer-monitoring-integration/) monitoring quickstart empowers you to track the performance of Azure Data Explorer via different metrics including CPU utilization level, ingestion latency, ingestion result and query duration.
-  
+
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context, and get valuable insights.
-  
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
   Monitoring Azure Data Explorer toolbox gives you an end-to-end solution for data ingestion, query, visualization and management. Install the New Relic Azure Data Explorer monitoring quickstart to get a pre-built dashboard tailored to monitor your Azure Data Explorer service.
 icon: logo.png
@@ -23,7 +24,6 @@ level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Azure Data Explorer
 documentation:
   - name: Azure Data Explorer installation docs
     description: |

--- a/quickstarts/azure/azure-data-lake-analytics/config.yml
+++ b/quickstarts/azure/azure-data-lake-analytics/config.yml
@@ -1,5 +1,6 @@
 id: 4ed0aedb-2f24-4189-b28f-8d498d89edbf
 slug: azure-data-lake-analytics
+title: Azure Data Lake Analytics
 description: |-
   ## What is Azure Data Lake Analytics?
 
@@ -12,18 +13,17 @@ description: |-
   ### Why monitor Azure Data Lake Analytics with New Relic?
 
   [New Relic Azure Data Lake Analytics](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-data-lake-analytic-monitoring-integration/) monitoring quickstart empowers you to track the performance of Azure Data Lake Analytics via different metrics including A standard dashboard that tracks key indicators like number of jobs stage, AU time for jobs ended in success, failure and cancelled. 
-  
+
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context, and get valuable insights.
-  
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
   Monitoring Azure Data Lake Analytics is critical to tracking the performance through key metrics. Install the New Relic Azure Data Lake Analytics Service monitoring quickstart to get a pre-built dashboard tailored to monitor your Azure Data Lake Analytics service.
 icon: logo.png
 level: New Relic
 authors:
   - New Relic
-  - New Relic Partner  
-title: Azure Data Lake Analytics
+  - New Relic Partner
 documentation:
   - name: Azure Data Lake Analytics installation docs
     description: |

--- a/quickstarts/azure/azure-data-lake-storage/config.yml
+++ b/quickstarts/azure/azure-data-lake-storage/config.yml
@@ -1,5 +1,6 @@
 id: 1e1c1ed6-12b5-46a0-89f0-7231edd0aed5
 slug: azure-data-lake-storage
+title: Azure Data Lake Storage
 description: |-
   ## What is Azure Data Lake Storage?
 
@@ -8,14 +9,14 @@ description: |-
   ### New Relic Azure Data Lake Storage quickstart features
 
   A standard dashboard that tracks key indicators like data read, data written, read requests, total storage and written requests. It runs custom queries and visualizes the data immediately.
- 
+
   ### Why monitor Azure Data Lake Storage with New Relic?
 
   [New Relic Azure Data Lake Storage](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-data-lake-storage-monitoring-integration/) monitoring quickstart empowers you to track the performance of Azure Data Lake Storage via different metrics including data read, data written, read requests, total storage and written requests. 
-  
+
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context, and get valuable insights.
-  
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
   Monitoring Azure Data Lake Storage is critical to tracking the performance through key metrics. Install the New Relic Azure Data Lake Storage monitoring quickstart to get a pre-built dashboard tailored to monitor your Azure Data Lake Storage service.
 icon: logo.png
@@ -23,7 +24,6 @@ level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Azure Data Lake Storage
 documentation:
   - name: Azure Data Lake Storage installation docs
     description: |

--- a/quickstarts/azure/azure-data-share/config.yml
+++ b/quickstarts/azure/azure-data-share/config.yml
@@ -1,5 +1,6 @@
 id: f965234e-4904-463b-935b-ff95da841abc
 slug: azure-data-share
+title: Azure Data Share
 description: |-
   ## What is Azure Data Share?
 
@@ -13,18 +14,17 @@ description: |-
   ### Why monitor Azure Data Share with New Relic?
 
   [New Relic Azure Data Share](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-data-share-monitoring-integration/) monitoring quickstart empowers you to track the performance of Azure Data Share via different metrics including share count, failed share subscription synchronizations, share subscription count and succeeded share synchronizations. 
-  
+
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context and get valuable insights.
-  
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
-  Using Data Share a data provider can share data and manage their shares all in one place. They can stay in control of how their data is handled by specifying terms of use for their data share. Azure Data Share helps enhance insights by making it easy to combine data from third parties to enrich analytics and AI scenarios.  
+  Using Data Share a data provider can share data and manage their shares all in one place. They can stay in control of how their data is handled by specifying terms of use for their data share. Azure Data Share helps enhance insights by making it easy to combine data from third parties to enrich analytics and AI scenarios.
 icon: logo.png
 level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Azure Data Share
 documentation:
   - name: Azure Data Share installation docs
     description: |
@@ -38,4 +38,4 @@ keywords:
 dashboards:
   - azure-data-share
 dataSourceIds:
-  - azure-monitor  
+  - azure-monitor

--- a/quickstarts/azure/azure-device-provisioning-service/config.yml
+++ b/quickstarts/azure/azure-device-provisioning-service/config.yml
@@ -1,5 +1,6 @@
 id: 10ecef52-8600-42f4-9587-ac8f5054a015
 slug: azure-device-provisioning-service
+title: Azure Device Provisioning Service
 description: |-
   ## What is Azure Device Provisioning Service?
 
@@ -15,7 +16,7 @@ description: |-
 
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context and get valuable insights.
 
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
   Monitoring Azure Device Provisioning Service is critical to tracking the performance through key metrics. Install the New Relic Azure Device Provisioning Service monitoring quickstart to get a pre-built dashboard tailored to monitor your Azure Device Provisioning Service.
 icon: logo.png
@@ -23,7 +24,6 @@ level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Azure Device Provisioning Service
 documentation:
   - name: Azure Device Provisioning Service installation docs
     description: |

--- a/quickstarts/azure/azure-hdinsight/config.yml
+++ b/quickstarts/azure/azure-hdinsight/config.yml
@@ -1,10 +1,11 @@
 id: 035f4083-0e3c-43f0-aca3-cc4b71730457
 slug: azure-hdinsight
+title: Azure HDInsight
 description: |-
   ## What is Azure HDInsight?
 
   Azure HDInsight is a managed, full-spectrum, open-source analytics service in the cloud for enterprises. With HDInsight, you can use open-source frameworks such as, Apache Spark, Apache Hive, LLAP, Apache Kafka, Hadoop and more, in your Azure environment.
-  
+
   ### New Relic Azure HDInsight quickstart features
 
   A standard dashboard that tracks key indicators like categorized gateway requests, pending memory, pending CPU. It runs custom queries and visualizes the data immediately.
@@ -12,10 +13,10 @@ description: |-
   ### Why monitor Azure HDInsight with New Relic?
 
   [New Relic Azure HDInsight](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-hdinsight-monitoring-integration/) monitoring quickstart empowers you to track the performance of Azure HDInsight via different metrics including categorized gateway requests, pending memory and pending CPU.
-  
+
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context, and get valuable insights.
-  
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
   Monitoring Azure HDInsight is critical to tracking the performance through key metrics. Install the New Relic Azure HDInsight monitoring quickstart to get a pre-built dashboard tailored to monitor your Azure HDInsight service.
 icon: logo.png
@@ -23,7 +24,6 @@ level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Azure HDInsight 
 documentation:
   - name: Azure HDInsight installation docs
     description: |
@@ -32,7 +32,7 @@ documentation:
       https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-hdinsight-monitoring-integration/
 keywords:
   - azure
-  - hdinsight 
+  - hdinsight
   - product partnerships
 dashboards:
   - azure-hdinsight

--- a/quickstarts/azure/azure-integration-service-environment/config.yml
+++ b/quickstarts/azure/azure-integration-service-environment/config.yml
@@ -1,5 +1,6 @@
 id: 6d356923-129b-4fbd-89cf-3df5fe75fa62
 slug: azure-integration-service-environment
+title: Azure Integration Service Environment
 description: |-
   ## What is Azure Integration Service Environment?
 
@@ -12,10 +13,10 @@ description: |-
   ### Why monitor Azure Integration Service Environment with New Relic?
 
   [New Relic Azure Integration Service Environment](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-integration-service-environment-monitoring-integration/) monitoring quickstart empowers you to track the performance of Azure Integration Service Environment via different metrics including actions completed, action latency, actions failed and connector memory usage. 
-  
+
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context and get valuable insights.
-  
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
   Monitoring Azure Integration Service Environment is critical to tracking the performance through key metrics. Install the New Relic Azure Integration Service Environment monitoring quickstart to  get a pre-built dashboard tailored to monitor your Azure Integration Service Environment.
 icon: logo.png
@@ -23,7 +24,6 @@ level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Azure Integration Service Environment
 documentation:
   - name: Azure Integration Service Environment installation docs
     description: |

--- a/quickstarts/azure/azure-iot-hub/config.yml
+++ b/quickstarts/azure/azure-iot-hub/config.yml
@@ -1,5 +1,6 @@
 id: 258b1e34-bc62-4692-b788-e652a884d916
 slug: azure-iot-hub
+title: Azure IoT Hub
 description: |-
   ## What is Azure IoT Hub?
 
@@ -12,10 +13,10 @@ description: |-
   ### Why monitor Azure IoT Hub with New Relic?
 
   [New Relic Azure Iothub](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-iot-hub-monitoring-integration/) monitoring quickstart empowers you to track the performance of Azure IoT Hub via different metrics including jobs completed, jobs failed, D2C endpoints latency and more. 
-  
+
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context and get valuable insights.
-  
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
   Monitoring Azure IoT Hub is critical to tracking the performance through key metrics. Install the New Relic Azure IoT Hub monitoring quickstart to get a pre-built dashboard tailored to monitor your Azure IoT Hub service.
 icon: logo.png
@@ -23,7 +24,6 @@ level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Azure IoT Hub
 documentation:
   - name: Azure IoT Hub installation docs
     description: |

--- a/quickstarts/azure/azure-netapp-capacity-pools/config.yml
+++ b/quickstarts/azure/azure-netapp-capacity-pools/config.yml
@@ -1,5 +1,6 @@
 id: 38dab6c5-98dd-4fbb-aeb8-3d73fc3c2234
 slug: azure-netapp-capacity-pools
+title: Azure NetApp Capacity Pools
 description: |-
   ## What is Azure NetApp Capacity Pools?
 
@@ -23,7 +24,6 @@ level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Azure NetApp Capacity Pools
 documentation:
   - name: Azure NetApp Capacity Pools installation docs
     description: |

--- a/quickstarts/azure/azure-netapp-files/config.yml
+++ b/quickstarts/azure/azure-netapp-files/config.yml
@@ -1,5 +1,6 @@
 id: 118491de-58f3-488c-aacf-bb11960495ec
 slug: azure-netapp-files
+title: Azure NetApp Files
 description: |-
   ## What is Azure NetApp Files?
 
@@ -12,10 +13,10 @@ description: |-
   ### Why monitor Azure NetApp Files with New Relic?
 
   [New Relic Azure NetApp Files](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-netapp-files-monitoring-integration/) monitoring quickstart empowers you to track the performance of Azure NetApp Files via different metrics including average write latency, total throughput, volume consumed size percentage, xregion replication lag time and more.
-  
+
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context, and get valuable insights.
-  
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
   Monitoring Azure NetApp Files is designed to provide high-performance file storage for enterprise workloads, provide high availability for your file storage needs, provides built-in data protection to help ensure the safe storage, availability and recoverability of your data. Download New Relic Azure NetApp Files monitoring quickstart to get a pre-built dashboard tailored to monitor your Azure NetApp Files service.
 icon: logo.png
@@ -23,7 +24,6 @@ level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Azure NetApp Files
 documentation:
   - name: Azure NetApp Files installation docs
     description: |

--- a/quickstarts/azure/azure-notification-hubs/config.yml
+++ b/quickstarts/azure/azure-notification-hubs/config.yml
@@ -1,10 +1,11 @@
 id: 7bfdc187-36b5-4f4a-a2fc-76052ed4531c
 slug: azure-notification-hubs
+title: Azure Notification Hubs
 description: |-
   ## What is Azure Notification Hubs?
 
   Azure Notification Hubs provide an easy-to-use and scaled-out push engine that enables you to send notifications to any platform(iOS, Android, Windows, etc.) from any back-end (cloud or on-premises).
-  
+
   ### New Relic Azure Notification Hubs quickstart features
 
   A standard dashboard that tracks key indicators like all incoming requests, successful notifications, payload errors, authorization errors and registration operations. It runs custom queries and visualizes the data immediately.
@@ -14,8 +15,8 @@ description: |-
   [New Relic Azure Notification Hubs](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-notification-hubs-monitoring-integration/) monitoring quickstart empowers you to track the performance of Azure Notification Hubs via different metrics including all incoming requests, successful notifications, payload errors, authorization errors and registration operations.
 
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context and get valuable insights.
-  
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
   Monitoring Azure Notification Hubs is critical to track the performance through key metrics. Download New Relic Azure Notification Hubs monitoring quickstart to get a pre-built dashboard tailored to monitor your Azure Notification Hubs service.
 icon: logo.png
@@ -23,7 +24,6 @@ level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Azure Notification Hubs
 documentation:
   - name: Azure Notification Hubs installation docs
     description: |

--- a/quickstarts/azure/azure-peering-service/config.yml
+++ b/quickstarts/azure/azure-peering-service/config.yml
@@ -1,5 +1,6 @@
 id: 97f13ea2-f247-47d2-adef-bb9b8cd0f4cd
 slug: azure-peering-service
+title: Azure Peering Service
 description: |-
   ## What is Azure Peering Service?
 
@@ -8,14 +9,14 @@ description: |-
   ### New Relic Azure Peering Service quickstart features
 
   A standard dashboard that tracks key indicators like round trip time. It runs custom queries and visualizes the data immediately.
-  
+
   ### Why monitor Azure Peering Service with New Relic?
 
   [New Relic Azure Peering Service](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-peering-service-monitoring-integration/) monitoring quickstart empowers you to track the performance of Azure Peering Service via round trip time. 
-  
+
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context and get valuable insights.
-  
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
   Monitoring Azure Peering Service is critical to tracking the performance through key metrics. Install the New Relic Azure Peering Service monitoring quickstart to  get a pre-built dashboard tailored to monitor your Azure Peering Service.
 icon: logo.png
@@ -23,9 +24,8 @@ level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Azure Peering Service
 documentation:
-  - name: Azure Peering Service installation docs 
+  - name: Azure Peering Service installation docs
     description: |
       Monitor Azure Peering Service by connecting Azure to New Relic.
     url: >-

--- a/quickstarts/azure/azure-peering/config.yml
+++ b/quickstarts/azure/azure-peering/config.yml
@@ -1,10 +1,11 @@
 id: 88267c0e-1067-4abe-b053-6ee210474e4f
 slug: azure-peering
+title: Azure Peering
 description: |-
   ## What is Azure Peering?
 
   Peering is the interconnection between Microsoft's global network (ASN AS8075) and your network for the purpose of exchanging internet traffic between Microsoft online services and Microsoft Azure Services. Carriers or Service Providers can request to connect at any of Microsoft's edge locations.
-  
+
   ### New Relic Azure Peering quickstart features
 
   A standard dashboard that tracks key indicators like egress traffic rate, flap counts, packet drop rate, session availability and more. It runs custom queries and visualizes the data immediately.
@@ -13,10 +14,10 @@ description: |-
   ### Why monitor Azure Peering with New Relic?
 
   [New Relic Azure Peering](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-peering-monitoring-integration/) monitoring quickstart empowers you to track the performance of Azure Peering via different metrics including egress traffic rate, flap counts, packet drop rate, session availability and more.
-  
+
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context, and get valuable insights.
-  
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
   Monitoring Azure Peering is critical to tracking the performance through key metrics. Install the New Relic Azure Peering monitoring quickstart to  get a pre-built dashboard tailored to monitor your Azure Peering.
 icon: logo.png
@@ -24,7 +25,6 @@ level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Azure Peering
 documentation:
   - name: Azure Peering installation docs
     description: |

--- a/quickstarts/azure/azure-private-dns-zones/config.yml
+++ b/quickstarts/azure/azure-private-dns-zones/config.yml
@@ -1,5 +1,6 @@
 id: cbd1434b-02ae-44a2-a761-862e346776d1
 slug: azure-private-dns-zones
+title: Azure Private DNS Zones
 description: |-
   ## What is Azure Private DNS Zones?
 
@@ -12,10 +13,10 @@ description: |-
   ### Why monitor Azure Private DNS Zones with New Relic?
 
   [New Relic Azure Private DNS Zones](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-private-dns-zones-monitoring-integration/) monitoring quickstart empowers you to track the performance of Azure Private DNS Zones via different metrics including query volume, record set capacity utilization, record set count and virtual network link count.
-  
+
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context, and get valuable insights.
-  
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
   Monitoring Azure Private DNS Zones is critical to track the performance through key metrics. Download New Relic Azure Private DNS Zones monitoring quickstart to get a pre-built dashboard tailored to monitor your Azure Private DNS Zones service.
 icon: logo.png
@@ -23,7 +24,6 @@ level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Azure Private DNS Zones
 documentation:
   - name: Azure Private DNS Zones installation docs
     description: |

--- a/quickstarts/azure/azure-purview/config.yml
+++ b/quickstarts/azure/azure-purview/config.yml
@@ -1,10 +1,11 @@
 id: 5337f5a2-5359-4547-837f-60c0759decf8
 slug: azure-purview
+title: Microsoft Purview
 description: |-
   ## What is Microsoft Purview?
 
   Microsoft Purview provides a unified data governance solution to help manage and govern your on-premises, multicloud, and software as a service (SaaS) data. Easily create a holistic, up-to-date map of your data landscape with automated data discovery, sensitive data classification, and end-to-end data lineage. Enable data consumers to access valuable, trustworthy data management. 
- 
+
   ### New Relic Microsoft Purview quickstart features
 
   A standard dashboard that tracks key indicators like scan cancelled count, scan completed count, scan failed count, data map capacity units count. It runs custom queries and visualizes the data immediately.
@@ -12,10 +13,10 @@ description: |-
   ### Why monitor Microsoft Purview with New Relic?
 
   [New Relic Microsoft Purview](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-purview-monitoring-integration/) monitoring quickstart empowers you to track the performance of Microsoft Purview via different metrics including scan failed count, scan cancelled count, scan completed count, data map capacity units count.
-  
+
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context and get valuable insights.
-  
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
   Monitoring Microsoft Purview is critical to tracking the performance through key metrics. Install the New Relic Microsoft Purview monitoring quickstart to get a pre-built dashboard tailored to monitor your Microsoft Purview service.
 icon: logo.png
@@ -23,7 +24,6 @@ level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Microsoft Purview
 documentation:
   - name: Microsoft Purview installation docs
     description: |

--- a/quickstarts/azure/azure-spring-apps/config.yml
+++ b/quickstarts/azure/azure-spring-apps/config.yml
@@ -1,5 +1,6 @@
 id: 9402af65-890c-49d7-aa00-d450d80b1505
 slug: azure-spring-apps
+title: Azure Spring Apps
 description: |-
   ## What is Azure Spring Apps?
 
@@ -12,10 +13,10 @@ description: |-
   ### Why monitor Azure Spring Apps with New Relic?
 
   [New Relic Azure Spring Apps](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-spring-apps-monitoring-integration/) monitoring quickstart empowers you to track the performance of Azure Spring Apps via different metrics including memory usage, CPU usage, global request total count and global request average time.
-  
+
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context, and get valuable insights.
-  
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
   Monitoring Azure Spring Apps is critical to track the performance through key metrics. Download New Relic Azure Spring Apps monitoring quickstart to get a pre-built dashboard tailored to monitor your Azure Spring Apps service.
 icon: logo.png
@@ -23,7 +24,6 @@ level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Azure Spring Apps
 documentation:
   - name: Azure Spring Apps installation docs
     description: |
@@ -38,4 +38,4 @@ keywords:
 dashboards:
   - azure-spring-apps
 dataSourceIds:
-  - azure-monitor  
+  - azure-monitor

--- a/quickstarts/azure/azure-stream-analytics/config.yml
+++ b/quickstarts/azure/azure-stream-analytics/config.yml
@@ -1,5 +1,6 @@
 id: eae1779f-9d4c-4996-ac13-a6c7d7f73d15
 slug: azure-stream-analytics
+title: Azure Stream Analytics
 description: |-
   ## What is Azure Stream Analytics?
 
@@ -12,10 +13,10 @@ description: |-
   ### Why monitor Azure Stream Analytics with New Relic?
 
   [New Relic Azure Stream Analytics](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-stream-analytics-monitoring-integration/) monitoring quickstart empowers you to track the performance of Azure Stream Analytics via different metrics including failed requests, deserialization errors, late input events, resource utilization and more. 
-  
+
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context, and get valuable insights.
-  
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
   Monitoring Azure Stream Analytics is critical to tracking the performance through key metrics. Install the New Relic Azure Stream Analytics monitoring quickstart to get a pre-built dashboard tailored to monitor your Azure Stream Analytics service.
 icon: logo.png
@@ -23,7 +24,6 @@ level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Azure Stream Analytics
 documentation:
   - name: Azure Stream Analytics installation docs
     description: |

--- a/quickstarts/azure/azure-synapse-analytics/config.yml
+++ b/quickstarts/azure/azure-synapse-analytics/config.yml
@@ -1,5 +1,6 @@
 id: 05729ec9-a69b-4ffa-91ee-3a34c1a2b10c
 slug: azure-synapse-analytics
+title: Azure Synapse Analytics
 description: |-
   ## What is Azure Synapse Analytics?
 
@@ -12,10 +13,10 @@ description: |-
   ### Why monitor Azure Synapse Analytics with New Relic?
 
   [New Relic Azure Synapse Analytics](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-synapse-analytics-monitoring-integration/) monitoring quickstart empowers you to track the performance of Azure Synapse Analytics via different metrics including account builtin sql pool data processed bytes, total sql streaming conversion errors, integration link processing latency in seconds, sql streaming resource utilization and more.
-  
+
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context, and get valuable insights.
-  
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
   Monitoring Azure Synapse Analytics is critical to tracking the performance through key metrics. Install the New Relic Azure Synapse Analytics monitoring quickstart to get a pre-built dashboard tailored to monitor your Azure Synapse Analytics service.
 icon: logo.png
@@ -23,7 +24,6 @@ level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Azure Synapse Analytics
 documentation:
   - name: Azure Synapse Analytics installation docs.
     description: |

--- a/quickstarts/azure/azure-time-series-insights/config.yml
+++ b/quickstarts/azure/azure-time-series-insights/config.yml
@@ -1,5 +1,6 @@
 id: 65fd54e5-d724-4834-878b-8e0ea9c9cd8a
 slug: azure-time-series-insights
+title: Azure Time Series Insights
 description: |-
   ## What is Azure Time Series Insights?
 
@@ -12,10 +13,10 @@ description: |-
   ### Why monitor Time Series Insights with New Relic?
 
   [New Relic Azure Time Series Insights](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-time-series-insights-monitoring-integration/) monitoring quickstart empowers you to track the performance of Azure Time Series Insights via different metrics including ingress storage, ingress received bytes, ingress received messages and warm storage used properties. 
-  
+
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context and get valuable insight.
-  
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
   Monitoring Azure Time Series Insights Cloud is a fully visualization service that makes it easy to explore and analyze via key metrics. Install the New Relic Azure Time Series Insight monitoring quickstart to get a pre-built dashboard tailored to monitor your Azure Time Series Insights service.
 icon: logo.png
@@ -23,7 +24,6 @@ level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Azure Time Series Insights
 documentation:
   - name: Azure Time Series insights installation docs
     description: |

--- a/quickstarts/azure/azure-web-apps/config.yml
+++ b/quickstarts/azure/azure-web-apps/config.yml
@@ -1,5 +1,6 @@
 id: 3f712d95-7823-4ce1-9bae-a3d82b615136
 slug: azure-web-apps
+title: Azure Web Apps
 description: |-
   ## What is Azure Web Apps?
 
@@ -13,10 +14,10 @@ description: |-
   ### Why monitor Azure Web Apps with New Relic?
 
   [New Relic Azure Web Apps](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-web-apps-monitoring-integration/) monitoring quickstart empowers you to track the performance of Azure Web Apps via different metrics including app connections, HTTP response time, bytes sent and bytes received.
-  
+
   Our integration features a standard dashboard that provides interactive visualizations to explore your data, understand context, and get valuable insights.
-  
-  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service. 
+
+  Start ingesting your Azure data today and get immediate access to our visualization dashboards so you can optimize your Azure service.
 summary: |-
   Monitoring Azure Web Apps is critical to track the performance of the application through key metrics. Download New Relic Azure Web Apps monitoring quickstart to get a pre-built dashboard tailored to monitor your Azure Web Apps service.
 icon: logo.png
@@ -24,7 +25,6 @@ level: New Relic
 authors:
   - New Relic
   - New Relic Partner
-title: Azure Web Apps
 documentation:
   - name: Azure Web Apps installation docs
     description: |


### PR DESCRIPTION
@glennthomas1 had previously created a bunch of Azure-based quickstarts: #1790 

Unfortunately, our workflows did not properly run when that PR was merged: the "submit gate" was never run, which meant that the "update quickstarts" workflow (which does the actual submission) wasn't run.

This PR attempts to trigger the workflow again by making a small adjustment to each of those files (necessary to be included in the upload). All I've done is move the `title` field towards the top of the config file. It's possible that my editor's linter cleaned up a few whitespace discrepancies, but no content has been altered.