### PR TITLE
LambdaTest: added new page for HyperExecute widgets

### DIFF
--- a/dashboards/lambdatest/lambdatest-logs.json
+++ b/dashboards/lambdatest/lambdatest-logs.json
@@ -502,6 +502,216 @@
           }
         }
       ]
+    },
+		{
+      "name": "LambdaTest - HyperExecute Overview",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Jobs",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "SELECT uniqueCount(job_id) AS 'Jobs' FROM Log WHERE `service`='lambdatest' AND `newrelic.source` = 'api.logs' AND `logtype` = 'hypertest' SINCE 1 week ago"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Tasks",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "SELECT uniqueCount(task_id) AS 'Tasks' FROM Log WHERE service='lambdatest' AND `newrelic.source` = 'api.logs' AND `logtype` = 'hypertest' SINCE 1 week ago"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Stages",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "SELECT uniqueCount(stage_id) AS 'Stages' FROM Log WHERE service='lambdatest' AND `newrelic.source` = 'api.logs' AND `logtype` = 'hypertest' SINCE 1 week ago"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Job trends",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 6,
+            "height": 4
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "SELECT uniqueCount(job_id) \nFROM Log \nWHERE `newrelic.source` = 'api.logs'\nAND service = 'lambdatest' AND `newrelic.source` = 'api.logs' AND `logtype` = 'hypertest'\nFACET job_status\nSINCE 1 week ago \nTIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Task trends",
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "width": 6,
+            "height": 4
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "SELECT uniqueCount(task_id) \nFROM Log \nWHERE `newrelic.source` = 'api.logs'\nAND service = 'lambdatest' AND `newrelic.source` = 'api.logs' AND `logtype` = 'hypertest'\nFACET task_status\nSINCE 1 week ago \nTIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Stage trends",
+          "layout": {
+            "column": 1,
+            "row": 8,
+            "width": 6,
+            "height": 4
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.area"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "SELECT uniqueCount(stage_id) \nFROM Log \nWHERE `newrelic.source` = 'api.logs'\nAND service = 'lambdatest' AND `newrelic.source` = 'api.logs' AND `logtype` = 'hypertest'\nFACET stage_status\nSINCE 1 week ago \nTIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Task status ratio",
+          "layout": {
+            "column": 7,
+            "row": 8,
+            "width": 6,
+            "height": 4
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.stacked-bar"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "SELECT percentage(uniqueCount(job_id), WHERE task_status = 'completed') AS 'Completed',\n       percentage(uniqueCount(job_id), WHERE task_status = 'failed') AS 'Failed',\n       percentage(uniqueCount(job_id), WHERE task_status = 'skipped') AS 'Skipped',\n\t   percentage(uniqueCount(job_id), WHERE task_status = 'cancelled') AS 'Cancelled',\n\t   percentage(uniqueCount(job_id), WHERE task_status = 'aborted') AS 'Aborted',\n\t   percentage(uniqueCount(job_id), WHERE task_status = 'lambda_error') AS 'Lambda error',\n\t   percentage(uniqueCount(job_id), WHERE task_status = 'timeout') AS 'Timeout',\n\t   percentage(uniqueCount(job_id), WHERE task_status = 'log-available') AS 'Log available'\nFROM Log \nWHERE `newrelic.source` = 'api.logs'\nAND service = 'lambdatest' AND `newrelic.source` = 'api.logs' AND `logtype` = 'hypertest'\nSINCE 1 week ago \nTIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "units": {
+              "unit": "PERCENTAGE"
+            }
+          }
+        }
+      ]
     }
   ],
   "variables": []


### PR DESCRIPTION
# Summary

Adding a new page containing widgets related to HyperExecute testing platform of LambdaTest.



