### PR TITLE
Added keyword for Quickstarts

### DIFF
--- a/quickstarts/java/camel/config.yml
+++ b/quickstarts/java/camel/config.yml
@@ -22,6 +22,7 @@ keywords:
   - java
   - camel
   - apache camel
+  - NR1_addData
 authors:
   - New Relic Labs
 installPlans:

--- a/quickstarts/java/datastax-cassandra/config.yml
+++ b/quickstarts/java/datastax-cassandra/config.yml
@@ -15,6 +15,7 @@ keywords:
   - apm
   - java
   - database
+  - NR1_addData
 installPlans:
   - setup-java-agent
 dataSourceIds:

--- a/quickstarts/java/derby/config.yml
+++ b/quickstarts/java/derby/config.yml
@@ -31,6 +31,7 @@ keywords:
   - apm
   - java
   - database
+  - NR1_addData
 installPlans:
   - setup-java-agent
 dataSourceIds:

--- a/quickstarts/java/elasticsearch-query/config.yml
+++ b/quickstarts/java/elasticsearch-query/config.yml
@@ -20,6 +20,7 @@ keywords:
   - apm
   - java
   - elasticsearch
+  - NR1_addData
 authors:
   - New Relic Labs
 installPlans:

--- a/quickstarts/java/gcp-pubsub/config.yml
+++ b/quickstarts/java/gcp-pubsub/config.yml
@@ -24,6 +24,7 @@ keywords:
   - java
   - pubsub
   - gcp
+  - NR1_addData
 authors:
   - New Relic Labs
 documentation:

--- a/quickstarts/java/websphere-liberty-profile/config.yml
+++ b/quickstarts/java/websphere-liberty-profile/config.yml
@@ -34,6 +34,7 @@ authors:
 keywords:
   - java
   - apm
+  - NR1_addData
 installPlans:
   - setup-java-agent
 dataSourceIds:


### PR DESCRIPTION
#### JIRA TICKET:
https://issues.newrelic.com/browse/NR-151739

#### DESCRIPTION:
Added keyword "NR1_addData" to below quickstarts:
1.camel
2.datastax cassandra
3.derby
4.elasticsearch query
5.pubsub
6.websphere liberty profile


## Pre merge checklist

<!-- THIS CHECKLIST MUST BE FULLY COMPLETE OR YOUR PR WILL NOT BE MERGED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you include a Data source and Documentation reference?
- [ ] Are all documentation links publicly accessible?
- [ ] Did you check your descriptive content for [voice and tone](https://docs.newrelic.com/docs/style-guide/writing-strategies/voice-strategies-docs-sound-new-relic/)?
- [ ] Did you check your descriptive content for spelling and grammar errors?
- [ ] Did you review your content with a subject matter expert? (e.g. a Browser agent quickstart is reviewed with a member of the Browser Agent team)

### Dashboards

- [ ] Does the PR contain a screenshot for each of your dashboards?
- [ ] Do your screenshots show data?
- [ ] Has the [sanitization script](https://github.com/newrelic/newrelic-quickstarts/blob/main/CONTRIBUTING.md#dashboards) been run on each dashboard?

### Alerts

- [ ] Did you check that your alerts actually work?
