### PR TITLE
feat: NR-411668 connector and ksql dashboards

### DIFF
--- a/dashboards/confluent-cloud/confluent-cloud.json
+++ b/dashboards/confluent-cloud/confluent-cloud.json
@@ -764,7 +764,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT average(confluent_kafka_connect_received_records or confluent.kafka.connect.received_records) FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX TIMESERIES "
+                "query": "SELECT average(confluent_kafka_connect_received_records or confluent.kafka.connect.received_records) as 'Received records' FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX TIMESERIES "
               }
             ],
             "platformOptions": {
@@ -794,7 +794,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT average(confluent_kafka_connect_sent_bytes or confluent.kafka.connect.sent_bytes) FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX TIMESERIES "
+                "query": "SELECT average(confluent_kafka_connect_sent_bytes or confluent.kafka.connect.sent_bytes) as 'Sent bytes' FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX TIMESERIES "
               }
             ],
             "platformOptions": {
@@ -824,7 +824,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT average(confluent_kafka_connect_received_bytes or confluent.kafka.connect.received_bytes) FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX TIMESERIES "
+                "query": "SELECT average(confluent_kafka_connect_received_bytes or confluent.kafka.connect.received_bytes) as 'Received bytes' FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX TIMESERIES "
               }
             ],
             "platformOptions": {
@@ -854,7 +854,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT average(confluent_kafka_connect_dead_letter_queue_records or confluent.kafka.connect.dead_letter_queue_records) FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX TIMESERIES "
+                "query": "SELECT average(confluent_kafka_connect_dead_letter_queue_records or confluent.kafka.connect.dead_letter_queue_records) as 'Dead letter queue records' FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX TIMESERIES "
               }
             ],
             "platformOptions": {

--- a/dashboards/confluent-cloud/confluent-cloud.json
+++ b/dashboards/confluent-cloud/confluent-cloud.json
@@ -587,6 +587,588 @@
           }
         }
       ]
