### PR TITLE
Updated documentation link for postgres

### DIFF
--- a/quickstarts/postgresql/config.yml
+++ b/quickstarts/postgresql/config.yml
@@ -16,7 +16,7 @@ documentation:
   - name: Postgres
     description: |
       Object-relational database management system designed to handle a range of workloads from single machines to data warehouses or services.
-    url: https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/postgresql-monitoring-integration/
+    url: https://docs.newrelic.com/install/postgresql/
 dataSourceIds:
   - postgresql
 keywords:


### PR DESCRIPTION
Updated the documentation link of postgres as this https://docs.newrelic.com/install/postgresql/ instead of https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/postgresql/postgresql-integration/