### PR TITLE
feat: update nginx otel datasource to show guided install steps

### DIFF
--- a/data-sources/nginx-otel/config.yml
+++ b/data-sources/nginx-otel/config.yml
@@ -4,8 +4,12 @@ description: |
   Monitor NGINX instances using OpenTelemetry Collector. Collect comprehensive metrics from connections, requests, client errors, server errors, and more across self-hosted and Kubernetes deployments.
 install:
   primary:
-    link:
-      url: https://docs.newrelic.com/docs/opentelemetry/nginx/nginx-otel-overview/
+    nerdlet:
+      nerdletId: marketplace.install-data-source
+      nerdletState:
+        dataSourceId: nginx-opentelemetry
+        frameworkConfigId: nginx-otel
+      requiresAccount: false
 icon: logo.svg
 
 keywords:


### PR DESCRIPTION
This adds the datasource nerdlet for the docker NGINX. The previous redirection was to docs but this changes to redirection to the installation framework.