### PR TITLE
Transform AWS Dashboards

### DIFF
--- a/dashboards/amazon-athena/amazon-athena.json
+++ b/dashboards/amazon-athena/amazon-athena.json
@@ -21,7 +21,7 @@
 						"nrqlQueries": [
 							{
 								"accountId": 0,
-								"query": "SELECT average(provider.totalExecutionTime.Sum) / 1000 AS 'Average execution time (s)', max(provider.totalExecutionTime.Maximum) / 1000 AS 'Max execution time (s)', min(provider.totalExecutionTime.Minimum) / 1000 AS 'Min execution time (s)' FROM AwsAthenaWorkGroupSample WHERE providerExternalId LIKE '%' SINCE 1 hour ago"
+								"query": "SELECT (average(`getField`(`aws.athena.TotalExecutionTime`, `total`)) / 1000) AS `Average execution time (s)`, (max(`aws.athena.TotalExecutionTime`) / 1000) AS `Max execution time (s)`, (min(`aws.athena.TotalExecutionTime`) / 1000) AS `Min execution time (s)` FROM Metric WHERE (newrelic.cloudIntegrations.providerExternalId LIKE '%') SINCE 1 HOURS AGO"
 							}
 						]
 					}
@@ -101,7 +101,7 @@
 						"nrqlQueries": [
 							{
 								"accountId": 0,
-								"query": "SELECT awsAccountId, awsRegion, providerExternalId FROM AwsAthenaWorkGroupSample SINCE 1 hour ago"
+								"query": "SELECT aws.accountId, aws.region, newrelic.cloudIntegrations.providerExternalId FROM Metric SINCE 1 HOURS AGO"
 							}
 						]
 					}

--- a/dashboards/amazon-linux/amazon-linux.json
+++ b/dashboards/amazon-linux/amazon-linux.json
@@ -25,7 +25,7 @@
 						"nrqlQueries": [
 							{
 								"accountId": 0,
-								"query": "SELECT sum(aws.ec2.CPUCreditBalance) AS 'Total CPU Credit Balance', sum(aws.ec2.CPUCreditUsage) AS 'CPU credit used', sum(aws.ec2.CPUSurplusCreditsCharged) AS 'CPU Surplus Credit Charged' FROM Metric WHERE collector.name = 'cloudwatch-metric-streams' AND aws.Namespace = 'AWS/EC2' FACET aws.ec2.InstanceId SINCE 1 hour ago"
+								"query": "SELECT sum(`provider.cpuCreditBalance.Sum`) AS `Total CPU Credit Balance`, sum(`provider.cpuCreditUsage.Sum`) AS `CPU credit used`, sum(`provider.cpuSurplusCreditsCharged.Sum`) AS `CPU Surplus Credit Charged` FROM ComputeSample WHERE ((`provider` = 'Ec2Instance') AND ((`collector`.`name` = 'cloudwatch-metric-streams') AND (`aws`.`Namespace` = 'AWS/EC2'))) SINCE 1 HOURS AGO FACET (ec2InstanceId OR provider.ec2InstanceId)"
 							}
 						]
 					},
@@ -70,7 +70,7 @@
 						"nrqlQueries": [
 							{
 								"accountId": 0,
-								"query": "SELECT sum(aws.ec2.StatusCheckFailed) AS 'Failed Checks' FROM Metric WHERE aws.Namespace = 'AWS/EC2' SINCE 1 hour ago"
+								"query": "SELECT sum(`provider.statusCheckFailed.Sum`) AS `Failed Checks` FROM ComputeSample WHERE ((`provider` = 'Ec2Instance') AND (`aws`.`Namespace` = 'AWS/EC2')) SINCE 1 HOURS AGO"
 							}
 						],
 						"thresholds": []
