### PR TITLE
Adding a keyword of Redmine quickstart into a Add Data and Stack page

### DIFF
--- a/quickstarts/redmine/config.yml
+++ b/quickstarts/redmine/config.yml
@@ -49,6 +49,9 @@ keywords:
   - redmine
   - ruby agent
   - ruby
+  - NR1_addData
+  - NR1_sys
+  - apm
 installPlans:
   - redmine
 dataSourceIds:


### PR DESCRIPTION
## Description:  
Added a keywords of redmine quickstart in Add data and Stack page.
NR1_addData
NR1_sys
### JIRA ticket: 
https://issues.newrelic.com/browse/NR-151504

## Pre merge checklist

<!-- THIS CHECKLIST MUST BE FULLY COMPLETE OR YOUR PR WILL NOT BE MERGED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you include a Data source and Documentation reference?
- [ ] Are all documentation links publicly accessible?
- [ ] Did you check your descriptive content for [voice and tone](https://docs.newrelic.com/docs/style-guide/writing-strategies/voice-strategies-docs-sound-new-relic/)?
- [ ] Did you check your descriptive content for spelling and grammar errors?
- [ ] Did you review your content with a subject matter expert? (e.g. a Browser agent quickstart is reviewed with a member of the Browser Agent team)

### Dashboards

- [ ] Does the PR contain a screenshot for each of your dashboards?
- [ ] Do your screenshots show data?
- [ ] Has the [sanitization script](https://github.com/newrelic/newrelic-quickstarts/blob/main/CONTRIBUTING.md#dashboards) been run on each dashboard?

### Alerts

- [ ] Did you check that your alerts actually work?
