### PR TITLE
Replaced Amazon S3 with amazon-web-services in sendgrid integration

### DIFF
--- a/quickstarts/sendgrid/config.yml
+++ b/quickstarts/sendgrid/config.yml
@@ -15,7 +15,7 @@ keywords:
   - NR1_sys
 dataSourceIds:
   - sendgrid-integration
-  - amazon-s3
+  - amazon-web-services
 documentation:
   - name: SendGrid Getting started with the Event Webhook
     url: https://docs.sendgrid.com/for-developers/tracking-events/getting-started-event-webhook


### PR DESCRIPTION
As we prepare to remove the Amazon S3 tile from the UI, including deleting the associated datasource, we aim to eliminate SendGrid's dependency on Amazon S3. We have replaced it with our new AWS integration, allowing customers to send their logs from S3 using this updated integration.