### PR TITLE
Update Alert class to handle nrql validation

### DIFF
--- a/utils/lib/Alert.ts
+++ b/utils/lib/Alert.ts
@@ -83,7 +83,7 @@ export type SubmitSetRequiredDataSourcesMutationResult =
   | { errors: ErrorOrNerdGraphError[] };
 
 class Alert extends Component<QuickstartConfigAlert[], QuickstartAlertInput[]> {
-  constructor(identifier: string, basePath = path.join(__dirname, '..', '..')) {
+  constructor(identifier: string, basePath?: string) {
     super(identifier, basePath);
     this.isValid = this.validate();
   }

--- a/utils/lib/Alert.ts
+++ b/utils/lib/Alert.ts
@@ -163,7 +163,6 @@ class Alert extends Component<QuickstartConfigAlert[], QuickstartAlertInput[]> {
    *
    * > Note: We do not currently validate the schema of an alert through
    * our API. This validation is used for edge cases found within our ecosystem.
-   *
    */
   validate(regex: RegExp = INVALID_REGEX) {
     if (!this.isValid) {

--- a/utils/lib/Alert.ts
+++ b/utils/lib/Alert.ts
@@ -30,7 +30,7 @@ import { CUSTOM_EVENT, recordNerdGraphResponse } from '../newrelic/customEvent';
 // within a nrql query. This portion is to help validate against
 // very specific edge cases to ensure we don't have anything break
 // during an install once it hits our UIs.
-const TIMESERIES = 'TIMESERIES' as const;
+const TIMESERIES = 'TIMESERIES';
 const INVALID_QUERY_KEYWORDS = [TIMESERIES] as const;
 
 // RegExp matches the _first_ instance of any invalid keywords

--- a/utils/lib/Alert.ts
+++ b/utils/lib/Alert.ts
@@ -164,7 +164,7 @@ class Alert extends Component<QuickstartConfigAlert[], QuickstartAlertInput[]> {
    * > Note: We do not currently validate the schema of an alert through
    * our API. This validation is used for edge cases found within our ecosystem.
    */
-  validate(regex: RegExp = INVALID_REGEX) {
+  validate(regex = INVALID_REGEX) {
     if (!this.isValid) {
       return false;
     }

--- a/utils/lib/__tests__/Alert.test.js
+++ b/utils/lib/__tests__/Alert.test.js
@@ -7,7 +7,6 @@ import {
   GITHUB_REPO_BASE_URL,
   ALERT_POLICY_REQUIRED_DATA_SOURCES_QUERY,
   ALERT_POLICY_SET_REQUIRED_DATA_SOURCES_MUTATION,
-  DASHBOARD_SET_REQUIRED_DATA_SOURCES_MUTATION,
 } from '../../constants';
 
 // TODO: maybe there is an easier way to mock a single function on this library
@@ -54,6 +53,14 @@ describe('Alert', () => {
       expect(alert.config).not.toBeDefined();
       expect(console.error).toHaveBeenCalled();
     });
+
+    test('Creates invalid alert when nrql query contains invalid keyword', () => {
+      jest.spyOn(global.console, 'error');
+      const alert = new Alert('mock-alert-policy-3', MOCK_FILES_BASEPATH);
+      expect(alert.isValid).toBe(false);
+      expect(alert.getMutationVariables()).toEqual([]);
+      expect(console.error).toHaveBeenCalled();
+    })
   });
 
   describe('getConfigFilePath', () => {
@@ -98,7 +105,7 @@ describe('Alert', () => {
       });
       const alert = new Alert('mock-alert-policy-2', MOCK_FILES_BASEPATH);
       expect(alert.isValid).toBe(false);
-      expect(console.log).toHaveBeenCalledTimes(1);
+      expect(console.log).toHaveBeenCalledTimes(2);
     });
 
     test('returns config for alert-policy with 1 condition', () => {

--- a/utils/lib/__tests__/Quickstart.test.js
+++ b/utils/lib/__tests__/Quickstart.test.js
@@ -100,6 +100,37 @@ describe('Quickstart', () => {
 
       expect(qs.isValid).toBe(false);
     });
+
+    test('Ensure quickstart is invalid from an invalid Alert', () => {
+      jest.spyOn(global.console, 'error').mockImplementation(() => {});
+      jest.spyOn(global.console, 'log').mockImplementation(() => {});
+      const qs = new Quickstart(
+        'quickstarts/mock-quickstart-6/config.yml',
+        MOCK_FILES_BASEPATH
+      );
+
+      const components = qs.getComponents();
+
+      expect(components).toBeDefined();
+      expect(qs.isValid).toBe(true);
+
+      // all components are invalid
+      const invalidComponents = components.map((component) => {
+        if (!component.isValid) {
+          return component;
+        }
+      }).filter(Boolean);
+
+      qs.validate();
+
+      expect(invalidComponents).toHaveLength(1)
+
+      const invalidComponent = invalidComponents.pop();
+      expect(invalidComponent.identifier).toBe('mock-alert-policy-3')
+
+      expect(qs.isValid).toBe(false);
+
+    })
   });
 
   describe('getMutationVariables', () => {

--- a/utils/lib/__tests__/Quickstart.test.js
+++ b/utils/lib/__tests__/Quickstart.test.js
@@ -115,17 +115,13 @@ describe('Quickstart', () => {
       expect(qs.isValid).toBe(true);
 
       // all components are invalid
-      const invalidComponents = components.map((component) => {
-        if (!component.isValid) {
-          return component;
-        }
-      }).filter(Boolean);
+      const invalidComponents = components.filter((c) => !c.isValid);
 
       qs.validate();
 
       expect(invalidComponents).toHaveLength(1)
 
-      const invalidComponent = invalidComponents.pop();
+      const invalidComponent = invalidComponents[0];
       expect(invalidComponent.identifier).toBe('mock-alert-policy-3')
 
       expect(qs.isValid).toBe(false);

--- a/utils/mock_files/alert-policies/mock-alert-policy-3/errors.yml
+++ b/utils/mock_files/alert-policies/mock-alert-policy-3/errors.yml
@@ -1,0 +1,34 @@
+---
+name: Errors
+
+description: |+
+  This alert fires when 10 percent of the transactions against an application end with an error, over a period of 5 minutes.
+type: STATIC
+nrql:
+  query: "from Transaction select percentage(count(*), where error is not false) as 'Errors' where transactionType = 'Web' facet appName TIMESERIES"
+
+valueFunction: SINGLE_VALUE
+
+# List of Critical and Warning thresholds for the condition
+terms:
+  - priority: CRITICAL
+    operator: ABOVE
+    # Value that triggers a violation
+    threshold: 10
+    # Time in seconds; 120 - 3600, must be a multiple of 60 for Baseline conditions
+    thresholdDuration: 300
+    # How many data points must be in violation for the duration
+    thresholdOccurrences: ALL
+
+# Loss of Signal Settings
+expiration:
+  # Close open violations if signal is lost (Default: false)
+  closeViolationsOnExpiration: true
+  # Open "Loss of Signal" violation if signal is lost (Default: false)
+  openViolationOnExpiration: false
+  # Time in seconds; Max value: 172800 (48hrs), null if closeViolationsOnExpiration and openViolationOnExpiration are both 'false'
+  expirationDuration: 86400
+
+# Duration after which a violation automatically closes
+# Time in seconds; 300 - 2592000 (Default: 86400 [1 day])
+violationTimeLimitSeconds: 86400

--- a/utils/mock_files/quickstarts/mock-quickstart-6/config.yml
+++ b/utils/mock_files/quickstarts/mock-quickstart-6/config.yml
@@ -32,6 +32,10 @@ documentation:
     url: docs.newrelic.com
     description: Description about this doc reference
 
+alertPolicies:
+  - mock-alert-policy-3
+
+
 # Content / Design
 icon: logo.png
 website: https://www.newrelic.com


### PR DESCRIPTION
# Summary

This PR stems from handling alert policy error while installing alerts in our UI.

We found that alert conditions that contain a nrql query with `TIMESERIES` fail an installation after it 
hits our database.

This is a supplementary PR #2190 so we can have a more automated process when verifying alert conditions in PRs.

### Testing

Our workflows that validate quickstarts will fail during checks.

Testing PR: https://github.com/newrelic/newrelic-quickstarts/pull/2197
- This PR should fail

Link to validation failure + logs: https://github.com/newrelic/newrelic-quickstarts/actions/runs/7468258398/job/20323336084

> Note: as of right now, we have 3 other alerts containing invalid queries, so it is a little noisy in the logs
