### PR TITLE
fix(Kubernetes Dashboard): fix query transformation errors

### DIFF
--- a/dashboards/kubernetes/kubernetes.json
+++ b/dashboards/kubernetes/kubernetes.json
@@ -82,7 +82,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT uniqueCount(k8s.namespaceName) FACET k8s.clusterName UNTIL 1 minute ago limit 100"
+                "query": "FROM Metric SELECT uniqueCount(k8s.namespaceName) WHERE metricName = 'k8s.pod.createdAt' FACET k8s.clusterName UNTIL 1 minute ago limit 100"
               }
             ]
           }
@@ -103,7 +103,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT uniqueCount(k8s.podName) as 'pod' FACET k8s.namespaceName UNTIL 1 minute ago limit 100"
+                "query": "FROM Metric SELECT uniqueCount(k8s.podName) as 'pod' WHERE metricName = 'k8s.pod.createdAt' FACET k8s.namespaceName UNTIL 1 minute ago limit 100"
               }
             ]
           }
@@ -124,7 +124,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT max(k8s.container.restartCount)-min(k8s.container.restartCount) as 'Restarts' FACET k8s.clusterName, k8s.podName, k8s.containerName UNTIL 1 minute ago TIMESERIES limit 50"
+                "query": "FROM Metric SELECT max(k8s.container.restartCount)-min(k8s.container.restartCount) as 'Restarts' WHERE metricName = 'k8s.container.restartCount' FACET k8s.clusterName, k8s.podName, k8s.containerName UNTIL 1 minute ago TIMESERIES limit 50"
               }
             ]
           }
@@ -145,7 +145,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT latest(k8s.container.cpuUsedCores)/latest(k8s.container.cpuLimitCores) * 100 as '% CPU' FACET k8s.clusterName, k8s.podName, k8s.containerName UNTIL 1 minute ago TIMESERIES limit 50"
+                "query": "FROM Metric SELECT latest(k8s.container.cpuUsedCores)/latest(k8s.container.cpuLimitCores) * 100 as '% CPU' WHERE metricName = 'k8s.container.restartCount' FACET k8s.clusterName, k8s.podName, k8s.containerName UNTIL 1 minute ago TIMESERIES limit 50"
               }
             ]
           }
@@ -166,7 +166,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT latest(k8s.container.memoryWorkingSetUtilization) as '% Memory' FACET k8s.clusterName, k8s.podName, k8s.containerName UNTIL 1 minute ago TIMESERIES limit 50"
+                "query": "FROM Metric SELECT latest(k8s.container.memoryWorkingSetUtilization) as '% Memory' WHERE metricName = 'k8s.container.restartCount' FACET k8s.clusterName, k8s.podName, k8s.containerName UNTIL 1 minute ago TIMESERIES limit 50"
               }
             ]
           }
@@ -187,7 +187,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric select latest(k8s.volume.fsUsedPercent) facet k8s.podName, k8s.volumeName, k8s.pvcName timeseries"
+                "query": "FROM Metric select latest(k8s.volume.fsUsedPercent) where metricName = 'k8s.volume.fsUsedPercent' facet k8s.podName, k8s.volumeName, k8s.pvcName timeseries"
               }
             ]
           }
@@ -208,7 +208,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT average(k8s.container.cpuUsedCores) as 'CPU Cores Used' FROM Metric FACET k8s.clusterName, k8s.podName, k8s.containerName timeseries since 60 minutes ago UNTIL 1 minute ago limit 50"
+                "query": "SELECT average(k8s.container.cpuUsedCores) as 'CPU Cores Used' FROM Metric WHERE metricName = 'k8s.container.restartCount' FACET k8s.clusterName, k8s.podName, k8s.containerName timeseries since 60 minutes ago UNTIL 1 minute ago limit 50"
               }
             ]
           }