@@ -98,7 +98,7 @@
 						"nrqlQueries": [
 							{
 								"accountId": 0,
-								"query": "SELECT average(aws.ec2.CPUUtilization) FROM Metric WHERE collector.name = 'cloudwatch-metric-streams' AND aws.Namespace = 'AWS/EC2' FACET aws.ec2.InstanceId SINCE 1 hour ago TIMESERIES 5 minutes "
+								"query": "SELECT average(`provider.cpuUtilization.Average`) FROM ComputeSample WHERE ((`provider` = 'Ec2Instance') AND ((`collector`.`name` = 'cloudwatch-metric-streams') AND (`aws`.`Namespace` = 'AWS/EC2'))) SINCE 1 HOURS AGO FACET (ec2InstanceId OR provider.ec2InstanceId) TIMESERIES 300000"
 							}
 						],
 						"yAxisLeft": {
@@ -128,7 +128,7 @@
 						"nrqlQueries": [
 							{
 								"accountId": 0,
-								"query": "SELECT average(aws.ec2.NetworkIn), average(aws.ec2.NetworkOut) FROM Metric WHERE collector.name = 'cloudwatch-metric-streams' AND aws.Namespace = 'AWS/EC2' FACET aws.ec2.InstanceId SINCE 1 hour ago TIMESERIES 5 minutes "
+								"query": "SELECT average(`provider.networkInBytes.Average`), average(`provider.networkOutBytes.Average`) FROM ComputeSample WHERE ((`provider` = 'Ec2Instance') AND ((`collector`.`name` = 'cloudwatch-metric-streams') AND (`aws`.`Namespace` = 'AWS/EC2'))) SINCE 1 HOURS AGO FACET (ec2InstanceId OR provider.ec2InstanceId) TIMESERIES 300000"
 							}
 						],
 						"yAxisLeft": {
@@ -158,7 +158,7 @@
 						"nrqlQueries": [
 							{
 								"accountId": 0,
-								"query": "SELECT average(aws.ec2.DiskReadOps), average(aws.ec2.DiskWriteOps) FROM Metric WHERE collector.name = 'cloudwatch-metric-streams' AND aws.Namespace = 'AWS/EC2' FACET aws.ec2.InstanceId SINCE 1 hour ago TIMESERIES 5 minutes "
+								"query": "SELECT average(`provider.diskReadOps.Average`), average(`provider.diskWriteOps.Average`) FROM ComputeSample WHERE ((`provider` = 'Ec2Instance') AND ((`collector`.`name` = 'cloudwatch-metric-streams') AND (`aws`.`Namespace` = 'AWS/EC2'))) SINCE 1 HOURS AGO FACET (ec2InstanceId OR provider.ec2InstanceId) TIMESERIES 300000"
 							}
 						],
 						"yAxisLeft": {
@@ -188,7 +188,7 @@
 						"nrqlQueries": [
 							{
 								"accountId": 0,
-								"query": "SELECT average(aws.ec2.DiskReadBytes), average(aws.ec2.DiskWriteBytes) FROM Metric WHERE collector.name = 'cloudwatch-metric-streams' AND aws.Namespace = 'AWS/EC2' FACET aws.ec2.InstanceId SINCE 1 hour ago TIMESERIES 5 minutes "
+								"query": "SELECT average(`provider.diskReadBytes.Average`), average(`provider.diskWriteBytes.Average`) FROM ComputeSample WHERE ((`provider` = 'Ec2Instance') AND ((`collector`.`name` = 'cloudwatch-metric-streams') AND (`aws`.`Namespace` = 'AWS/EC2'))) SINCE 1 HOURS AGO FACET (ec2InstanceId OR provider.ec2InstanceId) TIMESERIES 300000"
 							}
 						],
 						"yAxisLeft": {

--- a/dashboards/aws-billing/aws-billing.json
+++ b/dashboards/aws-billing/aws-billing.json
@@ -21,7 +21,7 @@
                         "nrqlQueries": [
                             {
                                 "accountId": 0,
-                                "query": "SELECT latest(`aws.billing.EstimatedCharges.byServiceCost`) FROM Metric since 1 day ago facet `aws.billing.ServiceName` limit 100"
+                                "query": "SELECT latest(`provider.estimatedCharges.Maximum`) FROM FinanceSample WHERE (`provider` = 'BillingServiceCost') SINCE 1 DAYS AGO FACET provider.serviceName LIMIT 100"
                             }
                         ]
                     }
@@ -56,7 +56,7 @@
                         "nrqlQueries": [
                             {
                                 "accountId": 0,
-                                "query": "SELECT latest(`aws.billing.EstimatedCharges.byAccountCost`) FROM Metric since 1 day ago facet `provider.accountId` limit 100"
+                                "query": "SELECT latest(`provider.estimatedCharges.Maximum`) FROM FinanceSample WHERE (`provider` = 'BillingAccountCost') SINCE 1 DAYS AGO FACET provider.accountId LIMIT 100"
                             }
                         ]
                     }
@@ -82,7 +82,7 @@
                         "nrqlQueries": [
                             {
                                 "accountId": 0,
-                                "query": "SELECT latest(`aws.billing.budgetType`) as 'Budget Type', max(`aws.billing.actualAmount.byBudget`) as 'Actual Amount', max(`aws.billing.limitAmount.byBudget`) as 'Budget Limit', latest(`aws.billing.forecastedAmount.byBudget`) as 'Forecast' FROM Metric facet `aws.billing.budgetName` since 1 day ago"
+                                "query": "SELECT latest(provider.budgetType) AS `Budget Type`, max(provider.actualAmount) AS `Actual Amount`, max(provider.limitAmount) AS `Budget Limit`, latest(provider.forecastedAmount) AS `Forecast` FROM FinanceSample WHERE (`provider` = 'BillingBudget') SINCE 1 DAYS AGO FACET provider.budgetName"
                             }
                         ]
                     }
@@ -117,7 +117,7 @@
                         "nrqlQueries": [
                             {
                                 "accountId": 0,
-                                "query": "SELECT max(`aws.billing.actualAmount.byBudget`) FROM Metric where `aws.billing.budgetType` = 'COST' TIMESERIES auto since 4 days ago facet `aws.billing.budgetName`"
+                                "query": "SELECT max(provider.actualAmount) FROM FinanceSample WHERE ((`provider` = 'BillingBudget') AND (provider.budgetType = 'COST')) SINCE 4 DAYS AGO FACET provider.budgetName TIMESERIES AUTO"
                             }
                         ]
                     }
