### PR TITLE
Set term duration to a multiple (600) of sliding window (30)

### DIFF
--- a/alert-policies/browser/AjaxResponseCodes.yml
+++ b/alert-policies/browser/AjaxResponseCodes.yml
@@ -24,7 +24,7 @@ terms:
     # Value that triggers a violation; float value
     threshold: 3 
     # Time in seconds; 120 - 3600, must be a multiple of 60 for Baseline conditions
-    thresholdDuration: 500
+    thresholdDuration: 600
     # How many data points must be in violation for the duration
     thresholdOccurrences: ALL
 

--- a/alert-policies/browser/AjaxThroughput.yml
+++ b/alert-policies/browser/AjaxThroughput.yml
@@ -24,7 +24,7 @@ terms:
     # Value that triggers a violation; float value
     threshold: 3 
     # Time in seconds; 120 - 3600, must be a multiple of 60 for Baseline conditions
-    thresholdDuration: 500
+    thresholdDuration: 600
     # How many data points must be in violation for the duration
     thresholdOccurrences: ALL
 

--- a/alert-policies/browser/AjaxTimetoSettle.yml
+++ b/alert-policies/browser/AjaxTimetoSettle.yml
@@ -24,7 +24,7 @@ terms:
     # Value that triggers a violation; float value
     threshold: 3 
     # Time in seconds; 120 - 3600, must be a multiple of 60 for Baseline conditions
-    thresholdDuration: 500
+    thresholdDuration: 600
     # How many data points must be in violation for the duration
     thresholdOccurrences: ALL
 

--- a/alert-policies/browser/FirstInputDelay.yml
+++ b/alert-policies/browser/FirstInputDelay.yml
@@ -24,7 +24,7 @@ terms:
     # Value that triggers a violation; float value
     threshold: 3 
     # Time in seconds; 120 - 3600, must be a multiple of 60 for Baseline conditions
-    thresholdDuration: 500
+    thresholdDuration: 600
     # How many data points must be in violation for the duration
     thresholdOccurrences: ALL
 

--- a/alert-policies/browser/JSErrors.yml
+++ b/alert-policies/browser/JSErrors.yml
@@ -24,7 +24,7 @@ terms:
     # Value that triggers a violation; float value
     threshold: 3 
     # Time in seconds; 120 - 3600, must be a multiple of 60 for Baseline conditions
-    thresholdDuration: 500
+    thresholdDuration: 600
     # How many data points must be in violation for the duration
     thresholdOccurrences: ALL
 

--- a/alert-policies/browser/LargestContentfulPaint.yml
+++ b/alert-policies/browser/LargestContentfulPaint.yml
@@ -24,7 +24,7 @@ terms:
     # Value that triggers a violation; float value
     threshold: 3 
     # Time in seconds; 120 - 3600, must be a multiple of 60 for Baseline conditions
-    thresholdDuration: 500
+    thresholdDuration: 600
     # How many data points must be in violation for the duration
     thresholdOccurrences: ALL
 

--- a/alert-policies/browser/PageloadTime.yml
+++ b/alert-policies/browser/PageloadTime.yml
@@ -24,7 +24,7 @@ terms:
     # Value that triggers a violation; float value
     threshold: 3 
     # Time in seconds; 120 - 3600, must be a multiple of 60 for Baseline conditions
-    thresholdDuration: 500
+    thresholdDuration: 600
     # How many data points must be in violation for the duration
     thresholdOccurrences: ALL
 

--- a/alert-policies/browser/Throughput.yml
+++ b/alert-policies/browser/Throughput.yml
@@ -24,7 +24,7 @@ terms:
     # Value that triggers a violation; float value
     threshold: 3 
     # Time in seconds; 120 - 3600, must be a multiple of 60 for Baseline conditions
-    thresholdDuration: 500
+    thresholdDuration: 600
     # How many data points must be in violation for the duration
     thresholdOccurrences: ALL
 


### PR DESCRIPTION
# Summary

Importing the Browser Alert Conditions results in a Validation Error:
![image](https://github.com/user-attachments/assets/fd796659-7271-48c0-a7f8-73915d70ab64)

This is due to the following error:
![image](https://github.com/user-attachments/assets/735bbaf0-bc42-47c8-acc6-b8fd8eddde8d)

The PR fixes that by setting the Term duration to 600 seconds (10 minutes), keeping the sliding window duration at 30 seconds.
