### PR TITLE
Remove from "ML Models" category

### DIFF
--- a/quickstarts/mosaicml/config.yml
+++ b/quickstarts/mosaicml/config.yml
@@ -36,7 +36,6 @@ keywords:
   - mosaicml
   - mosaicml ai
   - langchain
-  - mlops
   - large language model
   - natural language processing
   - machine learning


### PR DESCRIPTION
# Summary

Removes the keyword associated with the "ML Models" category.