### PR TITLE
feat: Added Packets Retransmits chart for eBPF

### DIFF
--- a/dashboards/ebpf/ebpf.json
+++ b/dashboards/ebpf/ebpf.json
@@ -143,7 +143,7 @@
           "layout": {
             "column": 1,
             "row": 7,
-            "width": 4,
+            "width": 3,
             "height": 3
           },
           "linkedEntityGuids": null,
@@ -194,9 +194,9 @@
         {
           "title": "[INBOUND CONNECTIONS] bytes received",
           "layout": {
-            "column": 5,
+            "column": 4,
             "row": 7,
-            "width": 4,
+            "width": 3,
             "height": 3
           },
           "linkedEntityGuids": null,
@@ -245,11 +245,11 @@
           }
         },
         {
-          "title": "[INBOUND CONNECTIONS] packets dropped",
+          "title": "[INBOUND CONNECTIONS] packets retransmits",
           "layout": {
-            "column": 9,
+            "column": 7,
             "row": 7,
-            "width": 4,
+            "width": 3,
             "height": 3
           },
           "linkedEntityGuids": null,
@@ -298,11 +298,64 @@
           }
         },
         {
+          "title": "[INBOUND CONNECTIONS] packets dropped",
+          "layout": {
+            "column": 10,
+            "row": 7,
+            "width": 3,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "markers": {
+              "displayedTypes": {
+                "criticalViolations": false,
+                "deployments": true,
+                "relatedDeployments": true,
+                "warningViolations": false
+              }
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "FROM Metric SELECT sum(ebpf.tcp.packet_dropped) where entity.name IN ({{entity_name}}) and protocol.name='tcp' and direction='INCOMING' FACET entity.name, local_addr, local_port limit max TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "refreshRate": {
+              "frequency": 30000
+            },
+            "thresholds": {
+              "isLabelVisible": true
+            },
+            "units": {
+              "unit": "COUNT"
+            },
+            "yAxisLeft": {
+              "zero": true
+            },
+            "yAxisRight": {
+              "zero": true
+            }
+          }
+        },
+        {
           "title": "[OUTBOUND CONNECTIONS] bytes sent",
           "layout": {
             "column": 1,
             "row": 10,
-            "width": 4,
+            "width": 3,
             "height": 3
           },
           "linkedEntityGuids": null,
@@ -353,9 +406,9 @@
         {
           "title": "[OUTBOUND CONNECTIONS] bytes received",
           "layout": {
-            "column": 5,
+            "column": 4,
             "row": 10,
-            "width": 4,
+            "width": 3,
             "height": 3
           },
           "linkedEntityGuids": null,
@@ -401,11 +454,11 @@
           }
         },
         {
-          "title": "[OUTBOUND CONNECTIONS] packets dropped",
+          "title": "[OUTBOUND CONNECTIONS] packets retransmits",
           "layout": {
-            "column": 9,
+            "column": 7,
             "row": 10,
-            "width": 4,
+            "width": 3,
             "height": 3
           },
           "linkedEntityGuids": null,
@@ -431,6 +484,59 @@
               {
                 "accountIds": [],
                 "query": "FROM Metric SELECT sum(ebpf.tcp.retransmits) where entity.name IN ({{entity_name}}) and protocol.name='tcp' and direction='OUTGOING' FACET entity.name,  remote_addr limit max TIMESERIES"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "refreshRate": {
+              "frequency": 30000
+            },
+            "thresholds": {
+              "isLabelVisible": true
+            },
+            "units": {
+              "unit": "COUNT"
+            },
+            "yAxisLeft": {
+              "zero": true
+            },
+            "yAxisRight": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "[OUTBOUND CONNECTIONS] packets dropped",
+          "layout": {
+            "column": 10,
+            "row": 10,
+            "width": 3,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "markers": {
+              "displayedTypes": {
+                "criticalViolations": false,
+                "deployments": true,
+                "relatedDeployments": true,
+                "warningViolations": false
+              }
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [],
+                "query": "FROM Metric SELECT sum(ebpf.tcp.packet_dropped) where entity.name IN ({{entity_name}}) and protocol.name='tcp' and direction='OUTGOING' FACET entity.name, remote_addr limit max TIMESERIES"
               }
             ],
             "platformOptions": {


### PR DESCRIPTION
# Summary

Updates to eBPF dashboard

Added new chart `Packets Retransmits` for both Inbound and Outbound Connections under eBPF dashboard

## Pre merge checklist

<!-- THIS CHECKLIST MUST BE FULLY COMPLETE OR YOUR PR WILL NOT BE MERGED -->

- [x] Did you check you NRQL syntax? - Does it work?
- [ ] Did you include a Data source and Documentation reference?
- [ ] Are all documentation links publicly accessible?
- [ ] Did you check your descriptive content for [voice and tone](https://docs.newrelic.com/docs/style-guide/writing-strategies/voice-strategies-docs-sound-new-relic/)?
- [ ] Did you check your descriptive content for spelling and grammar errors?
- [ ] Did you review your content with a subject matter expert? (e.g. a Browser agent quickstart is reviewed with a member of the Browser Agent team)

### Dashboards

- [ ] Does the PR contain a screenshot for each of your dashboards?
- [ ] Do your screenshots show data?
- [ ] Has the [sanitization script](https://github.com/newrelic/newrelic-quickstarts/blob/main/CONTRIBUTING.md#dashboards) been run on each dashboard?

### Alerts

- [ ] Did you check that your alerts actually work?
- [ ] Are you trying to create standalone alerts? Standalone alerts are deprecated. They should only be included in quickstarts.
