### PR TITLE
fix: add workflow_dispatch to CI workflows

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,6 +2,7 @@ name: PR Validation
 
 on:
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - "utils/**"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/validation_gate.yml
+++ b/.github/workflows/validation_gate.yml
@@ -6,6 +6,7 @@ name: Validation Gate
 
 on:
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "**.yml"
       - "**.yaml"
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

When the `nr-opensource-bot` auto-generates UUIDs after a merge to `release`, it commits with `[skip ci]` to prevent CI loops. If this bot commit becomes the HEAD of a `release → main` PR, GitHub skips all `pull_request`-triggered workflows — making it impossible to re-trigger checks without a direct push (which branch protection blocks).

## Fix

Add `workflow_dispatch` to four workflows so they can be manually triggered when needed:

- `validation_gate.yml`
- `pr-checks.yml`
- `yaml-lint.yml`
- `run_tests.yml`

## After merging

Once this PR is merged, unblock PR #2916 by running:

```bash
gh workflow run "Validation Gate" --ref release --repo newrelic/newrelic-quickstarts
gh workflow run "PR Validation" --ref release --repo newrelic/newrelic-quickstarts
gh workflow run "Lint Yaml" --ref release --repo newrelic/newrelic-quickstarts
```