### PR TITLE
Updated doc URL for Haproxy quickstart

### DIFF
--- a/quickstarts/haproxy/config.yml
+++ b/quickstarts/haproxy/config.yml
@@ -10,7 +10,7 @@ description: |
 
   ### New Relic HAProxy quickstart highlights
 
-  [New Relic's HAProxy monitoring agent](https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/haproxy-monitoring-integration/) tracks server capacity to ensure that it can handle all concurrent sessions. You can efficiently manage your resources and run applications optimally by keeping an eye on real-time HAProxy status and statistics.
+  [New Relic's HAProxy monitoring agent](https://docs.newrelic.com/install/haproxy/) tracks server capacity to ensure that it can handle all concurrent sessions. You can efficiently manage your resources and run applications optimally by keeping an eye on real-time HAProxy status and statistics.
 
   New Relic's HAProxy monitoring quickstart has the following out-of-the-box features so you can monitor your frontend/server inventory and the health/availability of your backend servers:
   - Alerts (latency and errors)
@@ -31,7 +31,7 @@ documentation:
   - name: HAProxy
     description: |
       Free, open-source software load balancer and proxy server for TCP and HTTP-based applications that spreads traffic across multiple servers.
-    url: https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/haproxy-monitoring-integration/
+    url: https://docs.newrelic.com/install/haproxy/
 dataSourceIds:
   - haproxy
 keywords:


### PR DESCRIPTION
# Description: 
Updated the documentation URL for Haproxy quickstart, which was showing previously 404 page not found error
Haproxy docs link: https://docs.newrelic.com/install/haproxy/