### PR TITLE
fix(mariadb): Restore mysql as dataSourceId on release

### DIFF
--- a/quickstarts/mariadb/config.yml
+++ b/quickstarts/mariadb/config.yml
@@ -24,7 +24,7 @@ keywords:
   - NR1_addData
   - NR1_sys
 dataSourceIds:
-  - mariadb
+  - mysql
 dashboards:
   - mariadb
 alertPolicies:


### PR DESCRIPTION
# Summary

Restore `dataSourceIds: - mysql` on the MariaDB quickstart. The current value `- mariadb` is not a registered dataSource (no `data-sources/mariadb/` directory and no entry in `utils/schema/core-datasource-ids.json`), so artifact validation fails for any PR targeting `release`.

## Background

The validator builds the allowed `dataSourceIds` enum from `data-sources/*/config.yml` plus `utils/schema/core-datasource-ids.json`. `mysql` is in the core list; `mariadb` is not in either. The MariaDB integration ships through the mysql data source — the documentation link in this quickstart's own `config.yml` points to the mysql monitoring integration docs, confirming `mysql` is the correct value.

## What changed and why

`main` still has the correct `- mysql`. The bad value was introduced on `release` only, in #2859:

- `dc1f8c01` "fix: Remove mariadb datasource" — changed `- mysql` → `- mariadb` (and dropped NR1 keywords)
- `b68b72e5b` "fix: Added NR1 keywords to mariadb" — restored the keywords but left `dataSourceIds` broken

This PR reverts just the broken line. Keywords stay as-is.

## Reproduction (before this fix)

```
cd utils && npm run build-validate-quickstart-artifact
# Error #1 ... instancePath: '/quickstarts/.../dataSourceIds/0'
# Received value: mariadb
# message: 'must be equal to one of the allowed values'
```

## Pre merge checklist

- [x] Did you check you NRQL syntax? - Does it work? — _N/A, no NRQL changes_
- [x] Did you include a Data source and Documentation reference? — _Documentation already present, this PR only fixes the dataSourceId pointer_
- [x] Are all documentation links publicly accessible?
- [x] Did you check your descriptive content for [voice and tone](https://docs.newrelic.com/docs/style-guide/writing-strategies/voice-strategies-docs-sound-new-relic/)? — _N/A, no descriptive content changed_
- [x] Did you check your descriptive content for spelling and grammar errors? — _N/A_
- [x] Did you review your content with a subject matter expert? — _N/A, this is restoring a previous validated value_

### Dashboards

- [x] Does the PR contain a screenshot for each of your dashboards? — _N/A, no dashboard changes_
- [x] Do your screenshots show data? — _N/A_
- [x] Has the [sanitization script](https://github.com/newrelic/newrelic-quickstarts/blob/main/CONTRIBUTING.md#dashboards) been run on each dashboard? — _N/A_

### Alerts

- [x] Did you check that your alerts actually work? — _N/A, no alert changes_
- [x] Are you trying to create standalone alerts? — _No_

🤖 Generated with [Claude Code](https://claude.com/claude-code)