### PR TITLE
feat: enhance Java dashboard with app filtering and improved queries

### DIFF
--- a/dashboards/java/java.json
+++ b/dashboards/java/java.json
@@ -1,13 +1,16 @@
 {
   "name": "Java",
   "description": null,
+  "permissions": "PUBLIC_READ_WRITE",
   "pages": [
     {
+      "guid": "NzE0NTc2MXxWSVp8REFTSEJPQVJEfDQyOTY0OTA2",
       "name": "Overview",
       "description": null,
       "widgets": [
         {
-          "title": "",
+          "id": "477874051",
+          "title": null,
           "layout": {
             "column": 1,
             "row": 1,
@@ -23,6 +26,7 @@
           }
         },
         {
+          "id": "477874052",
           "title": "Applications Name (click on the application name to filter)",
           "layout": {
             "column": 3,
@@ -50,6 +54,7 @@
           }
         },
         {
+          "id": "477874053",
           "title": "CPU Utilization",
           "layout": {
             "column": 7,
@@ -57,7 +62,7 @@
             "width": 6,
             "height": 4
           },
-          "linkedEntityGuids": null,
+          "linkedEntityGuids": [],
           "visualization": {
             "id": "viz.line"
           },
@@ -68,22 +73,39 @@
             "legend": {
               "enabled": true
             },
+            "markers": {
+              "displayedTypes": {
+                "criticalViolations": false,
+                "deployments": true,
+                "relatedDeployments": true,
+                "warningViolations": false
+              }
+            },
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT min(apm.service.cpu.usertime.utilization) as 'Minimum CPU Utilization', max(apm.service.cpu.usertime.utilization) as 'Maximum CPU Utilization', average(apm.service.cpu.usertime.utilization) as 'Average CPU Utilization' FROM Metric TIMESERIES AUTO"
+                "accountIds": [
+                  0
+                ],
+                "query": "SELECT \nmin(apm.service.cpu.usertime.utilization) as 'Minimum CPU Utilization', \nmax(apm.service.cpu.usertime.utilization) as 'Maximum CPU Utilization', \naverage(apm.service.cpu.usertime.utilization) as 'Average CPU Utilization' \nFROM Metric\nWHERE appName IN ({{javaAppNames}})\nFACET appName \nTIMESERIES AUTO"
               }
             ],
             "platformOptions": {
               "ignoreTimeRange": false
             },
+            "thresholds": {
+              "isLabelVisible": true
+            },
             "yAxisLeft": {
+              "zero": true
+            },
+            "yAxisRight": {
               "zero": true
             }
           }
         },
         {
-          "title": "",
+          "id": "477874054",
+          "title": null,
           "layout": {
             "column": 1,
             "row": 3,
@@ -99,6 +121,7 @@
           }
         },
         {
+          "id": "477874055",
           "title": "Servlet Request Initialized",
           "layout": {
             "column": 1,
@@ -106,7 +129,7 @@
             "width": 4,
             "height": 3
           },
-          "linkedEntityGuids": null,
+          "linkedEntityGuids": [],
           "visualization": {
             "id": "viz.area"
           },
@@ -117,10 +140,20 @@
             "legend": {
               "enabled": true
             },
+            "markers": {
+              "displayedTypes": {
+                "criticalViolations": false,
+                "deployments": true,
+                "relatedDeployments": true,
+                "warningViolations": false
+              }
+            },
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT average(newrelic.timeslice.value) * 1000 AS `Java/javax.servlet.ServletRequestListener/requestInitialized` FROM Metric WHERE metricTimesliceName = 'Java/javax.servlet.ServletRequestListener/requestInitialized' TIMESERIES "
+                "accountIds": [
+                  0
+                ],
+                "query": "SELECT average(newrelic.timeslice.value) * 1000 AS `Java/javax.servlet.ServletRequestListener/requestInitialized` \nFROM Metric \nWHERE metricTimesliceName = 'Java/javax.servlet.ServletRequestListener/requestInitialized' \nWHERE appName IN ({{javaAppNames}})\nFACET appName\nTIMESERIES AUTO"
               }
             ],
             "platformOptions": {
@@ -129,6 +162,7 @@
           }
         },
         {
+          "id": "477874056",
           "title": "Average Error Rate",
           "layout": {
             "column": 5,
@@ -147,7 +181,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT average(newrelic.goldenmetrics.apm.application.errorRate) AS ''"
+                "query": "FROM Metric SELECT average(newrelic.goldenmetrics.apm.application.errorRate) AS '' WHERE appName IN ({{javaAppNames}})"
               }
             ],
             "platformOptions": {
@@ -162,6 +196,7 @@
           }
         },
         {
+          "id": "477874057",
           "title": "Segment Names",
           "layout": {
             "column": 8,
@@ -169,7 +204,7 @@
             "width": 5,
             "height": 3
           },
-          "linkedEntityGuids": null,
+          "linkedEntityGuids": [],
           "visualization": {
             "id": "viz.pie"
           },
@@ -182,8 +217,10 @@
             },
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "FROM Metric select count(apm.service.overview.web) facet segmentName"
+                "accountIds": [
+                  0
+                ],
+                "query": "FROM Metric \nselect count(apm.service.overview.web) \nWHERE appName IN ({{javaAppNames}})\nFACET appName, segmentName"
               }
             ],
             "platformOptions": {
@@ -192,6 +229,7 @@
           }
         },
         {
+          "id": "477874058",
           "title": "Code Function ",
           "layout": {
             "column": 1,
@@ -219,6 +257,7 @@
           }
         },
         {
+          "id": "477874059",
           "title": "Http Status Code",
           "layout": {
             "column": 7,
@@ -254,11 +293,13 @@
       ]
     },
     {
+      "guid": "NzE0NTc2MXxWSVp8REFTSEJPQVJEfDQyOTY0OTA3",
       "name": "Transaction ",
       "description": null,
       "widgets": [
         {
-          "title": "",
+          "id": "477874060",
+          "title": null,
           "layout": {
             "column": 1,
             "row": 1,
@@ -274,6 +315,7 @@
           }
         },
         {
+          "id": "477874061",
           "title": "Transactions Overview",
           "layout": {
             "column": 1,
@@ -301,6 +343,7 @@
           }
         },
         {
+          "id": "477874062",
           "title": "Top Popular Transactions",
           "layout": {
             "column": 5,
@@ -331,6 +374,7 @@
           }
         },
         {
+          "id": "477874063",
           "title": "Transaction Types(click on the transaction type to filter)",
           "layout": {
             "column": 1,
@@ -358,6 +402,7 @@
           }
         },
         {
+          "id": "477874064",
           "title": "Adpex Score (second)",
           "layout": {
             "column": 3,
@@ -391,6 +436,7 @@
           }
         },
         {
+          "id": "477874065",
           "title": "Web Transactions Histogram",
           "layout": {
             "column": 6,
@@ -421,6 +467,7 @@
           }
         },
         {
+          "id": "477874066",
           "title": "Top 5 Slowest Transactions Per Day",
           "layout": {
             "column": 9,
@@ -448,6 +495,7 @@
           }
         },
         {
+          "id": "477874067",
           "title": "Average Transaction Duration Today Compared With 1 Day Ago",
           "layout": {
             "column": 1,
@@ -475,6 +523,7 @@
           }
         },
         {
+          "id": "477874068",
           "title": "Total Time ",
           "layout": {
             "column": 5,
@@ -508,6 +557,7 @@
           }
         },
         {
+          "id": "477874069",
           "title": "Throughput",
           "layout": {
             "column": 9,
@@ -515,7 +565,7 @@
             "width": 4,
             "height": 3
           },
-          "linkedEntityGuids": null,
+          "linkedEntityGuids": [],
           "visualization": {
             "id": "viz.line"
           },
@@ -526,16 +576,32 @@
             "legend": {
               "enabled": true
             },
+            "markers": {
+              "displayedTypes": {
+                "criticalViolations": false,
+                "deployments": true,
+                "relatedDeployments": true,
+                "warningViolations": false
+              }
+            },
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT rate(count(apm.service.transaction.duration), 1 minute)  FROM Metric  TIMESERIES"
+                "accountIds": [
+                  0
+                ],
+                "query": "SELECT rate(count(apm.service.transaction.duration), 1 minute)  FROM Metric  TIMESERIES\nWHERE appName IN ({{javaAppNames}})\nFACET appName"
               }
             ],
             "platformOptions": {
               "ignoreTimeRange": false
             },
+            "thresholds": {
+              "isLabelVisible": true
+            },
             "yAxisLeft": {
+              "zero": true
+            },
+            "yAxisRight": {
               "zero": true
             }
           }
