### PR TITLE
Fix Open AI keywords

### DIFF
--- a/quickstarts/openai/config.yaml
+++ b/quickstarts/openai/config.yaml
@@ -40,9 +40,9 @@ keywords:
   - mlops
   - llm
   - generative ai
-  - chatgpt 
-  - gpt 
-  - chat 
+  - chatgpt
+  - gpt
+  - chat
   - genai
   - open
   - NR1_sys

--- a/quickstarts/openai/config.yaml
+++ b/quickstarts/openai/config.yaml
@@ -33,7 +33,6 @@ documentation:
       https://github.com/newrelic/openai-api-monitoring
 
 keywords:
-  - generative-aillm
   - featured
   - openai
   - ai
@@ -47,6 +46,7 @@ keywords:
   - genai
   - open
   - NR1_sys
+  - NR1_addData
 
 dataSourceIds:
   - llm-application


### PR DESCRIPTION
I had previously added the `generative-aillm` keyword but am realizing I should've added `NR1_addData` to get this to show up in add data.