### PR TITLE
feat(NVIDIA): Remove keyword

### DIFF
--- a/data-sources/nvidia-dcgm/config.yml
+++ b/data-sources/nvidia-dcgm/config.yml
@@ -18,4 +18,3 @@ keywords:
   - AI Performance
   - GPU Optimization
   - AI Optimization
-  - NR1_addData


### PR DESCRIPTION
# Summary
There is a [quickstart that has the same keyword](https://github.com/newrelic/newrelic-quickstarts/blob/a8b5d32e7c159694104fa7c6a0babe676343b8fc/quickstarts/nvidia-dcgm/config.yml#L41), the keyword should not be on both data source and quickstart that uses the data source. This PR removes the data source keyword.