@@ -543,11 +609,13 @@
       ]
     },
     {
+      "guid": "NzE0NTc2MXxWSVp8REFTSEJPQVJEfDQyOTY0OTA4",
       "name": "JVMs",
       "description": null,
       "widgets": [
         {
-          "title": "",
+          "id": "477874070",
+          "title": null,
           "layout": {
             "column": 1,
             "row": 1,
@@ -563,6 +631,7 @@
           }
         },
         {
+          "id": "477874071",
           "title": "Heap Memory Usage (MB)",
           "layout": {
             "column": 1,
@@ -570,7 +639,7 @@
             "width": 4,
             "height": 3
           },
-          "linkedEntityGuids": null,
+          "linkedEntityGuids": [],
           "visualization": {
             "id": "viz.area"
           },
@@ -581,10 +650,20 @@
             "legend": {
               "enabled": true
             },
+            "markers": {
+              "displayedTypes": {
+                "criticalViolations": false,
+                "deployments": true,
+                "relatedDeployments": true,
+                "warningViolations": false
+              }
+            },
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT average(apm.service.memory.heap.max) as 'Max Heap', average(apm.service.memory.heap.committed) as 'Committed Heap', average(apm.service.memory.heap.used) as 'Used Heap' FROM Metric TIMESERIES AUTO "
+                "accountIds": [
+                  0
+                ],
+                "query": "SELECT average(apm.service.memory.heap.max) as 'Max Heap', average(apm.service.memory.heap.committed) as 'Committed Heap', average(apm.service.memory.heap.used) as 'Used Heap' FROM Metric TIMESERIES AUTO WHERE appName IN ({{javaAppNames}})\nFACET appName"
               }
             ],
             "platformOptions": {
@@ -593,6 +672,7 @@
           }
         },
         {
+          "id": "477874072",
           "title": "Garbage Collection",
           "layout": {
             "column": 5,
@@ -600,7 +680,7 @@
             "width": 4,
             "height": 3
           },
-          "linkedEntityGuids": null,
+          "linkedEntityGuids": [],
           "visualization": {
             "id": "viz.stacked-bar"
           },
@@ -611,10 +691,20 @@
             "legend": {
               "enabled": true
             },
+            "markers": {
+              "displayedTypes": {
+                "criticalViolations": false,
+                "deployments": true,
+                "relatedDeployments": true,
+                "warningViolations": false
+              }
+            },
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT average(newrelic.timeslice.value)*1000 FROM Metric WHERE metricTimesliceName LIKE 'GC%' FACET metricTimesliceName TIMESERIES"
+                "accountIds": [
+                  0
+                ],
+                "query": "SELECT average(newrelic.timeslice.value)*1000 FROM Metric WHERE metricTimesliceName LIKE 'GC%'   TIMESERIES\nWHERE appName IN ({{javaAppNames}})\nFACET appName, metricTimesliceName"
               }
             ],
             "platformOptions": {
@@ -623,6 +713,7 @@
           }
         },
         {
+          "id": "477874073",
           "title": "Class Count",
           "layout": {
             "column": 9,
@@ -641,7 +732,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT average(newrelic.timeslice.value)* 1000 FROM Metric where metricTimesliceName like 'JmxBuiltIn/Classes%' FACET metricTimesliceName  "
+                "query": "SELECT average(newrelic.timeslice.value)* 1000 FROM Metric where metricTimesliceName like 'JmxBuiltIn/Classes%' AND appName IN ({{javaAppNames}}) FACET metricTimesliceName  "
               }
             ],
             "platformOptions": {
@@ -650,6 +741,7 @@
           }
         },
         {
+          "id": "477874074",
           "title": "Heap MemoryPool Usage(MB)",
           "layout": {
             "column": 1,
@@ -671,7 +763,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT count(newrelic.timeslice.value) * 1000  where metricTimesliceName like 'MemoryPool/Heap%' FACET metricTimesliceName TIMESERIES "
+                "query": "FROM Metric SELECT count(newrelic.timeslice.value) * 1000  where metricTimesliceName like 'MemoryPool/Heap%' AND appName IN ({{javaAppNames}}) FACET appName, metricTimesliceName TIMESERIES "
               }
             ],
             "platformOptions": {
@@ -680,6 +772,7 @@
           }
         },
         {
+          "id": "477874075",
           "title": "Non-Heap MemoryPool Usage(MB) ",
           "layout": {
             "column": 7,
@@ -701,7 +794,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT count(newrelic.timeslice.value) * 1000  where metricTimesliceName like 'MemoryPool/Non-Heap%' FACET metricTimesliceName  TIMESERIES "
+                "query": "FROM Metric SELECT count(newrelic.timeslice.value) * 1000  where metricTimesliceName like 'MemoryPool/Non-Heap%' AND appName IN ({{javaAppNames}}) FACET appName, metricTimesliceName  TIMESERIES "
               }
             ],
             "platformOptions": {
@@ -710,7 +803,8 @@
           }
         },
         {
-          "title": "",
+          "id": "477874076",
+          "title": null,
           "layout": {
             "column": 1,
             "row": 8,
@@ -726,6 +820,7 @@
           }
         },
         {
+          "id": "477874077",
           "title": "Top 5 Time Consuming Threads",
           "layout": {
             "column": 1,
@@ -744,7 +839,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT sum(newrelic.timeslice.value) FROM Metric  WITH METRIC_FORMAT 'Threads/TotalTime/{thread}/CpuTime' WHERE metricTimesliceName LIKE 'Threads/TotalTime/%/CpuTime'  AND thread NOT LIKE '%New Relic%'  FACET `thread` LIMIT 5 "
+                "query": "SELECT sum(newrelic.timeslice.value) FROM Metric  WITH METRIC_FORMAT 'Threads/TotalTime/{thread}/CpuTime' WHERE metricTimesliceName LIKE 'Threads/TotalTime/%/CpuTime'  AND thread NOT LIKE '%New Relic%' AND appName IN ({{javaAppNames}}) FACET `thread` LIMIT 5 "
               }
             ],
             "platformOptions": {
@@ -753,6 +848,7 @@
           }
         },
         {
+          "id": "477874078",
           "title": "Average Thread Count",
           "layout": {
             "column": 5,
@@ -774,7 +870,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT average(newrelic.timeslice.value) AS `JmxBuiltIn/Threads/Thread Count` FROM Metric WHERE metricTimesliceName = 'JmxBuiltIn/Threads/Thread Count' TIMESERIES "
+                "query": "SELECT average(newrelic.timeslice.value) AS `JmxBuiltIn/Threads/Thread Count` FROM Metric WHERE metricTimesliceName = 'JmxBuiltIn/Threads/Thread Count' AND appName IN ({{javaAppNames}}) FACET appName TIMESERIES "
               }
             ],
             "platformOptions": {
@@ -786,6 +882,7 @@
           }
         },
         {
+          "id": "477874079",
           "title": "Thread State",
           "layout": {
             "column": 9,
@@ -807,7 +904,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT sum(newrelic.timeslice.value) FROM Metric  WITH METRIC_FORMAT 'Threads/SummaryState/{threadstate}/Count' WHERE metricTimesliceName LIKE 'Threads/SummaryState/%/Count'  AND threadstate NOT LIKE '%New Relic%'  FACET `threadstate` LIMIT 5 SINCE 604800 seconds AGO TIMESERIES"
+                "query": "SELECT sum(newrelic.timeslice.value) FROM Metric  WITH METRIC_FORMAT 'Threads/SummaryState/{threadstate}/Count' WHERE metricTimesliceName LIKE 'Threads/SummaryState/%/Count'  AND threadstate NOT LIKE '%New Relic%' AND appName IN ({{javaAppNames}}) FACET appName, `threadstate` LIMIT 5 SINCE 604800 seconds AGO TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -818,11 +915,13 @@
       ]
     },
     {
+      "guid": "NzE0NTc2MXxWSVp8REFTSEJPQVJEfDQyOTY0OTA5",
       "name": "Databases",
       "description": null,
       "widgets": [
         {
-          "title": "",
+          "id": "477874080",
+          "title": null,
           "layout": {
             "column": 1,
             "row": 1,
@@ -838,6 +937,7 @@
           }
         },
         {
+          "id": "477874081",
           "title": "Table Names",
           "layout": {
             "column": 1,
@@ -856,7 +956,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "FROM Metric SELECT average(apm.service.datastore.operation.duration * 1000) AS 'Average Operation Duration (seconds)' FACET table "
+                "query": "FROM Metric SELECT average(apm.service.datastore.operation.duration * 1000) AS 'Average Operation Duration (seconds)' WHERE appName IN ({{javaAppNames}}) FACET table "
               }
             ],
             "platformOptions": {
@@ -865,6 +965,7 @@
           }
         },
         {
+          "id": "477874082",
           "title": "Data Store Type",
           "layout": {
             "column": 3,
@@ -883,7 +984,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT sum(apm.service.datastore.operation.duration * 1000) FROM Metric FACET `datastoreType` "
+                "query": "SELECT sum(apm.service.datastore.operation.duration * 1000) FROM Metric WHERE appName IN ({{javaAppNames}}) FACET `datastoreType` "
               }
             ],
             "platformOptions": {
@@ -892,6 +993,7 @@
           }
         },
         {
+          "id": "477874083",
           "title": "Top Databases - By Throughput",
           "layout": {
             "column": 6,
@@ -913,7 +1015,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT rate(count(apm.service.datastore.operation.duration), 1 minute) FROM Metric TIMESERIES facet concat(datastoreType, ' ', table, ' ', operation) "
+                "query": "SELECT rate(count(apm.service.datastore.operation.duration), 1 minute) FROM Metric WHERE appName IN ({{javaAppNames}}) FACET appName, concat(datastoreType, ' ', table, ' ', operation) TIMESERIES "
               }
             ],
             "platformOptions": {
@@ -922,6 +1024,7 @@
           }
         },
         {
+          "id": "477874084",
           "title": "Database Connection Attempts - By Average",
           "layout": {
             "column": 10,
@@ -943,7 +1046,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT average(newrelic.timeslice.value) AS 'Datastore/getConnection' FROM Metric WHERE metricTimesliceName = 'Datastore/getConnection' LIMIT MAX TIMESERIES "
+                "query": "SELECT average(newrelic.timeslice.value) AS 'Datastore/getConnection' FROM Metric WHERE metricTimesliceName = 'Datastore/getConnection' AND appName IN ({{javaAppNames}}) FACET appName LIMIT MAX TIMESERIES "
               }
             ],
             "platformOptions": {
@@ -952,6 +1055,7 @@
           }
         },
         {
+          "id": "477874085",
           "title": "Database Connection Attempts - By Count",
           "layout": {
             "column": 1,
@@ -973,7 +1077,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT count(newrelic.timeslice.value) AS 'Datastore/getConnection' FROM Metric WHERE (metricTimesliceName = 'Datastore/getConnection') LIMIT MAX TIMESERIES"
+                "query": "SELECT count(newrelic.timeslice.value) AS 'Datastore/getConnection' FROM Metric WHERE (metricTimesliceName = 'Datastore/getConnection') AND appName IN ({{javaAppNames}}) FACET appName LIMIT MAX TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -982,6 +1086,7 @@
           }
         },
         {
+          "id": "477874086",
           "title": "Top 5 Database Operations - By Time Consumed",
           "layout": {
             "column": 5,
@@ -1003,7 +1108,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT sum(apm.service.datastore.operation.duration * 1000) FROM Metric FACET `datastoreType`, `table`, `operation` LIMIT 5 TIMESERIES "
+                "query": "SELECT sum(apm.service.datastore.operation.duration * 1000) FROM Metric WHERE appName IN ({{javaAppNames}}) FACET appName, `datastoreType`, `table`, `operation` LIMIT 5 TIMESERIES "
               }
             ],
             "platformOptions": {
@@ -1012,6 +1117,7 @@
           }
         },
         {
+          "id": "477874087",
           "title": "Top 5 Databases - By Query Time",
           "layout": {
             "column": 9,
@@ -1033,7 +1139,7 @@
             "nrqlQueries": [
               {
                 "accountId": 0,
-                "query": "SELECT average(apm.service.datastore.operation.duration * 1000) FROM Metric FACET `datastoreType`, `table`, `operation` LIMIT 5 TIMESERIES "
+                "query": "SELECT average(apm.service.datastore.operation.duration * 1000) FROM Metric WHERE appName IN ({{javaAppNames}}) FACET appName, `datastoreType`, `table`, `operation` LIMIT 5 TIMESERIES "
               }
             ],
             "platformOptions": {
@@ -1044,10 +1150,12 @@
       ]
     },
     {
+      "guid": "NzE0NTc2MXxWSVp8REFTSEJPQVJEfDQyOTY0OTEw",
       "name": "Error",
       "description": null,
       "widgets": [
         {
+          "id": "477874088",
           "title": "Errors Overview",
           "layout": {
             "column": 1,
@@ -1076,6 +1184,7 @@
           }
         },
         {
+          "id": "477874089",
           "title": "Transactions Errors Today Compared With 1 Day Ago",
           "layout": {
             "column": 5,
@@ -1121,6 +1230,7 @@
           }
         },
         {
+          "id": "477874090",
           "title": "Errors by Transaction Type",
           "layout": {
             "column": 9,
@@ -1148,6 +1258,7 @@
           }
         },
         {
+          "id": "477874091",
           "title": "Transaction Errors Day By Day",
           "layout": {
             "column": 1,
@@ -1175,6 +1286,7 @@
           }
         },
         {
+          "id": "477874092",
           "title": "Transaction Errors",
           "layout": {
             "column": 6,
@@ -1210,11 +1322,13 @@
       ]
     },
     {
+      "guid": "NzE0NTc2MXxWSVp8REFTSEJPQVJEfDQyOTY0OTEx",
       "name": "Log",
       "description": null,
       "widgets": [
         {
-          "title": "",
+          "id": "477874093",
+          "title": null,
           "layout": {
             "column": 1,
             "row": 1,
@@ -1230,6 +1344,7 @@
           }
         },
         {
+          "id": "477874094",
           "title": "Log Entity Names (click on the entity name to filter)",
           "layout": {
             "column": 1,
@@ -1257,6 +1372,7 @@
           }
         },
         {
+          "id": "477874095",
           "title": "Logs by Severity Level",
           "layout": {
             "column": 4,
@@ -1290,7 +1406,8 @@
           }
         },
         {
-          "title": "",
+          "id": "477874096",
+          "title": null,
           "layout": {
             "column": 7,
             "row": 2,
@@ -1313,5 +1430,32 @@
       ]
     }
   ],
-  "variables": []
+  "variables": [
+    {
+      "name": "javaAppNames",
+      "items": null,
+      "defaultValues": [
+        {
+          "value": {
+            "string": "*"
+          }
+        }
+      ],
+      "nrqlQuery": {
+        "accountIds": [
+          0
+        ],
+        "query": "FROM Entity SELECT uniques(name)\nWHERE tags.instrumentation.name = 'apm'\nWHERE tags.language = 'java'"
+      },
+      "options": {
+        "ignoreTimeRange": true,
+        "excluded": false,
+        "showApplyAction": true
+      },
+      "title": "Java App Names",
+      "type": "NRQL",
+      "isMultiSelection": true,
+      "replacementStrategy": "STRING"
+    }
+  ]
 }

--- a/dashboards/java/java.json
+++ b/dashboards/java/java.json
@@ -1,7 +1,6 @@
 {
   "name": "Java",
   "description": null,
-  "permissions": "PUBLIC_READ_WRITE",
   "pages": [
     {
       "guid": "NzE0NTc2MXxWSVp8REFTSEJPQVJEfDQyOTY0OTA2",
@@ -62,7 +61,7 @@
             "width": 6,
             "height": 4
           },
-          "linkedEntityGuids": [],
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -83,9 +82,7 @@
             },
             "nrqlQueries": [
               {
-                "accountIds": [
-                  0
-                ],
+                "accountIds": [],
                 "query": "SELECT \nmin(apm.service.cpu.usertime.utilization) as 'Minimum CPU Utilization', \nmax(apm.service.cpu.usertime.utilization) as 'Maximum CPU Utilization', \naverage(apm.service.cpu.usertime.utilization) as 'Average CPU Utilization' \nFROM Metric\nWHERE appName IN ({{javaAppNames}})\nFACET appName \nTIMESERIES AUTO"
               }
             ],
@@ -129,7 +126,7 @@
             "width": 4,
             "height": 3
           },
-          "linkedEntityGuids": [],
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.area"
           },
@@ -150,9 +147,7 @@
             },
             "nrqlQueries": [
               {
-                "accountIds": [
-                  0
-                ],
+                "accountIds": [],
                 "query": "SELECT average(newrelic.timeslice.value) * 1000 AS `Java/javax.servlet.ServletRequestListener/requestInitialized` \nFROM Metric \nWHERE metricTimesliceName = 'Java/javax.servlet.ServletRequestListener/requestInitialized' \nWHERE appName IN ({{javaAppNames}})\nFACET appName\nTIMESERIES AUTO"
               }
             ],
@@ -204,7 +199,7 @@
             "width": 5,
             "height": 3
           },
