### PR TITLE
updated data sourceId for mariadb

### DIFF
--- a/quickstarts/mariadb/config.yml
+++ b/quickstarts/mariadb/config.yml
@@ -24,7 +24,7 @@ keywords:
   - NR1_addData
   - NR1_sys
 dataSourceIds:
-  - mysql
+  - mariadb
 dashboards:
   - mariadb
 alertPolicies:

--- a/utils/schema/core-datasource-ids.json
+++ b/utils/schema/core-datasource-ids.json
@@ -73,6 +73,7 @@
   "llm-application",
   "logstash",
   "macos",
+  "mariadb",
   "maui",
   "memcached",
   "micrometer",


### PR DESCRIPTION
# Summary

Updated the dataSourceIds in the MariaDB quickstart configuration from mysql to mariadb to support the new dedicated MariaDB data source being created in the Elixir [repository](https://source.datanerd.us/nr1-dev-experience/catalog-service-elixir/pull/951)

## Pre merge checklist

<!-- THIS CHECKLIST MUST BE FULLY COMPLETE OR YOUR PR WILL NOT BE MERGED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you include a Data source and Documentation reference?
- [ ] Are all documentation links publicly accessible?
- [ ] Did you check your descriptive content for [voice and tone](https://docs.newrelic.com/docs/style-guide/writing-strategies/voice-strategies-docs-sound-new-relic/)?
- [ ] Did you check your descriptive content for spelling and grammar errors?
- [ ] Did you review your content with a subject matter expert? (e.g. a Browser agent quickstart is reviewed with a member of the Browser Agent team)

### Dashboards

- [ ] Does the PR contain a screenshot for each of your dashboards?
- [ ] Do your screenshots show data?
- [ ] Has the [sanitization script](https://github.com/newrelic/newrelic-quickstarts/blob/main/CONTRIBUTING.md#dashboards) been run on each dashboard?

### Alerts

- [ ] Did you check that your alerts actually work?
- [ ] Are you trying to create standalone alerts? Standalone alerts are deprecated. They should only be included in quickstarts.
