### PR TITLE
fix(mariadb): Show the mysql config directly

### DIFF
--- a/data-sources/mariadb/config.yml
+++ b/data-sources/mariadb/config.yml
@@ -7,13 +7,16 @@ icon: logo.svg
 install:
   primary:
     nerdlet:
+      nerdletId: marketplace.install-data-source
+      nerdletState:
+        dataSourceId: mariadb
+      requiresAccount: false
+  fallback:
+    nerdlet:
       nerdletId: nr1-install-newrelic.quickstart-installation-plan
       nerdletState:
         quickstartId: 0919c174-0ce5-4b34-a5c0-255986ff9706
       requiresAccount: true
-  fallback:
-    link:
-      url: https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/mysql-monitoring-integration
 keywords:
   - infrastructure
   - database


### PR DESCRIPTION
# Summary

As part of Shape Up week, we at Virtuoso are aiming to enhance the user experience for MariaDB integration. To achieve this, we are implementing a streamlined process that allows users to directly access the Install flow page, bypassing the intermediary suggestion page.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->

## Pre merge checklist

<!-- THIS CHECKLIST MUST BE FULLY COMPLETE OR YOUR PR WILL NOT BE MERGED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you include a Data source and Documentation reference?
- [ ] Are all documentation links publicly accessible?
- [ ] Did you check your descriptive content for [voice and tone](https://docs.newrelic.com/docs/style-guide/writing-strategies/voice-strategies-docs-sound-new-relic/)?
- [ ] Did you check your descriptive content for spelling and grammar errors?
- [ ] Did you review your content with a subject matter expert? (e.g. a Browser agent quickstart is reviewed with a member of the Browser Agent team)

### Dashboards

- [ ] Does the PR contain a screenshot for each of your dashboards?
- [ ] Do your screenshots show data?
- [ ] Has the [sanitization script](https://github.com/newrelic/newrelic-quickstarts/blob/main/CONTRIBUTING.md#dashboards) been run on each dashboard?

### Alerts

- [ ] Did you check that your alerts actually work?