-          "linkedEntityGuids": [],
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.pie"
           },
@@ -217,9 +212,7 @@
             },
             "nrqlQueries": [
               {
-                "accountIds": [
-                  0
-                ],
+                "accountIds": [],
                 "query": "FROM Metric \nselect count(apm.service.overview.web) \nWHERE appName IN ({{javaAppNames}})\nFACET appName, segmentName"
               }
             ],
@@ -565,7 +558,7 @@
             "width": 4,
             "height": 3
           },
-          "linkedEntityGuids": [],
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.line"
           },
@@ -586,9 +579,7 @@
             },
             "nrqlQueries": [
               {
-                "accountIds": [
-                  0
-                ],
+                "accountIds": [],
                 "query": "SELECT rate(count(apm.service.transaction.duration), 1 minute)  FROM Metric  TIMESERIES\nWHERE appName IN ({{javaAppNames}})\nFACET appName"
               }
             ],
@@ -639,7 +630,7 @@
             "width": 4,
             "height": 3
           },
-          "linkedEntityGuids": [],
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.area"
           },
@@ -660,9 +651,7 @@
             },
             "nrqlQueries": [
               {
-                "accountIds": [
-                  0
-                ],
+                "accountIds": [],
                 "query": "SELECT average(apm.service.memory.heap.max) as 'Max Heap', average(apm.service.memory.heap.committed) as 'Committed Heap', average(apm.service.memory.heap.used) as 'Used Heap' FROM Metric TIMESERIES AUTO WHERE appName IN ({{javaAppNames}})\nFACET appName"
               }
             ],
