### PR TITLE
[bug] Update kubernetes.json

### DIFF
--- a/dashboards/kubernetes/kubernetes.json
+++ b/dashboards/kubernetes/kubernetes.json
@@ -583,7 +583,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric select filter(uniqueCount(k8s.podName), where  k8s.status = 'Running') as 'Running Pods', filter(uniqueCount(k8s.podName), where k8s.status = 'Pending') as 'Pending Pods', (average(k8s.node.cpuUsedCores) / average(k8s.node.allocatableCpuCores) * 100) as 'CPU %', (average(k8s.node.memoryWorkingSetBytes) / average(k8s.node.allocatableMemoryBytes) * 100) as 'Mem %', (average(k8s.node.fsUsedBytes) / average(k8s.node.fsCapacityBytes) * 100) as 'Disk Util %' where metricName = 'k8s.pod.createdAt' nodeName is not null facet nodeName limit 2000 since 30 minutes ago"
+                "query": "FROM Metric select filter(uniqueCount(k8s.podName), where  k8s.status = 'Running') as 'Running Pods', filter(uniqueCount(k8s.podName), where k8s.status = 'Pending') as 'Pending Pods', (average(k8s.node.cpuUsedCores) / average(k8s.node.allocatableCpuCores) * 100) as 'CPU %', (average(k8s.node.memoryWorkingSetBytes) / average(k8s.node.allocatableMemoryBytes) * 100) as 'Mem %', (average(k8s.node.fsUsedBytes) / average(k8s.node.fsCapacityBytes) * 100) as 'Disk Util %' where metricName = 'k8s.pod.createdAt' and nodeName is not null facet nodeName limit 2000 since 30 minutes ago"
               }
             ]
           }


### PR DESCRIPTION
added `and` operator

# Summary

Added `and` operator which seems to be missing from a NRQL query.

Currently, adding this dashboard returns an error, this PR aims to fix that:

<img width="1478" alt="Screenshot 2023-09-15 at 7 50 12 PM" src="https://github.com/newrelic/newrelic-quickstarts/assets/8403155/9c23b256-4df1-4f50-afe7-fe4a8b219720">

