### PR TITLE
fix: point Anthropic quickstart to Traceloop OpenLLMetry data source

### DIFF
--- a/quickstarts/anthropic/config.yml
+++ b/quickstarts/anthropic/config.yml
@@ -22,10 +22,10 @@ description: |-
   - Pinpoint failures in prompts, token limits, or third-party integrations with precision.
 
   ### Get started!
-  Instrument your application with OpenLLMetry — an OpenTelemetry-based SDK for LLMs — and connect it to New Relic to start monitoring your Anthropic Claude usage. Check out the documentation below to get set up quickly.
+  Traceloop's OpenLLMetry, an OpenTelemetry-based SDK for LLMs, gives you a straightforward path to instrumenting your application and connecting it to New Relic to start monitoring your Anthropic Claude usage. Check out the documentation below to get set up quickly.
 
   ### More info
-  Check out the [documentation](https://github.com/traceloop/openllmetry) to learn more about New Relic monitoring for Anthropic Claude models.
+  To set up OpenLLMetry with Newrelic, see [Newrelic Documentation](https://docs.newrelic.com/docs/opentelemetry/get-started/traceloop-llm-observability/traceloop-llm-observability-intro/).
 
 summary: |-
   Monitor your Anthropic Claude models (Haiku, Sonnet & Opus) in New Relic — track cost, token usage, latency, and errors via OpenLLMetry.
@@ -39,7 +39,7 @@ documentation:
   - name: Anthropic integration docs
     description: |
       Instrument your Anthropic-powered application with OpenLLMetry to send telemetry data to New Relic for full observability.
-    url: https://github.com/traceloop/openllmetry
+    url: https://docs.newrelic.com/docs/opentelemetry/get-started/traceloop-llm-observability/traceloop-llm-observability-intro/
 keywords:
   - anthropic
   - claude
@@ -56,4 +56,4 @@ alertPolicies:
 dashboards:
   - anthropic
 dataSourceIds:
-  - opentelemetry
+  - traceloop


### PR DESCRIPTION
The generic opentelemetry dataSourceId routed users to New Relic's generic OTel intro doc instead of Anthropic-relevant content. Switch to the existing traceloop data source and align doc links accordingly.

# Summary

A concise description of the changes being introduced. Please review the pre-merge checklist section to validate this pull request is ready for review and merge. **If it is not ready, please mark the pull request as a draft.**

_The owners of this repo are not experts in the subject matter of the quickstarts. We review for the quickstart to be functional and for security risks. If you are seeking feedback on the content of the quickstart, please seek out a subject matter expert. If you are not an internal NR contributor, we can do our best to connect you with a content reviewer._

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->

## Pre merge checklist

<!-- THIS CHECKLIST MUST BE FULLY COMPLETE OR YOUR PR WILL NOT BE MERGED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you include a Data source and Documentation reference?
- [ ] Are all documentation links publicly accessible?
- [ ] Did you check your descriptive content for [voice and tone](https://docs.newrelic.com/docs/style-guide/writing-strategies/voice-strategies-docs-sound-new-relic/)?
- [ ] Did you check your descriptive content for spelling and grammar errors?
- [ ] Did you review your content with a subject matter expert? (e.g. a Browser agent quickstart is reviewed with a member of the Browser Agent team)

### Dashboards

- [ ] Does the PR contain a screenshot for each of your dashboards?
- [ ] Do your screenshots show data?
- [ ] Has the [sanitization script](https://github.com/newrelic/newrelic-quickstarts/blob/main/CONTRIBUTING.md#dashboards) been run on each dashboard?

### Alerts

- [ ] Did you check that your alerts actually work?
- [ ] Are you trying to create standalone alerts? Standalone alerts are deprecated. They should only be included in quickstarts.
