### PR TITLE
chore(otel): align OTel Collector titles (IBM MQ, Docker, RabbitMQ, Elasticsearch) + fix RabbitMQ install

### DIFF
--- a/dashboards/docker-otel/docker-otel.json
+++ b/dashboards/docker-otel/docker-otel.json
@@ -1,5 +1,5 @@
 {
-  "name": "Docker (OpenTelemetry)",
+  "name": "Docker (OpenTelemetry Collector)",
   "description": null,
   "pages": [
     {

--- a/dashboards/elasticsearch-otel/elasticsearch-otel.json
+++ b/dashboards/elasticsearch-otel/elasticsearch-otel.json
@@ -1,5 +1,5 @@
 {
-  "name": "Elasticsearch OpenTelemetry Dashboard",
+  "name": "Elasticsearch (OpenTelemetry Collector)",
   "pages": [
     {
       "name": "elasticsearch-otel",

--- a/dashboards/ibmmq-otel/ibmmq-otel.json
+++ b/dashboards/ibmmq-otel/ibmmq-otel.json
@@ -1,5 +1,5 @@
 {
-  "name": "IBM MQ OTel - Dashboard",
+  "name": "IBM MQ (OpenTelemetry Collector)",
   "description": "Monitor IBM MQ infrastructure instrumented via the OpenTelemetry collector (NRDot scraping the IBM MQ Prometheus exporter). Tracks queue manager health, queue depth and throughput, channel performance, and filesystem utilization.",
   "pages": [
     {

--- a/dashboards/rabbitmq-otel/rabbitmq-otel.json
+++ b/dashboards/rabbitmq-otel/rabbitmq-otel.json
@@ -1,5 +1,5 @@
 {
-  "name": "RabbitMQ OTEL Overview",
+  "name": "RabbitMQ (OpenTelemetry Collector)",
   "variables": [],
   "pages": [
     {

--- a/data-sources/docker-otel/config.yml
+++ b/data-sources/docker-otel/config.yml
@@ -1,5 +1,5 @@
 id: docker-otel
-displayName: Docker (OpenTelemetry)
+displayName: Docker (OpenTelemetry Collector)
 description: |
   The Open Telemetry Dockerstats receiver allows you to collect metrics related to the usage of CPU, memory, network, and more.
 install:

--- a/data-sources/elasticsearch-otel/config.yml
+++ b/data-sources/elasticsearch-otel/config.yml
@@ -1,5 +1,5 @@
 id: elasticsearch-opentelemetry
-displayName: Elasticsearch (OpenTelemetry)
+displayName: Elasticsearch (OpenTelemetry Collector)
 description: |
   Monitor Elasticsearch health with our OTel integration.Collect cluster, node, and index metrics plus host data and logs. Gain full visibility into performance to quickly troubleshoot issues within New Relic.
 install:

--- a/data-sources/ibmmq-integration-docs/config.yml
+++ b/data-sources/ibmmq-integration-docs/config.yml
@@ -1,5 +1,5 @@
 id: ibmmq-integration-docs
-displayName: IBM MQ integration
+displayName: IBM MQ (Infrastructure Agent)
 description: |
   The New Relic IBM MQ monitor allows you to monitor the performance of MQ Objects like channels and queues.
 install:

--- a/data-sources/ibmmq-otel/config.yml
+++ b/data-sources/ibmmq-otel/config.yml
@@ -1,5 +1,5 @@
 id: ibmmq-opentelemetry
-displayName: IBM MQ (OpenTelemetry)
+displayName: IBM MQ (OpenTelemetry Collector)
 description: |
   Monitor IBM MQ with OpenTelemetry. The NRDOT collector scrapes the IBM MQ Prometheus exporter (mq-metric-samples) and forwards queue manager, queue, and channel metrics to New Relic over OTLP.
 install:

--- a/data-sources/rabbitmq-otel/config.yml
+++ b/data-sources/rabbitmq-otel/config.yml
@@ -1,5 +1,5 @@
 id: rabbitmq-opentelemetry
-displayName: RabbitMQ (OpenTelemetry)
+displayName: RabbitMQ (OpenTelemetry Collector)
 description: |
   Monitor RabbitMQ with OTel integration. Collect node metrics, queue stats, message flow, and I/O performance. Gain full visibility to troubleshoot issues in New Relic.
 install:
@@ -7,7 +7,7 @@ install:
     nerdlet:
       nerdletId: marketplace.install-data-source
       nerdletState:
-        dataSourceId: rabbitmq-otel
+        dataSourceId: rabbitmq-opentelemetry
         frameworkConfigId: rabbitmq-otel
       requiresAccount: false
 

--- a/quickstarts/docker-otel/config.yml
+++ b/quickstarts/docker-otel/config.yml
@@ -1,6 +1,6 @@
 id: 67298fce-4bbe-40d0-8cda-b80aad183794
 slug: docker-otel
-title: Docker (OpenTelemetry)
+title: Docker (OpenTelemetry Collector)
 summary: |
   Monitoring docker is essential to enable your team deliver high-quality software that yields a positive customer experience. Install New Relic Docker for Open Telemetry quickstart to proactively instrument Docker with the Dockerstats receiver.
 description: |

--- a/quickstarts/docker-otel/config.yml
+++ b/quickstarts/docker-otel/config.yml
@@ -33,6 +33,7 @@ documentation:
 dashboards:
   - docker-otel
 keywords:
+  - otel docker
   - containers
   - open telemetry
   - docker

--- a/quickstarts/elasticsearch-otel/config.yml
+++ b/quickstarts/elasticsearch-otel/config.yml
@@ -1,6 +1,6 @@
 id: 4b8900d1-df3b-496c-a22e-8e419e4c2776
 slug: elasticsearch-opentelemetry
-title: Elasticsearch (OpenTelemetry)
+title: Elasticsearch (OpenTelemetry Collector)
 description: |
   This quickstart includes dashboards and alerts for popular signals regarding Elasticsearch cluster health and performance.
   Monitoring Elasticsearch is essential for maintaining cluster health and preventing latency in your data-driven applications. The Elasticsearch for OpenTelemetry quickstart provides deep visibility into your search infrastructure to ensure optimal performance and uptime across your entire stack.

--- a/quickstarts/elasticsearch-otel/config.yml
+++ b/quickstarts/elasticsearch-otel/config.yml
@@ -17,6 +17,7 @@ documentation:
       Multitenant-capable full-text RESTful search engine with an HTTP web interface and schema-free JSON documents.
     url: https://docs.newrelic.com/docs/opentelemetry/integrations/elasticsearch/elasticsearch-otel-integration-overview/
 keywords:
+  - otel elasticsearch
   - infrastructure
   - database
   - Opentelemetry

--- a/quickstarts/haproxy-otel/config.yml
+++ b/quickstarts/haproxy-otel/config.yml
@@ -31,6 +31,7 @@ documentation:
 dataSourceIds:
   - haproxy-opentelemetry
 keywords:
+  - otel haproxy
   - open telemetry
   - otel
   - haproxy

--- a/quickstarts/ibmmq-otel/config.yml
+++ b/quickstarts/ibmmq-otel/config.yml
@@ -1,6 +1,6 @@
 id: b50ee32a-b024-4273-82f4-dc1c0e415f1e
 slug: ibmmq-otel
-title: IBM MQ (OpenTelemetry)
+title: IBM MQ (OpenTelemetry Collector)
 description: |
   ## IBM MQ performance via OpenTelemetry
 

--- a/quickstarts/ibmmq-otel/config.yml
+++ b/quickstarts/ibmmq-otel/config.yml
@@ -26,6 +26,8 @@ level: New Relic
 icon: logo.png
 
 keywords:
+  - otel ibm mq
+  - otel ibmmq
   - infrastructure
   - ibm mq
   - ibm-mq

--- a/quickstarts/ibmmq/config.yml
+++ b/quickstarts/ibmmq/config.yml
@@ -1,6 +1,6 @@
 id: 924fd4b3-a6d1-4a6e-9e2c-b598f197f713
 slug: ibmmq
-title: IBM MQ
+title: IBM MQ (Infrastructure Agent)
 description: |
   ## IBM MQ performance
 

--- a/quickstarts/nginx-otel/config.yml
+++ b/quickstarts/nginx-otel/config.yml
@@ -22,6 +22,7 @@ documentation:
 dataSourceIds:
   - nginx-opentelemetry
 keywords:
+  - otel nginx
   - open telemetry
   - otel
   - nginx

--- a/quickstarts/rabbitmq-otel/config.yml
+++ b/quickstarts/rabbitmq-otel/config.yml
@@ -1,6 +1,6 @@
 id: e82c2e4d-2a15-4f67-b89e-5c1d8f4e3a2b
 slug: rabbitmq-opentelemetry
-title: RabbitMQ (OpenTelemetry)
+title: RabbitMQ (OpenTelemetry Collector)
 description: |
   This quickstart includes dashboards and alerts for popular signals regarding RabbitMQ node health, message flow, and queue performance.
   Monitoring RabbitMQ is essential for maintaining message broker health and preventing bottlenecks in your distributed applications. The RabbitMQ for OpenTelemetry quickstart provides deep visibility into your messaging infrastructure to ensure optimal performance and reliability across your entire stack.

--- a/quickstarts/rabbitmq-otel/config.yml
+++ b/quickstarts/rabbitmq-otel/config.yml
@@ -17,6 +17,7 @@ documentation:
       Open-source message broker that supports multiple messaging protocols for asynchronous communication between applications.
     url: https://docs.newrelic.com/docs/opentelemetry/integrations/rabbitmq/overview/
 keywords:
+  - otel rabbitmq
   - infrastructure
   - messaging
   - queue


### PR DESCRIPTION
## What
Align OpenTelemetry Collector naming, fix RabbitMQ's guided install, add `otel <integration>` keywords, and align native IBM MQ naming.

### 1. Titles → `(OpenTelemetry Collector)`
For **IBM MQ**, **Docker**, **RabbitMQ**, **Elasticsearch**: quickstart `title` + data source `displayName` + dashboard `name` → `(OpenTelemetry Collector)`, matching Kafka/NGINX/HAProxy.

### 2. Fix RabbitMQ guided install
`data-sources/rabbitmq-otel` `dataSourceId` `rabbitmq-otel` → `rabbitmq-opentelemetry` (must match `id`; same fix as IBM MQ #2888), so **Begin installation** resolves its steps.

### 3. `otel <integration>` keywords
Add `otel docker`, `otel ibm mq`, `otel ibmmq`, `otel rabbitmq`, `otel elasticsearch`, `otel nginx`, `otel haproxy` (kafka already had `otel kafka`).

### 4. Native IBM MQ → `(Infrastructure Agent)`
The native IBM MQ read `IBM MQ integration` (data source `ibmmq-integration-docs`) / `IBM MQ` (quickstart `ibmmq`). Renamed both to **`IBM MQ (Infrastructure Agent)`** so it pairs cleanly with `IBM MQ (OpenTelemetry Collector)` and shows a clear label in the OTel dashboard setup wizard — matching the Kafka/NGINX native pattern.

## Scope notes
- Dashboard **title** only (page/tab names unchanged).
- `documentation[].name` labels and `description` prose unchanged.
- Native counterparts for the other integrations (docker, elasticsearch, haproxy, rabbitmq, redis) live in catalog-service-elixir and are handled in a separate PR there.
- All JSON/YAML validated; built off latest upstream `release` (preserves merged #2888).

Assisted-by: Claude Opus 4.8