### PR TITLE
Remove battlesnake from core listings

### DIFF
--- a/quickstarts/battlesnake/config.yml
+++ b/quickstarts/battlesnake/config.yml
@@ -26,8 +26,6 @@ keywords:
   - infrastructure
   - snake
   - battlesnake
-  - NR1_addData
-  - NR1_sys
 icon: logo.png
 website: https://play.battlesnake.com
 dashboards:


### PR DESCRIPTION
# Summary

Removing some tagging from the battlesnake quickstart.