### PR TITLE
fix(ibmmq-otel): correct data source dataSourceId so install steps resolve

### DIFF
--- a/data-sources/ibmmq-otel/config.yml
+++ b/data-sources/ibmmq-otel/config.yml
@@ -7,7 +7,7 @@ install:
     nerdlet:
       nerdletId: marketplace.install-data-source
       nerdletState:
-        dataSourceId: ibmmq-otel
+        dataSourceId: ibmmq-opentelemetry
         frameworkConfigId: ibm-mq-otel
       requiresAccount: false
 


### PR DESCRIPTION
## Problem
On staging, clicking **Begin installation** on the IBM MQ (OpenTelemetry) quickstart fails with *"We couldn't locate the installation steps for this workflow."*

## Root cause
The install nerdlet resolves the data source via `dataSource(id: $dataSourceId)`. In `data-sources/ibmmq-otel/config.yml` the `nerdletState.dataSourceId` was `ibmmq-otel` (the folder name), but the catalog id is `ibmmq-opentelemetry` (the `id:` field). The lookup returned nothing, so no install steps were found.

## Fix
Set `dataSourceId: ibmmq-opentelemetry` to match the `id` — the same pattern the working `kafka-opentelemetry` data source uses (`id` == `dataSourceId`). `frameworkConfigId: ibm-mq-otel` is unchanged and matches the deployed shared-component framework config.

Follow-up to #2886.