### PR TITLE
Some fixes to the release script

### DIFF
--- a/utils/create_validate_pr_quickstarts.ts
+++ b/utils/create_validate_pr_quickstarts.ts
@@ -3,7 +3,7 @@ import {
   filterOutTestFiles,
   isNotRemoved,
 } from './lib/github-api-helpers';
-import { translateMutationErrors, chunk } from './lib/nr-graphql-helpers';
+import { translateMutationErrors } from './lib/nr-graphql-helpers';
 
 import Quickstart, { QuickstartMutationResponse } from './lib/Quickstart';
 import { CUSTOM_EVENT, recordNerdGraphResponse } from './newrelic/customEvent';

--- a/utils/create_validate_pr_quickstarts.ts
+++ b/utils/create_validate_pr_quickstarts.ts
@@ -21,6 +21,8 @@ import {
 } from './types/nerdgraph';
 import logger from './logger';
 
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
 type ResponseWithErrors =
   NerdGraphResponseWithLocalErrors<QuickstartMutationResponse> & {
     name: string;
@@ -125,13 +127,12 @@ export const createValidateQuickstarts = async (
   const quickstartErrors: string[] = [];
 
   logger.info(`Submitting ${quickstarts.length} quickstarts...`);
-  for (const c of chunk(quickstarts, 5)) {
+  for (const c of quickstarts) {
     try {
-      const res = await Promise.all(
-        c.map((quickstart) => quickstart.submitMutation(isDryRun))
-      );
+      const res = await c.submitMutation(isDryRun);
+      await sleep(10);
 
-      results = [...results, ...res];
+      results = [...results, res];
     } catch (err) {
       const error = err as Error;
 

--- a/utils/lib/Alert.ts
+++ b/utils/lib/Alert.ts
@@ -30,7 +30,7 @@ import { CUSTOM_EVENT, recordNerdGraphResponse } from '../newrelic/customEvent';
 // within a nrql query. This portion is to help validate against
 // very specific edge cases to ensure we don't have anything break
 // during an install once it hits our UIs.
-const TIMESERIES = 'TIMESERIES';
+const TIMESERIES = '\sTIMESERIES\s';
 const INVALID_QUERY_KEYWORDS = [TIMESERIES] as const;
 
 // RegExp matches the _first_ instance of any invalid keywords

--- a/utils/lib/Alert.ts
+++ b/utils/lib/Alert.ts
@@ -30,11 +30,8 @@ import { CUSTOM_EVENT, recordNerdGraphResponse } from '../newrelic/customEvent';
 // within a nrql query. This portion is to help validate against
 // very specific edge cases to ensure we don't have anything break
 // during an install once it hits our UIs.
-const TIMESERIES = '\sTIMESERIES\s';
-const INVALID_QUERY_KEYWORDS = [TIMESERIES] as const;
-
 // RegExp matches the _first_ instance of any invalid keywords
-const INVALID_REGEX = new RegExp(INVALID_QUERY_KEYWORDS.join('|'), 'mi');
+const INVALID_REGEX = /\sTIMESERIES[\s]?/mi
 
 interface RequiredDataSources {
   id: string;

--- a/utils/set-alert-policy-required-datasources.ts
+++ b/utils/set-alert-policy-required-datasources.ts
@@ -4,6 +4,7 @@ import {
   fetchPaginatedGHResults,
   filterQuickstartConfigFiles,
   isNotRemoved,
+  filterOutTestFiles,
 } from './lib/github-api-helpers';
 import Quickstart from './lib/Quickstart';
 import Alert, { SubmitSetRequiredDataSourcesMutationResult } from './lib/Alert';
@@ -33,7 +34,7 @@ const getQuickstartNameAndDataSources = async (
   const files = await fetchPaginatedGHResults(ghUrl, ghToken);
   logger.info(`Found ${files.length} files`);
 
-  const quickstartNames = filterQuickstartConfigFiles(files)
+  const quickstartNames = filterQuickstartConfigFiles(filterOutTestFiles(files))
     .filter(isNotRemoved)
     .reduce<{ name: string; dataSourceIds: string[] }[]>(
       (acc, { filename }) => {

--- a/utils/set-dashboards-required-datasources.ts
+++ b/utils/set-dashboards-required-datasources.ts
@@ -1,5 +1,6 @@
 import {
   fetchPaginatedGHResults,
+  filterOutTestFiles,
   filterQuickstartConfigFiles,
   isNotRemoved,
 } from './lib/github-api-helpers';
@@ -35,7 +36,7 @@ const getQuickstartIds = async (
   const files = await fetchPaginatedGHResults(ghUrl, ghToken);
   logger.info(`Found ${files.length} files`);
 
-  const filteredQuickstarts = filterQuickstartConfigFiles(files)
+  const filteredQuickstarts = filterQuickstartConfigFiles(filterOutTestFiles(files))
     .filter(isNotRemoved)
     .reduce<Quickstart[]>((acc, { filename }) => {
       const quickstart = new Quickstart(filename);


### PR DESCRIPTION
# Summary
* Reducing the number of requests that run at a time to avoid race conditions in the API. 
* Filter out test/mock files
* Update alert validation to look for the `TIMESERIES` keyword not just the word `timeseries`