### PR TITLE
Added keywords for Quickstarts

### DIFF
--- a/quickstarts/kubernetes-prometheus/config.yml
+++ b/quickstarts/kubernetes-prometheus/config.yml
@@ -51,6 +51,7 @@ keywords:
   - metrics
   - kubelet
   - compute resources
+  - NR1_addData
 dashboards:
   - kubernetes-prometheus-compute-resources
   - kubernetes-prometheus-kubelet

--- a/quickstarts/kubernetes/azure-kubernetes-service/config.yml
+++ b/quickstarts/kubernetes/azure-kubernetes-service/config.yml
@@ -24,6 +24,7 @@ keywords:
   - azure
   - k8s
   - aks
+  - NR1_addData
 installPlans:
   - kubernetes-install
 dataSourceIds:

--- a/quickstarts/kubernetes/google-kubernetes-engine/config.yml
+++ b/quickstarts/kubernetes/google-kubernetes-engine/config.yml
@@ -24,6 +24,7 @@ keywords:
   - containers
   - k8s
   - google
+  - NR1_addData
 installPlans:
   - kubernetes-install
 dataSourceIds:

--- a/quickstarts/lampy/config.yml
+++ b/quickstarts/lampy/config.yml
@@ -46,6 +46,7 @@ keywords:
   - apache
   - mysql
   - python
+  - NR1_addData
 
 dashboards:
   - lampy

--- a/quickstarts/launchdarkly/config.yml
+++ b/quickstarts/launchdarkly/config.yml
@@ -19,6 +19,7 @@ documentation:
     url: https://docs.launchdarkly.com/integrations/new-relic
 keywords:
   - testing
+  - NR1_addData
 installPlans:
   - third-party-launchdarkly
 dataSourceIds:

--- a/quickstarts/lighthouse/config.yml
+++ b/quickstarts/lighthouse/config.yml
@@ -20,3 +20,4 @@ keywords:
   - project management
   - issue tracking
   - lighthouse
+  - NR1_addData

--- a/quickstarts/lighttpd/config.yml
+++ b/quickstarts/lighttpd/config.yml
@@ -40,3 +40,4 @@ keywords:
   - Lighttpd
   - web server
   - infrastructure
+  - NR1_addData

--- a/quickstarts/loadmill/config.yml
+++ b/quickstarts/loadmill/config.yml
@@ -28,6 +28,7 @@ keywords:
   - automation
   - AI
   - network
+  - NR1_addData
 
 # Reference to dashboards to be included in this quickstart
 dashboards:


### PR DESCRIPTION
#### JIRA TICKET:
https://issues.newrelic.com/browse/NR-151730
#### DESCRIPTION:
Added keyword "NR1_addData" to below quickstarts:
1.LAMPY
2.launchdarkly
3.lighthouse
4.lighttpd
5.loadmill
6.azure kubernetes service
7.google kubernetes engine
8.kubernetes prometheus

## Pre merge checklist

<!-- THIS CHECKLIST MUST BE FULLY COMPLETE OR YOUR PR WILL NOT BE MERGED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you include a Data source and Documentation reference?
- [ ] Are all documentation links publicly accessible?
- [ ] Did you check your descriptive content for [voice and tone](https://docs.newrelic.com/docs/style-guide/writing-strategies/voice-strategies-docs-sound-new-relic/)?
- [ ] Did you check your descriptive content for spelling and grammar errors?
- [ ] Did you review your content with a subject matter expert? (e.g. a Browser agent quickstart is reviewed with a member of the Browser Agent team)

### Dashboards

- [ ] Does the PR contain a screenshot for each of your dashboards?
- [ ] Do your screenshots show data?
- [ ] Has the [sanitization script](https://github.com/newrelic/newrelic-quickstarts/blob/main/CONTRIBUTING.md#dashboards) been run on each dashboard?

### Alerts

- [ ] Did you check that your alerts actually work?
