### PR TITLE
fix(otel): Redis OTel Collector title + native quickstart (Infrastructure Agent) titles

### DIFF
--- a/dashboards/redis-otel/redis-otel.json
+++ b/dashboards/redis-otel/redis-otel.json
@@ -1,5 +1,5 @@
 {
-  "name": "Redis OpenTelemetry Dashboard",
+  "name": "Redis (OpenTelemetry Collector)",
   "variables": [],
   "pages": [
     {

--- a/data-sources/redis-otel/config.yml
+++ b/data-sources/redis-otel/config.yml
@@ -1,5 +1,5 @@
 id: redis-otel
-displayName: Redis (OpenTelemetry)
+displayName: Redis (OpenTelemetry Collector)
 description: |
   The OpenTelemetry Redis receiver enables the collection of metrics related to clients, connections, memory usage, network, and more.
 install:

--- a/quickstarts/docker/config.yml
+++ b/quickstarts/docker/config.yml
@@ -18,7 +18,7 @@ icon: logo.svg
 level: New Relic
 authors:
   - New Relic
-title: Docker
+title: Docker (Infrastructure Agent)
 dataSourceIds:
   - docker
 documentation:

--- a/quickstarts/elasticsearch/config.yml
+++ b/quickstarts/elasticsearch/config.yml
@@ -1,6 +1,6 @@
 id: d42f2744-3d69-4860-97af-ec9e75885038
 slug: elasticsearch
-title: Elasticsearch
+title: Elasticsearch (Infrastructure Agent)
 description: |
   This quickstart includes dashboards and alerts for popular signals regarding Elasticsearch cluster health and performance.
   Use this quickstart together with the New Relic Elasticsearch On Host Integration and New Relic Infrastructure agent log forwarding to get insight into the performance of your Elasticsearch clusters.

--- a/quickstarts/rabbitmq/config.yml
+++ b/quickstarts/rabbitmq/config.yml
@@ -1,6 +1,6 @@
 id: 523d091a-7949-433b-91cf-ae2736251af7
 slug: rabbitmq
-title: RabbitMQ
+title: RabbitMQ (Infrastructure Agent)
 description: |
   ## RabbitMQ performance
 

--- a/quickstarts/redis-otel/config.yml
+++ b/quickstarts/redis-otel/config.yml
@@ -1,6 +1,6 @@
 id: 6d07c47a-6b4d-4369-98c5-3736ec6d2000
 slug: redis-otel
-title: Redis (OpenTelemetry)
+title: Redis (OpenTelemetry Collector)
 summary: |
   Gain immediate, centralized visibility into your Redis instances. This quickstart delivers a comprehensive observability suite that transforms raw telemetry into actionable insights for memory, performance, and connection health.
 description: |

--- a/quickstarts/redis/config.yml
+++ b/quickstarts/redis/config.yml
@@ -1,6 +1,6 @@
 id: 289983fe-378e-4690-9302-2490e2afe11c
 slug: redis
-title: Redis
+title: Redis (Infrastructure Agent)
 description: |+
   ## A complete Redis monitoring system
 


### PR DESCRIPTION
## What
Follow-up consistency pass after #2892, fixing marketplace naming still on the old form.

### 1. Redis OpenTelemetry -> `(OpenTelemetry Collector)`
Redis was missed in #2892. Align its title everywhere to match the other OTel Collector integrations (kafka/nginx/docker/etc.):
- data source `redis-otel` displayName: `Redis (OpenTelemetry)` -> **`Redis (OpenTelemetry Collector)`**
- quickstart `redis-otel` title: same
- dashboard `redis-otel` name: `Redis OpenTelemetry Dashboard` -> **`Redis (OpenTelemetry Collector)`**

(Redis OTel is correctly wired otherwise — `dataSourceId` == `id` == `redis-otel`, nerdlet install, so the guided Setup already works.)

### 2. Native quickstart titles -> `(Infrastructure Agent)`
Kafka, NGINX, HAProxy, and IBM MQ native quickstarts already read `(Infrastructure Agent)`, but these four were still plain — so the native tile looked duplicated next to its `(Infrastructure Agent)` data source. Aligned:
- `Docker` -> **`Docker (Infrastructure Agent)`**
- `RabbitMQ` -> **`RabbitMQ (Infrastructure Agent)`**
- `Elasticsearch` -> **`Elasticsearch (Infrastructure Agent)`**
- `Redis` -> **`Redis (Infrastructure Agent)`**

## Notes
- 7 files, all YAML/JSON validated; built off latest `release` (includes merged #2892).
- Docker/NGINX OTel titles are already `(OpenTelemetry Collector)` on `release` (from #2892) — what still shows old in staging is pre-deploy cache.
- Out of scope (different integration families / owners, distinct naming): `kubernetes-opentelemetry`, `gitlab-integration`, `singlestore`, and the generic `opentelemetry` quickstart.
- Also noticed: native **dashboard** names for RabbitMQ (`RabbitMQ`), Redis (`Redis`), and Elasticsearch (`Elasticsearch Monitoring`) don't carry `(Infrastructure Agent)` like Kafka/NGINX do — left as-is here (dashboard-content surface, not the tile); can align in a follow-up if desired.

Assisted-by: Claude Opus 4.8