### PR TITLE
Update Sendgrid Description

### DIFF
--- a/quickstarts/sendgrid/config.yml
+++ b/quickstarts/sendgrid/config.yml
@@ -2,7 +2,7 @@ id: 6e0cc60a-e6ae-4c97-b5d4-b99568f04e9d
 slug: sendgrid-quickstart
 title: SendGrid Events
 description: |
-  SendGrid provides a cloud-based service that assists businesses with email delivery. This quickstart allows you to easily visualize the status of email delivery via SendGrid. In order to use this quickstart you will need to send SendGrid events to New Relic. If you are already sending events to AWS S3 using the SendGrid Event Webhook, they can be transferred to New Relic by using NewRelic-log-ingestion-s3.
+  SendGrid provides a cloud-based service that assists businesses with email delivery. This quickstart allows you to easily visualize the status of email delivery via SendGrid. In order to use this quickstart you will need to send SendGrid events to New Relic. If you are already sending events to AWS S3 using the SendGrid Event Webhook, they can be transferred to New Relic by using [AWS Lambda function](https://docs.newrelic.com/install/aws-logs/?service=aws_services).
 summary: |
   SendGrid provides a cloud-based service that assists businesses with email delivery. This quickstart allows you to visualize status of email delivery.
 level: New Relic

--- a/quickstarts/sendgrid/config.yml
+++ b/quickstarts/sendgrid/config.yml
@@ -2,7 +2,7 @@ id: 6e0cc60a-e6ae-4c97-b5d4-b99568f04e9d
 slug: sendgrid-quickstart
 title: SendGrid Events
 description: |
-  SendGrid provides a cloud-based service that assists businesses with email delivery. This quickstart allows you to easily visualize the status of email delivery via SendGrid. In order to use this quickstart you will need to send SendGrid events to New Relic. If you are already sending events to AWS S3 using the SendGrid Event Webhook, they can be transferred to New Relic by using [AWS Lambda function](https://docs.newrelic.com/install/aws-logs/?service=aws_services).
+  SendGrid provides a cloud-based service that assists businesses with email delivery. This quickstart allows you to easily visualize the status of email delivery via SendGrid. In order to use this quickstart you will need to send SendGrid events to New Relic. If you are already sending events to AWS S3 using the SendGrid Event Webhook, they can be transferred to New Relic by using [AWS Lambda function](https://docs.newrelic.com/install/aws-logs/?service=aws_services) and selecting S3 as your source.
 summary: |
   SendGrid provides a cloud-based service that assists businesses with email delivery. This quickstart allows you to visualize status of email delivery.
 level: New Relic


### PR DESCRIPTION
As we prepare to remove the Amazon S3 tile from the UI, including deleting the associated datasource, we aim to eliminate SendGrid's dependency on Amazon S3. We have replaced it with our new AWS integration, allowing customers to send their logs from S3 using this updated integration. This PR includes change in the description of the quickstart.