### PR TITLE
feat: add JP production environment to release script

### DIFF
--- a/utils/release.ts
+++ b/utils/release.ts
@@ -7,7 +7,7 @@ import { generatePrUrl } from './lib/github-api-helpers';
 import { setDashboardsRequiredDataSources } from './set-dashboards-required-datasources';
 import { setAlertPoliciesRequiredDataSources } from './set-alert-policy-required-datasources';
 
-type Environment = 'local' | 'staging' | 'us' | 'eu';
+type Environment = 'local' | 'staging' | 'us' | 'eu' | 'jp';
 type Context = {
   ENVIRONMENT: Environment;
   GH_TOKEN: string;
@@ -22,6 +22,7 @@ const API_ENDPOINTS: Record<Environment, string> = {
   staging: 'https://staging-api.newrelic.com/graphql',
   us: 'https://api.newrelic.com/graphql',
   eu: 'https://api.eu.newrelic.com/graphql',
+  jp: 'https://api.jp.newrelic.com/graphql',
 };
 
 const divider = () => console.log('―――――――――――――――――――――――――――――');
@@ -39,6 +40,7 @@ const bootstrap = async (): Promise<Context> => {
       { name: 'Staging', value: 'staging' },
       { name: 'US Production', value: 'us' },
       { name: 'EU Production', value: 'eu' },
+      { name: 'JP Production', value: 'jp' },
     ],
   });
 


### PR DESCRIPTION
# Summary

Adds Japan (JP) production as a target environment in `utils/release.ts` to support quickstart releases to the JP region, following the catalog-service-elixir JP deployment (JDC Wave 2).

**Changes:**
- Added `'jp'` to the `Environment` type
- Added `jp: 'https://api.jp.newrelic.com/graphql'` to `API_ENDPOINTS`
- Added `JP Production` to the environment selection prompt

When JP is selected, the script will look for `NR_API_TOKEN_JP` in the environment (or `.env` file), consistent with how US and EU tokens are handled.

## Pre merge checklist

- [x] Not applicable — this is a tooling/script change, not a quickstart submission