### PR TITLE
Point Ollama to the updated AI Monitoring installer

### DIFF
--- a/quickstarts/ollama/config.yml
+++ b/quickstarts/ollama/config.yml
@@ -31,7 +31,7 @@ documentation:
       Implement monitoring and instrumentation for your Ollama app to ensure that your observability data is integrated into New Relic for effective performance analysis and insights.
     url: https://github.com/newrelic/nr-openai-observability
 dataSourceIds:
-  - langchain
+  - llm-application
 keywords:
   - ollama
   - large language model
@@ -49,6 +49,4 @@ keywords:
   - NR1_addData
   - NR1_sys
 alertPolicies:
-  - langchain
-dashboards:
   - langchain


### PR DESCRIPTION
# Summary

This points the Ollama quickstart to the new AI Monitoring installation approach (directly through the APM agent). The default dashboard does not really make sense for an app that uses Ollama so I'm removing the link to that. The curated AI Monitoring pages (or the new entity's page) is probably where we should send the user but it doesn't seem like we can easily hook that up via the quickstart config

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->

## Pre merge checklist

<!-- THIS CHECKLIST MUST BE FULLY COMPLETE OR YOUR PR WILL NOT BE MERGED -->

- [x] Did you check you NRQL syntax? - Does it work?
- [x] Did you include a Data source and Documentation reference?
- [x] Are all documentation links publicly accessible?
- [x] Did you check your descriptive content for [voice and tone](https://docs.newrelic.com/docs/style-guide/writing-strategies/voice-strategies-docs-sound-new-relic/)?
- [x] Did you check your descriptive content for spelling and grammar errors?
- [x] Did you review your content with a subject matter expert? (e.g. a Browser agent quickstart is reviewed with a member of the Browser Agent team)

### Dashboards

- [x] Does the PR contain a screenshot for each of your dashboards?
- [x] Do your screenshots show data?
- [x] Has the [sanitization script](https://github.com/newrelic/newrelic-quickstarts/blob/main/CONTRIBUTING.md#dashboards) been run on each dashboard?

### Alerts

- [x] Did you check that your alerts actually work?
