### PR TITLE
fix: Websockets quickstart updates

### DIFF
--- a/dashboards/browser-web-sockets/browser-web-sockets.json
+++ b/dashboards/browser-web-sockets/browser-web-sockets.json
@@ -1,9 +1,9 @@
 {
-  "name": "Web Sockets",
+  "name": "Websockets",
   "description": null,
   "pages": [
     {
-      "name": "Web Sockets",
+      "name": "Websockets",
       "widgets": [
         {
           "layout": {
@@ -111,7 +111,7 @@
               "zero": true
             }
           },
-          "title": "Web Sockets With Errors",
+          "title": "Websockets With Errors",
           "visualization": {
             "id": "viz.line"
           }
@@ -201,7 +201,7 @@
               "zero": true
             }
           },
-          "title": "Web Socket Instances",
+          "title": "Websocket Instances",
           "visualization": {
             "id": "viz.line"
           }
@@ -494,7 +494,7 @@
               "ignoreTimeRange": false
             }
           },
-          "title": "Web Sockets By Binary Type",
+          "title": "Websockets By Binary Type",
           "visualization": {
             "id": "viz.table"
           }
@@ -520,7 +520,7 @@
               "ignoreTimeRange": false
             }
           },
-          "title": "Web Sockets By Extension",
+          "title": "Websockets By Extension",
           "visualization": {
             "id": "viz.table"
           }

--- a/data-sources/browser-web-sockets/config.yml
+++ b/data-sources/browser-web-sockets/config.yml
@@ -1,9 +1,9 @@
 id: browser-web-sockets
-displayName: Browser Web Sockets
+displayName: Browser Websockets
 description: |
-  Utilize Browser WebSocket events to analyze telemetry and performance data of your web sockets connections.
+  Utilize Browser WebSocket events to analyze telemetry and performance data of your websockets connections.
 install:
   primary:
     link:
-      url: https://docs.newrelic.com/attribute-dictionary/?dataSource=Browser+agent&event=WebSocket
+      url: https://docs.newrelic.com/docs/browser/new-relic-browser/browser-pro-features/websockets/
 icon: logo.svg

--- a/quickstarts/browser-web-sockets/config.yml
+++ b/quickstarts/browser-web-sockets/config.yml
@@ -1,17 +1,17 @@
 id: 2cc13c93-462e-4d7b-8c2c-be822d58c3a7
 slug: browser-web-sockets
-title: Browser Web Sockets
-summary: Example dashboards utilizing web sockets from New Relic Browser agent data
+title: Browser Websockets
+summary: Example dashboards utilizing websockets from New Relic Browser agent data
 description: |
-  Utilize Browser WebSocket events to analyze telemetry and performance data of your web sockets connections.
+  Utilize Browser WebSocket events to analyze telemetry and performance data of your websockets connections.
 level: New Relic
 authors:
   - Grady Ellison
 icon: logo.svg
 documentation:
-  - name: Browser Web Sockets
+  - name: Browser Websockets
     description: Browser WebSocket events are captured when a WebSocket connection lifecycle completes — either when the connection closes normally or when the page navigates away with an open connection. It includes metrics about the connection, messages received, data sent, and how the connection was closed. Each WebSocket instance is tracked independently and emits one event per connection lifetime.
-    url: https://docs.newrelic.com/attribute-dictionary/?dataSource=Browser+agent&event=WebSocket
+    url: https://docs.newrelic.com/docs/browser/new-relic-browser/browser-pro-features/websockets/
 dataSourceIds:
   - browser-web-sockets
 keywords:


### PR DESCRIPTION
# Summary

Some minor updates to the websockets quickstart
- Websockets is now one word instead of two (web sockets)
- Update docs link to one that has more contextual and introductory information

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->

## Pre merge checklist

<!-- THIS CHECKLIST MUST BE FULLY COMPLETE OR YOUR PR WILL NOT BE MERGED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you include a Data source and Documentation reference?
- [ ] Are all documentation links publicly accessible?
- [ ] Did you check your descriptive content for [voice and tone](https://docs.newrelic.com/docs/style-guide/writing-strategies/voice-strategies-docs-sound-new-relic/)?
- [ ] Did you check your descriptive content for spelling and grammar errors?
- [ ] Did you review your content with a subject matter expert? (e.g. a Browser agent quickstart is reviewed with a member of the Browser Agent team)

### Dashboards

- [ ] Does the PR contain a screenshot for each of your dashboards?
- [ ] Do your screenshots show data?
- [ ] Has the [sanitization script](https://github.com/newrelic/newrelic-quickstarts/blob/main/CONTRIBUTING.md#dashboards) been run on each dashboard?

### Alerts

- [ ] Did you check that your alerts actually work?
- [ ] Are you trying to create standalone alerts? Standalone alerts are deprecated. They should only be included in quickstarts.
