### PR TITLE
feat: Remove vert.x data source from add data

### DIFF
--- a/data-sources/vertx-extensions/config.yml
+++ b/data-sources/vertx-extensions/config.yml
@@ -29,4 +29,3 @@ keywords:
   - mongodb
   - reactive
   - coroutines
-  - NR1_addData


### PR DESCRIPTION
https://new-relic.atlassian.net/browse/NR-307149

Duplicate vert.x tiles show, removing the vert.x data source and leaving the quickstart.