### PR TITLE
Properly validate data source id references on quickstarts

### DIFF
--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -87,6 +87,7 @@ jobs:
                     'Validation / Image count and extension compliance',
                     'Validation / Ensure icons exist',
                     'Validation / Install plan ids exist',
+                    'Validation / Validate data source ids',
                     'Validation / Install plan schema compliance',
                     'Validation / Data source schema compliance',
                     'Validation / Quickstart id are unique',

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,7 @@ jobs:
                     'Validation / Image count and extension compliance',
                     'Validation / Ensure icons exist',
                     'Validation / Install plan ids exist',
+                    'Validation / Validate data source ids',
                     'Validation / Install plan schema compliance',
                     'Validation / Data source schema compliance',
                     'Validation / Quickstart id are unique',

--- a/.github/workflows/validate_packs.yml
+++ b/.github/workflows/validate_packs.yml
@@ -233,6 +233,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ env.pr-number }}
+          NR_API_URL: ${{ secrets.NR_API_URL }}
+          NR_API_TOKEN: ${{ secrets.NR_API_TOKEN }}
         run: |
           URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/$PR_NUMBER/files"
           cd utils && yarn validate-quickstart-data-sources "$URL"

--- a/.github/workflows/validate_packs.yml
+++ b/.github/workflows/validate_packs.yml
@@ -204,6 +204,46 @@ jobs:
           statusContext: "Validation / Install plan ids exist"
           state: ${{ job.status }}
 
+  validate-data-source-ids:
+    name: Validate data source ids
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: validation_gate.yml
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - name: Get PR number
+        id: get_pr_number
+        run: |
+          export PR_NUMBER=$(cat artifact/pr_number.txt)
+          echo "pr-number=$PR_NUMBER" >> $GITHUB_ENV
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: "refs/pull/${{ env.pr-number }}/merge"
+
+      - name: Setup workspace
+        uses: './.github/actions/bootstrap'
+
+      - name: Validate new files
+        id: validation
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ env.pr-number }}
+        run: |
+          URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/$PR_NUMBER/files"
+          cd utils && yarn validate-quickstart-data-sources "$URL"
+
+      - name: Add commit status
+        if: always()
+        uses: './.github/actions/add-commit-status'
+        with:
+          statusContext: "Validation / Data source ids exist"
+          state: ${{ job.status }}
+
   ensure-quickstart-dashboard-names-are-unique:
     name: Ensure quickstart dashboard names are unique
     runs-on: ubuntu-latest

--- a/utils/validate-quickstart-data-sources.ts
+++ b/utils/validate-quickstart-data-sources.ts
@@ -56,16 +56,16 @@ export const validateDataSourceIds = async (
 
   if (quickstartsWithInvalidDataSources.length > 0) {
     console.error(
-      `ERROR: Found install plans with no corresponding data source id.\n`
+      `ERROR: Found quickstarts with no corresponding data source id.\n`
     );
-    console.error(`An install plan id must match an existing data source id.`);
+    console.error(`An data source id must match an existing data source id.`);
     quickstartsWithInvalidDataSources.forEach((m) =>
       console.error(
         `- ${m.invalidDataSourceIds.join(', ')} in ${m.quickstart.configPath}`
       )
     );
     console.error(
-      `\nPlease change to an existing install plan id or remove the ids.`
+      `\nPlease change to an existing data source id or remove the ids.`
     );
 
     if (require.main === module) {


### PR DESCRIPTION
# Summary

We had previously implemented a script to check if a data source referenced in a quickstart actually exists. This script never made it into a workflow and wasn't being run on pull requests, this PR adds a job to run this script and updates some of the error output.