### PR TITLE
Remove Azure OpenAI from mlops category

### DIFF
--- a/quickstarts/azure-openai/config.yml
+++ b/quickstarts/azure-openai/config.yml
@@ -40,7 +40,6 @@ keywords:
   - openai
   - ai
   - gpt
-  - mlops
   - llm
   - NR1_addData
   - NR1_sys


### PR DESCRIPTION
# Summary

Azure OpenAI should only show up under Generative AI/LLMs, not the ML Models category.