### PR TITLE
Update preview link to local

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -692,6 +692,7 @@ Quickstart Previews are available for contributors to review their new or improv
 - To view a local quickstart preview, you can run the command `yarn preview node-js/express` or `yarn preview catchpoint` using the _path_ to the quickstart within the `quickstarts/` directory.
 - This script needs to be run under the `utils` directory.
 - The script will run a local server for the Public I/O site to fetch files from the specified quickstart.
+- Currently this functionality is not working on the Public I/O site, but it is entirely possible to use it locally by running the older _deprecated_ version of the site [on your machine](https://github.com/newrelic/instant-observability-website#%EF%B8%8F-local-development).
 - The command line will provide a link that can be navigated to view the quickstart.
   - In order for local quickstart preview to be enabled on the Public I/O site, there needs to be a `config.yml` file present in the quickstart directory. However, there does not need to have any content inside the file.
   - _Only one quickstart may be served for local quickstart preview_
@@ -699,6 +700,8 @@ Quickstart Previews are available for contributors to review their new or improv
 > Note: While working on a quickstart, changes may not be updated in the local preview automatically. If you do not see immediate changes, refresh the page to pull in recent updates.
 
 #### Step-by-step guide to view Local Quickstart Preview
+
+Clone down the [_deprecated_ site](https://github.com/newrelic/instant-observability-website#%EF%B8%8F-local-development) to your machine and follow the local development instructions. Once you have it up and running, continue to the steps below.
 
 Starting from the top level of the repository: `newrelic-quickstarts`
 

--- a/utils/preview.ts
+++ b/utils/preview.ts
@@ -16,8 +16,7 @@ const PORT = process.env.PORT || '3000';
 const PARENT_DIRECTORY = path.resolve(__dirname, '../quickstarts');
 const DASHBOARDS_DIRECTORY = path.resolve(__dirname, '../dashboards');
 const ALERTS_DIRECTORY = path.resolve(__dirname, '../alert-policies');
-const BASE_PREVIEW_LINK =
-  'https://newrelic.com/instant-observability/preview?local=true';
+const BASE_PREVIEW_LINK = 'http://localhost:8000/preview?local=true';
 
 const app = express();
 


### PR DESCRIPTION
# Summary
* Updates the preview url to be localhost while support is built in to the new production site.


