### PR TITLE
Newline change to trigger publishing

### DIFF
--- a/quickstarts/apdex-optimizer/config.yml
+++ b/quickstarts/apdex-optimizer/config.yml
@@ -59,8 +59,6 @@ keywords:
   - apdex
   - errors
 
-
-
 # Reference to dashboards to be included in this quickstart
 dashboards:
   - apdex-optimizer


### PR DESCRIPTION
# Summary

This quickstart got lost in the November shuffle, this change is just to get it picked up by the publishing process.