@@ -680,7 +669,7 @@
             "width": 4,
             "height": 3
           },
-          "linkedEntityGuids": [],
+          "linkedEntityGuids": null,
           "visualization": {
             "id": "viz.stacked-bar"
           },
@@ -701,9 +690,7 @@
             },
             "nrqlQueries": [
               {
-                "accountIds": [
-                  0
-                ],
+                "accountIds": [],
                 "query": "SELECT average(newrelic.timeslice.value)*1000 FROM Metric WHERE metricTimesliceName LIKE 'GC%'   TIMESERIES\nWHERE appName IN ({{javaAppNames}})\nFACET appName, metricTimesliceName"
               }
             ],
@@ -1442,9 +1429,7 @@
         }
       ],
       "nrqlQuery": {
-        "accountIds": [
-          0
-        ],
+        "accountIds": [],
         "query": "FROM Entity SELECT uniques(name)\nWHERE tags.instrumentation.name = 'apm'\nWHERE tags.language = 'java'"
       },
       "options": {


### PR DESCRIPTION
# Summary

This PR fixes the fact that the Java quickstart dashboard would always be added to an account with broken widgets because all the timeslice metrics queries require a `WHERE appName\entity.guid` in order work. Since you can't hardcode these into a quickstart dashboard, I have made some improvements using dashboard variables. (you can also add `WHERE appName LIKE '%'` but this method allows users to filter apps with the dashboard variable. 

- Add javaAppNames dashboard variable for application-specific filtering
- Update all NRQL queries to use the new filtering mechanism
- Improve query structure with proper WHERE clauses and FACET statements
- Add widget IDs, page GUIDs, and enhanced chart configurations
- Ensure all dashboard widgets filter data by selected Java applications

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->

## Pre merge checklist

<!-- THIS CHECKLIST MUST BE FULLY COMPLETE OR YOUR PR WILL NOT BE MERGED -->

- [x] Did you check you NRQL syntax? - Does it work?
- [x] Did you include a Data source and Documentation reference?
- [x] Are all documentation links publicly accessible?
- [x] Did you check your descriptive content for [voice and tone](https://docs.newrelic.com/docs/style-guide/writing-strategies/voice-strategies-docs-sound-new-relic/)?
- [x] Did you check your descriptive content for spelling and grammar errors?
- [x] Did you review your content with a subject matter expert? (e.g. a Browser agent quickstart is reviewed with a member of the Browser Agent team)

### Dashboards

- [x] Does the PR contain a screenshot for each of your dashboards?
- [x] Do your screenshots show data?
- [x] Has the [sanitization script](https://github.com/newrelic/newrelic-quickstarts/blob/main/CONTRIBUTING.md#dashboards) been run on each dashboard?

### Alerts

- [x] Did you check that your alerts actually work?
- [x]Are you trying to create standalone alerts? Standalone alerts are deprecated. They should only be included in quickstarts.
