### PR TITLE
fix: Target `release` and update checks

### DIFF
--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
-          ref: "main"
+          ref: "release"
           fetch-depth: 0
 
       - name: Setup workspace
@@ -46,7 +46,7 @@ jobs:
             const result = await github.rest.repos.updateBranchProtection({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              branch: 'main',
+              branch: 'release',
               required_status_checks: null,
               restrictions: null,
               enforce_admins: null,
@@ -60,8 +60,8 @@ jobs:
           git config --local user.email "${{ env.THIRD_PARTY_GIT_AUTHOR_EMAIL }}"
           git config --local user.name "${{ env.THIRD_PARTY_GIT_AUTHOR_NAME }}"
 
-          # main could have been modified since we checked out, so pull before committing
-          git pull --ff-only origin main
+          # release could have been modified since we checked out, so pull before committing
+          git pull --ff-only origin release
 
           git add ./quickstarts/*
           git diff-index --quiet HEAD ./quickstarts/* || { git commit -m 'chore: generate UUID(s) [skip ci]' && echo "commit=true" >> $GITHUB_ENV; }
@@ -80,18 +80,19 @@ jobs:
             const result = await github.rest.repos.updateBranchProtection({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              branch: 'main',
+              branch: 'release',
               required_status_checks: {
                 strict: true,
                 contexts: [
                     'Validation / Image count and extension compliance',
                     'Validation / Ensure icons exist',
                     'Validation / Install plan ids exist',
-                    'Validation / Validate data source ids',
+                    'Validation / Data source ids exist',
                     'Validation / Install plan schema compliance',
                     'Validation / Data source schema compliance',
                     'Validation / Quickstart id are unique',
-                    'Validation / Validate Quickstart Schema'
+                    'Validation / Validate Quickstart Schema',
+                    'Validation / Quickstart dashboard name is unique'
                 ]
               },
               restrictions: {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,11 +79,12 @@ jobs:
                     'Validation / Image count and extension compliance',
                     'Validation / Ensure icons exist',
                     'Validation / Install plan ids exist',
-                    'Validation / Validate data source ids',
+                    'Validation / Data source ids exist',
                     'Validation / Install plan schema compliance',
                     'Validation / Data source schema compliance',
                     'Validation / Quickstart id are unique',
-                    'Validation / Validate Quickstart Schema'
+                    'Validation / Validate Quickstart Schema',
+                    'Validation / Quickstart dashboard name is unique'
                 ]
               },
               restrictions: {

--- a/.github/workflows/submit-gate.yml
+++ b/.github/workflows/submit-gate.yml
@@ -7,7 +7,7 @@ name: Submit Gate
 on: 
   pull_request:
     branches:
-      - main
+      - release
     types: [closed]
 
 jobs:


### PR DESCRIPTION
# Summary

Now that pull requests are going into the `release` branch, we need to generate quickstart ids at that time instead when they are merged into the `main` branch. This ensures that the `release` branch stays ahead or even with `main`. 
Also updates the required checks to be accurate.
