### PR TITLE
Added keywords for quickstarts

### DIFF
--- a/quickstarts/harbor/config.yml
+++ b/quickstarts/harbor/config.yml
@@ -21,6 +21,7 @@ keywords:
   - promql
   - grafana
   - featured
+  - NR1_addData
 documentation:
   - name: Prometheus Installation Docs
     url: https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/

--- a/quickstarts/hashicorp/hcp-envoy/config.yml
+++ b/quickstarts/hashicorp/hcp-envoy/config.yml
@@ -30,6 +30,7 @@ keywords:
   - envoy-proxy
   - nrlabs
   - nrlabs-data
+  - NR1_addData
 
 # Documentation references
 documentation:

--- a/quickstarts/hivemq/config.yml
+++ b/quickstarts/hivemq/config.yml
@@ -56,3 +56,4 @@ keywords:
   - messaging
   - queue
   - prometheus
+  - NR1_addData

--- a/quickstarts/ibmmq/config.yml
+++ b/quickstarts/ibmmq/config.yml
@@ -34,6 +34,7 @@ keywords:
   - mq
   - messaging
   - queue
+  - NR1_addData
 authors:
   - New Relic
 documentation:

--- a/quickstarts/istio/config.yml
+++ b/quickstarts/istio/config.yml
@@ -34,6 +34,7 @@ keywords:
   - service
   - mesh
   - k8s
+  - NR1_addData
 
 # Reference to install plans located under /install directory
 # Allows us to construct reusable "install plans" and just use their ID in the quickstart config

--- a/quickstarts/jfrog-platform/config.yml
+++ b/quickstarts/jfrog-platform/config.yml
@@ -34,6 +34,7 @@ keywords:
   - xray
   - security
   - featured
+  - NR1_addData
 documentation:
   - name: JFrog Observability Solution
     url: https://github.com/jfrog/log-analytics-newrelic

--- a/quickstarts/jira-errors/config.yml
+++ b/quickstarts/jira-errors/config.yml
@@ -18,6 +18,7 @@ keywords:
   - issue
   - error tracking
   - newrelic partner
+  - NR1_addData
 installPlans:
   - third-party-jira-errors-inbox
 dataSourceIds:

--- a/quickstarts/jmeter/config.yml
+++ b/quickstarts/jmeter/config.yml
@@ -42,6 +42,7 @@ keywords:
   - stress
   - functional
   - testing web application
+  - NR1_addData
 
 # Reference to dashboards to be included in this quickstart
 dashboards:

--- a/quickstarts/jumpstart/config.yml
+++ b/quickstarts/jumpstart/config.yml
@@ -12,6 +12,7 @@ keywords:
   - jumpstart
   - quickstart
   - intro
+  - NR1_addData
 installPlans:
   - third-party-jumpstart
 dataSourceIds:

--- a/quickstarts/lamp/config.yml
+++ b/quickstarts/lamp/config.yml
@@ -26,5 +26,6 @@ keywords:
   - apache
   - mysql
   - php
+  - NR1_addData
 dashboards:
   - lamp


### PR DESCRIPTION
### Jira Ticket:
https://issues.newrelic.com/browse/NR-151573

#### Description:
Added keywords for the below quickstarts:
1.Harbor
2.HCP envoy
3.hiveMQ
4.IBM MQ
5.Istio
6.jfrog
7.jira errors
8.jumpstart
9.jmeter
10.lamp
## Pre merge checklist

<!-- THIS CHECKLIST MUST BE FULLY COMPLETE OR YOUR PR WILL NOT BE MERGED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you include a Data source and Documentation reference?
- [ ] Are all documentation links publicly accessible?
- [ ] Did you check your descriptive content for [voice and tone](https://docs.newrelic.com/docs/style-guide/writing-strategies/voice-strategies-docs-sound-new-relic/)?
- [ ] Did you check your descriptive content for spelling and grammar errors?
- [ ] Did you review your content with a subject matter expert? (e.g. a Browser agent quickstart is reviewed with a member of the Browser Agent team)

### Dashboards

- [ ] Does the PR contain a screenshot for each of your dashboards?
- [ ] Do your screenshots show data?
- [ ] Has the [sanitization script](https://github.com/newrelic/newrelic-quickstarts/blob/main/CONTRIBUTING.md#dashboards) been run on each dashboard?

### Alerts

- [ ] Did you check that your alerts actually work?
