### PR TITLE
Update Delphix Doc Link

### DIFF
--- a/quickstarts/delphix/config.yml
+++ b/quickstarts/delphix/config.yml
@@ -18,7 +18,7 @@ description: |
 
   The quickstart contains a sample Delphix Platform Dashboard and Storage Utilization Alert to help users get started. 
 
-  Populating data for dashboards, alerts, and workflows requires the [Delphix Integration](https://github.com/delphix/dct-newrelic-integration) and [Delphix Data Control Tower](https://docs.delphix.com/dct).
+  Populating data for dashboards, alerts, and workflows requires the [Delphix Integration](https://github.com/delphix/dct-newrelic-integration) and [Delphix Data Control Tower](https://dct.delphix.com/docs/latest).
 icon: logo.svg
 website: https://www.delphix.com
 summary: |


### PR DESCRIPTION
# Summary

The Delphix team updated our documentation links. This PR exists solely to fix the broken link.