+    },
+    {
+      "name": "Connector metrics",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Sent records per minute",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 4
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": true
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "SELECT average(confluent_kafka_connect_sent_records or confluent.kafka.connect.sent_records) as 'Sent records' FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX TIMESERIES "
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Connector status by status, plugin type",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 4
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": true
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "SELECT average(confluent_kafka_connect_connector_status or confluent.kafka.connect.connector_status) as 'Connector status' FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX FACET status, plugin_type TIMESERIES "
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Connector task status by task, status, plugin type",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 4
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": true
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "SELECT average(confluent_kafka_connect_connector_task_status or confluent.kafka.connect.connector_task_status) as 'Connector task status' FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX FACET task, status, plugin_type TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Connector task batch size avg by task per minute ",
+          "layout": {
+            "column": 1,
+            "row": 2,
+            "width": 4,
+            "height": 4
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": true
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "SELECT average(confluent_kafka_connect_connector_task_batch_size_avg or confluent.kafka.connect.connector_task_batch_size_avg) FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX FACET task TIMESERIES "
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Connector task batch size max by task per minute ",
+          "layout": {
+            "column": 5,
+            "row": 2,
+            "width": 4,
+            "height": 4
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": true
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "SELECT average(confluent_kafka_connect_connector_task_batch_size_max or confluent.kafka.connect.connector_task_batch_size_max) FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX FACET task TIMESERIES "
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Received records per minute",
+          "layout": {
+            "column": 9,
+            "row": 2,
+            "width": 4,
+            "height": 4
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": true
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "SELECT average(confluent_kafka_connect_received_records or confluent.kafka.connect.received_records) FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX TIMESERIES "
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Sent bytes per minute",
+          "layout": {
+            "column": 1,
+            "row": 3,
+            "width": 4,
+            "height": 4
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": true
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "SELECT average(confluent_kafka_connect_sent_bytes or confluent.kafka.connect.sent_bytes) FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX TIMESERIES "
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Received bytes per minute",
+          "layout": {
+            "column": 5,
+            "row": 3,
+            "width": 4,
+            "height": 4
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": true
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "SELECT average(confluent_kafka_connect_received_bytes or confluent.kafka.connect.received_bytes) FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX TIMESERIES "
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Dead letter queue records per minute",
+          "layout": {
+            "column": 9,
+            "row": 3,
+            "width": 4,
+            "height": 4
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": true
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "SELECT average(confluent_kafka_connect_dead_letter_queue_records or confluent.kafka.connect.dead_letter_queue_records) FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX TIMESERIES "
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Ksql metrics",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Streaming unit count per minute",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 4
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": true
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "SELECT average(confluent_kafka_ksql_streaming_unit_count or confluent.kafka.ksql.streaming_unit_count) as 'Streaming unit count' FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX TIMESERIES "
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Query saturation by query id",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 4
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": true
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "SELECT average(confluent_kafka_ksql_query_saturation or confluent.kafka.ksql.query_saturation) as 'Query saturation' FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX FACET query_id TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Task stored bytes by node id, task id, query id",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 4
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": true
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "SELECT average(confluent_kafka_ksql_task_stored_bytes or confluent.kafka.ksql.task_stored_bytes) as 'Task stored bytes' FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX FACET ksql_node_id, task_id, query_id TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Storage utilization",
+          "layout": {
+            "column": 1,
+            "row": 2,
+            "width": 4,
+            "height": 4
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": true
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "SELECT average(confluent_kafka_ksql_storage_utilization or confluent.kafka.ksql.storage_utilization) as 'Storage utilization' FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Consumed total bytes by query id",
+          "layout": {
+            "column": 5,
+            "row": 2,
+            "width": 4,
+            "height": 4
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": true
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "SELECT average(confluent_kafka_ksql_consumed_total_bytes or confluent.kafka.ksql.consumed_total_bytes) FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX FACET query_id TIMESERIES "
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Produced total bytes by query id",
+          "layout": {
+            "column": 9,
+            "row": 2,
+            "width": 4,
+            "height": 4
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": true
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "SELECT average(confluent_kafka_ksql_produced_total_bytes or confluent.kafka.ksql.produced_total_bytes) FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX FACET query_id TIMESERIES "
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Offset processed total by a task id, query id, topic, partition",
+          "layout": {
+            "column": 1,
+            "row": 3,
+            "width": 4,
+            "height": 4
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": true
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "SELECT average(confluent_kafka_ksql_offsets_processed_total or confluent.kafka.ksql.offsets_processed_total) FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX FACET task_id, query_id, topic, partition TIMESERIES "
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Committed offset lag by task id, query id, topic, partition",
+          "layout": {
+            "column": 5,
+            "row": 3,
+            "width": 4,
+            "height": 4
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": true
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "SELECT average(confluent_kafka_ksql_committed_offset_lag or confluent.kafka.ksql.committed_offset_lag) as 'Consumer offset lag' FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX FACET task_id, query_id, topic, partition TIMESERIES "
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Processing errors total by query id",
+          "layout": {
+            "column": 9,
+            "row": 3,
+            "width": 4,
+            "height": 4
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": true
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "SELECT rate(sum(confluent_kafka_ksql_processing_errors_total or confluent.kafka.ksql.processing_errors_total), 1 second) FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX FACET query_id TIMESERIES "
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        },
+        {
+          "title": "Query restarts by query ids",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 4
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": true
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "SELECT rate(sum(confluent_kafka_ksql_query_restarts or confluent.kafka.ksql.query_restarts), 1 second) FROM Metric where entity.name = 'confluent' and `kafka_id` in ({{kafka_id}}) LIMIT MAX FACET query_id TIMESERIES "
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        }
+      ]
     }
   ],
   "variables": [

--- a/dashboards/confluent-cloud/confluent-cloud.json
+++ b/dashboards/confluent-cloud/confluent-cloud.json
@@ -1139,7 +1139,7 @@
           }
         },
         {
-          "title": "Query restarts by query ids",
+          "title": "Query restarts by query id",
           "layout": {
             "column": 1,
             "row": 4,


### PR DESCRIPTION
# Summary

This task involves adding connector and KSQL metrics tabs to the Confluent Cloud dashboard. Please refer to the documentation for connector and KSQL metrics: https://api.telemetry.confluent.cloud/docs/descriptors/datasets/cloud.

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->

## Pre merge checklist

<!-- THIS CHECKLIST MUST BE FULLY COMPLETE OR YOUR PR WILL NOT BE MERGED -->

- [x] Did you check you NRQL syntax? - Does it work?
- [x] Did you include a Data source and Documentation reference?
- [x] Are all documentation links publicly accessible?
- [x] Did you check your descriptive content for [voice and tone](https://docs.newrelic.com/docs/style-guide/writing-strategies/voice-strategies-docs-sound-new-relic/)?
- [x] Did you check your descriptive content for spelling and grammar errors?
- [ ] Did you review your content with a subject matter expert? (e.g. a Browser agent quickstart is reviewed with a member of the Browser Agent team)

### Dashboards

- [ ] Does the PR contain a screenshot for each of your dashboards?
- [ ] Do your screenshots show data?
- [x] Has the [sanitization script](https://github.com/newrelic/newrelic-quickstarts/blob/main/CONTRIBUTING.md#dashboards) been run on each dashboard?

### Alerts

- [ ] Did you check that your alerts actually work?
- [ ] Are you trying to create standalone alerts? Standalone alerts are deprecated. They should only be included in quickstarts.