@@ -326,7 +326,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT latest(k8s.node.cpuUsedCores) as 'Used Cores', latest(k8s.node.memoryWorkingSetBytes) / 1000000 as 'Used Memory MB', uniqueCount(k8s.podName) as 'Pods' FACET k8s.nodeName since 10 minutes ago UNTIL 1 minute ago limit 100"
+                "query": "FROM Metric SELECT latest(k8s.node.cpuUsedCores) as 'Used Cores', latest(k8s.node.memoryWorkingSetBytes) / 1000000 as 'Used Memory MB', uniqueCount(k8s.podName) as 'Pods' WHERE metricName = 'k8s.node.cpuUsedCores' FACET k8s.nodeName since 10 minutes ago UNTIL 1 minute ago limit 100"
               }
             ]
           }
@@ -347,7 +347,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT uniqueCount(k8s.podName) FROM Metric where k8s.status='Running' SINCE 10 minutes AGO UNTIL 1 minute ago facet k8s.clusterName, k8s.deploymentName WHERE k8s.deploymentName IS NOT NULL TIMESERIES limit 50"
+                "query": "SELECT uniqueCount(k8s.podName) FROM Metric where k8s.status = 'Running' AND metricName = 'k8s.pod.createdAt' SINCE 10 minutes AGO UNTIL 1 minute ago facet k8s.clusterName, k8s.deploymentName WHERE k8s.deploymentName IS NOT NULL TIMESERIES limit 50"
               }
             ]
           }
@@ -389,7 +389,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT uniquecount(k8s.podName) FROM Metric where status='Running' facet k8s.nodeName since 10 minutes ago UNTIL 1 minute ago"
+                "query": "SELECT uniquecount(k8s.podName) FROM Metric where status='Running' and metricName = 'k8s.pod.createdAt' facet k8s.nodeName since 10 minutes ago UNTIL 1 minute ago"
               }
             ]
           }
@@ -453,7 +453,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric select uniqueCount(k8s.nodeName) as 'Nodes', filter(uniqueCount(k8s.podName), where k8s.status = 'Running') as 'Running Pods', filter(uniqueCount(k8s.podName), where k8s.status in ('Pending')) as 'Pending Pods', uniqueCount(k8s.podName) as 'Total Pods' facet k8s.clusterName since 30 minutes ago limit 1000"
+                "query": "FROM Metric select uniqueCount(k8s.nodeName) as 'Nodes', filter(uniqueCount(k8s.podName), where k8s.status = 'Running' and metricName = 'k8s.pod.createdAt') as 'Running Pods', filter(uniqueCount(k8s.podName), where k8s.status in ('Pending') and metricName = 'k8s.pod.createdAt') as 'Pending Pods', uniqueCount(k8s.podName) as 'Total Pods' where metricName = 'k8s.pod.createdAt' facet k8s.clusterName since 30 minutes ago limit 1000"
               }
             ]
           }
@@ -583,7 +583,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric select filter(uniqueCount(k8s.podName), where  k8s.status = 'Running') as 'Running Pods', filter(uniqueCount(k8s.podName), where k8s.status = 'Pending') as 'Pending Pods', (average(k8s.node.cpuUsedCores) / average(k8s.node.allocatableCpuCores) * 100) as 'CPU %', (average(k8s.node.memoryWorkingSetBytes) / average(k8s.node.allocatableMemoryBytes) * 100) as 'Mem %', (average(k8s.node.fsUsedBytes) / average(k8s.node.fsCapacityBytes) * 100) as 'Disk Util %' where nodeName is not null facet nodeName limit 2000 since 30 minutes ago"
+                "query": "FROM Metric select filter(uniqueCount(k8s.podName), where  k8s.status = 'Running') as 'Running Pods', filter(uniqueCount(k8s.podName), where k8s.status = 'Pending') as 'Pending Pods', (average(k8s.node.cpuUsedCores) / average(k8s.node.allocatableCpuCores) * 100) as 'CPU %', (average(k8s.node.memoryWorkingSetBytes) / average(k8s.node.allocatableMemoryBytes) * 100) as 'Mem %', (average(k8s.node.fsUsedBytes) / average(k8s.node.fsCapacityBytes) * 100) as 'Disk Util %' where metricName = 'k8s.pod.createdAt' nodeName is not null facet nodeName limit 2000 since 30 minutes ago"
               }
             ]
           }