@@ -137,7 +137,7 @@
                         "nrqlQueries": [
                             {
                                 "accountId": 0,
-                                "query": "SELECT max(`aws.billing.actualAmount.byBudget`) FROM Metric where `aws.billing.budgetType`='USAGE' TIMESERIES auto since 4 days ago facet `aws.billing.budgetName`"
+                                "query": "SELECT max(provider.actualAmount) FROM FinanceSample WHERE ((`provider` = 'BillingBudget') AND (provider.budgetType = 'USAGE')) SINCE 4 DAYS AGO FACET provider.budgetName TIMESERIES AUTO"
                             }
                         ]
                     }
@@ -157,7 +157,7 @@
                         "nrqlQueries": [
                             {
                                 "accountId": 0,
-                                "query": "SELECT max(`aws.billing.forecastedAmount.byBudget`) FROM Metric where `aws.billing.budgetType`='COST' TIMESERIES auto since 4 days ago facet `aws.billing.budgetName`"
+                                "query": "SELECT max(provider.forecastedAmount) FROM FinanceSample WHERE ((`provider` = 'BillingBudget') AND (provider.budgetType = 'COST')) SINCE 4 DAYS AGO FACET provider.budgetName TIMESERIES AUTO"
                             }
                         ]
                     }
@@ -177,7 +177,7 @@
                         "nrqlQueries": [
                             {
                                 "accountId": 0,
-                                "query": "SELECT max(`aws.billing.forecastedAmount.byBudget`) FROM Metric where `aws.billing.budgetType`='USAGE' TIMESERIES auto since 4 days ago facet `aws.billing.budgetName`"
+                                "query": "SELECT max(provider.forecastedAmount) FROM FinanceSample WHERE ((`provider` = 'BillingBudget') AND (provider.budgetType = 'USAGE')) SINCE 4 DAYS AGO FACET provider.budgetName TIMESERIES AUTO"
                             }
                         ]
                     }


### PR DESCRIPTION
# Summary

This PR converts some AWS dashboards from Metric to Samples or Samples to Metrics depending on the Quickstart `dataSourceIds` field. This is because metrics streams send Dimensional Metric and polling sends Infrastructure Samples and this data will not be converted.

Summary:
- Amazon athena dashboard to Metric
- Amazon Linux dashboard to Sample
- AWS Billing Dashboard to Sample