@@ -718,7 +718,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric select max(k8s.container.restartCount) AS 'Restart Count', latest(k8s.reason) AS 'Last Restart Reason' where k8s.container.restartCount[latest] > 0 AND k8s.reason IS NOT NULL order by k8s.container.restartCount facet k8s.containerName AS 'Container Name', k8s.podName AS 'Pod Name', k8s.clusterName AS 'Cluster Name' since 30 minutes ago limit 1000"
+                "query": "FROM Metric select max(k8s.container.restartCount) AS 'Restart Count', latest(k8s.reason) AS 'Last Restart Reason' where k8s.container.restartCount[latest] > 0 AND k8s.reason IS NOT NULL and metricName = 'k8s.container.restartCount' order by k8s.container.restartCount facet k8s.containerName AS 'Container Name', k8s.podName AS 'Pod Name', k8s.clusterName AS 'Cluster Name' since 30 minutes ago limit 1000"
               }
             ]
           }
@@ -786,7 +786,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric select uniqueCount(k8s.podName) as 'Pod Count' where k8s.status is not null facet k8s.clusterName AS 'Cluster Name', k8s.status AS 'Status' since 30 minutes ago limit 100"
+                "query": "FROM Metric select uniqueCount(k8s.podName) as 'Pod Count' where k8s.status is not null and metricName = 'k8s.pod.createdAt' facet k8s.clusterName AS 'Cluster Name', k8s.status AS 'Status' since 30 minutes ago limit 100"
               }
             ]
           }
@@ -811,7 +811,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric select k8s.podName AS 'Pod Name', k8s.status AS 'Status' , k8s.clusterName AS 'Cluster Name' where k8s.status = 'Pending' since 30 minutes ago limit 1000"
+                "query": "FROM Metric select k8s.podName AS 'Pod Name', k8s.status AS 'Status' , k8s.clusterName AS 'Cluster Name' where k8s.status = 'Pending' and metricName = 'k8s.pod.createdAt' since 30 minutes ago limit 1000"
               }
             ]
           }
@@ -857,7 +857,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric select k8s.podName AS 'Pod Name', k8s.status AS 'Status', k8s.clusterName AS 'Cluster Name' where k8s.status = 'Failed' since 30 minutes ago limit 1000"
+                "query": "FROM Metric select k8s.podName AS 'Pod Name', k8s.status AS 'Status', k8s.clusterName AS 'Cluster Name' where k8s.status = 'Failed' and metricName = 'k8s.pod.createdAt' since 30 minutes ago limit 1000"
               }
             ]
           }


### PR DESCRIPTION
# Summary

Fixes https://issues.newrelic.com/browse/NR-143803. 

A user is seeing the following error for multiple widgets in the Kubernetes Quickstart dashboard:

`We tried to transform your Metric query into a query that is compatible with the previous Infrastructure metric format. The transformation was cancelled because it would result in an oversize query. ` 

This error is because the shimming could not make a transformation of the query. By adding the `metricName` filter, we can tell the transformation which sample table to look at. 

## Pre merge checklist

<!-- THIS CHECKLIST MUST BE FULLY COMPLETE OR YOUR PR WILL NOT BE MERGED -->

- [x] Did you check you NRQL syntax? - Does it work?
- [ ] Did you include a Data source and Documentation reference?
- [ ] Are all documentation links publicly accessible?
- [ ] Did you check your descriptive content for [voice and tone](https://docs.newrelic.com/docs/style-guide/writing-strategies/voice-strategies-docs-sound-new-relic/)?
- [ ] Did you check your descriptive content for spelling and grammar errors?
- [ ] Did you review your content with a subject matter expert? (e.g. a Browser agent quickstart is reviewed with a member of the Browser Agent team)

### Dashboards

- [ ] Does the PR contain a screenshot for each of your dashboards?
- [ ] Do your screenshots show data?
- [ ] Has the [sanitization script](https://github.com/newrelic/newrelic-quickstarts/blob/main/CONTRIBUTING.md#dashboards) been run on each dashboard?

### Alerts

- [ ] Did you check that your alerts actually work?
