### PR TITLE
Update mssql-otel dashboard: fixes, metric cleanup, and OTel alignment

### DIFF
--- a/dashboards/mssql-otel/mssql-otel.json
+++ b/dashboards/mssql-otel/mssql-otel.json
@@ -1,6 +1,6 @@
 {
   "name": "SQL Server OTel Monitoring",
-  "description": "Comprehensive SQL Server monitoring dashboard using nrsqlserverreceiver metrics. Covers golden signals, performance, memory, storage, waits, locks, security, transactions, query monitoring, thread pool, tempdb, and Always-On. Multi-instance support via entity variable.",
+  "description": "Comprehensive SQL Server monitoring dashboard using nrsqlserverreceiver metrics. Covers golden signals, performance, memory, storage, waits, locks, security, transactions, query monitoring, thread pool, tempdb, and Always-On. Multi-instance support via instance variable (service.instance.id).",
   "pages": [
     {
       "name": "Overview - Golden Metrics",
@@ -37,8 +37,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.user.connection.count) AS 'Connections' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.user.connection.count' TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.user.connection.count) AS 'Connections' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.user.connection.count' TIMESERIES"
               }
             ]
           }
@@ -58,8 +58,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.page.buffer_cache.hit_ratio) AS 'Hit %' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.page.buffer_cache.hit_ratio' SINCE 5 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.page.buffer_cache.hit_ratio) AS 'Hit %' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.page.buffer_cache.hit_ratio'"
               }
             ],
             "thresholds": [
@@ -89,8 +89,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.batch.request.rate) AS 'Batch Requests/sec' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.batch.request.rate' TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.batch.request.rate) AS 'Batch Requests/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.batch.request.rate' TIMESERIES"
               }
             ]
           }
@@ -110,8 +110,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.process.count) FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.process.count' FACET `process.status` TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.process.count) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.process.count' FACET `process.status` TIMESERIES"
               }
             ]
           }
@@ -131,8 +131,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.deadlock.rate) AS 'Deadlocks/sec' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.deadlock.rate' TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.deadlock.rate) AS 'Deadlocks/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.deadlock.rate' TIMESERIES"
               }
             ]
           }
@@ -152,8 +152,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.processes.blocked) AS 'Blocked' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.processes.blocked' TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.processes.blocked) AS 'Blocked' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.processes.blocked' TIMESERIES"
               }
             ]
           }
@@ -173,8 +173,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.page.life_expectancy) AS 'PLE (s)' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.page.life_expectancy' TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.page.life_expectancy) AS 'PLE (s)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.page.life_expectancy' TIMESERIES"
               }
             ]
           }
@@ -194,8 +194,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.cpu.count) AS 'CPUs', latest(sqlserver.computer.uptime) / 86400 AS 'Uptime (days)' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName IN ('sqlserver.cpu.count', 'sqlserver.computer.uptime') SINCE 5 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.cpu.count) AS 'CPUs', latest(sqlserver.computer.uptime) / 86400 AS 'Uptime (days)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName IN ('sqlserver.cpu.count', 'sqlserver.computer.uptime')"
               }
             ]
           }
@@ -207,7 +207,7 @@
       "description": "Detailed breakdown of the slowest queries",
       "widgets": [
         {
-          "title": null,
+          "title": "",
           "layout": {
             "column": 1,
             "row": 1,
@@ -241,7 +241,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Log SELECT latest(db.query.full_text) AS 'Query', latest(sqlserver.query_hash) AS 'query_hash', latest(db.namespace) AS 'Database', sum(sqlserver.execution_count) AS 'Executions', sum(sqlserver.total_elapsed_time)/sum(sqlserver.execution_count) AS 'Avg Duration (s)', sum(sqlserver.total_worker_time)/sum(sqlserver.execution_count) AS 'Avg CPU (s)', sum(sqlserver.total_logical_reads) AS 'Logical Reads' WHERE entity.guid IN ({{entity}}) AND event.name = 'db.server.top_query' FACET sqlserver.query_hash SINCE 30 minutes ago LIMIT 20"
+                "query": "FROM Log SELECT latest(db.query.full_text) AS 'Query', latest(sqlserver.query_hash) AS 'query_hash', latest(db.namespace) AS 'Database', sum(sqlserver.execution_count) AS 'Executions', sum(sqlserver.total_elapsed_time)/sum(sqlserver.execution_count) AS 'Avg Duration (s)', sum(sqlserver.total_worker_time)/sum(sqlserver.execution_count) AS 'Avg CPU (s)', sum(sqlserver.total_logical_reads) AS 'Logical Reads' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' FACET sqlserver.query_hash LIMIT MAX"
               }
             ],
             "platformOptions": {
@@ -264,8 +264,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT sum(sqlserver.execution_count) FROM Log WHERE entity.guid IN ({{entity}}) AND event.name = 'db.server.top_query' FACET db.namespace TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT sum(sqlserver.execution_count) FROM Log WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' FACET db.namespace TIMESERIES"
               }
             ]
           }
@@ -285,8 +285,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT sum(sqlserver.total_worker_time)/sum(sqlserver.execution_count) AS 'Avg CPU (s)' FROM Log WHERE entity.guid IN ({{entity}}) AND event.name = 'db.server.top_query' FACET db.namespace TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT sum(sqlserver.total_worker_time)/sum(sqlserver.execution_count) AS 'Avg CPU (s)' FROM Log WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' FACET db.namespace TIMESERIES"
               }
             ]
           }
@@ -332,7 +332,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Log SELECT latest(sqlserver.query_start) AS 'Start Time', latest(sqlserver.query_hash) AS 'query_hash',  latest(db.namespace) AS 'Database', latest(sqlserver.total_elapsed_time) AS 'Duration (s)', latest(db.query.full_text) AS 'Query', latest(user.name) AS 'User', latest(client.address) AS 'Host', latest(sqlserver.wait_type) AS 'Wait Type', latest(sqlserver.wait_time) AS 'Wait (s)', latest(sqlserver.blocking_session_id) AS 'Blocked By'  WHERE entity.guid IN ({{entity}}) AND event.name = 'db.server.query_sample' FACET sqlserver.query_start, sqlserver.session_id SINCE 5 minutes ago LIMIT MAX"
+                "query": "FROM Log SELECT latest(sqlserver.query_start) AS 'Start Time', latest(sqlserver.query_hash) AS 'query_hash',  latest(db.namespace) AS 'Database', latest(sqlserver.total_elapsed_time) AS 'Duration (s)', latest(db.query.full_text) AS 'Query', latest(user.name) AS 'User', latest(client.address) AS 'Host', latest(sqlserver.wait_type) AS 'Wait Type', latest(sqlserver.wait_time) AS 'Wait (s)', latest(sqlserver.blocking_session_id) AS 'Blocked By'  WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' FACET sqlserver.query_start, sqlserver.session_id LIMIT MAX"
               }
             ],
             "platformOptions": {
@@ -355,8 +355,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "FROM Log SELECT latest(sqlserver.wait_time) AS 'Wait (s)' WHERE entity.guid IN ({{entity}}) AND event.name = 'db.server.query_sample' AND sqlserver.wait_type != '' FACET sqlserver.wait_type TIMESERIES AUTO SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "FROM Log SELECT latest(sqlserver.wait_time) AS 'Wait (s)' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' AND sqlserver.wait_type != '' FACET sqlserver.wait_type TIMESERIES AUTO"
               }
             ]
           }
@@ -376,8 +376,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "FROM Log SELECT uniqueCount(sqlserver.session_id) WHERE entity.guid IN ({{entity}}) AND event.name = 'db.server.query_sample' FACET sqlserver.session_status TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "FROM Log SELECT uniqueCount(sqlserver.session_id) WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' FACET sqlserver.session_status TIMESERIES"
               }
             ]
           }
@@ -397,8 +397,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "FROM Log SELECT latest(sqlserver.wait_type) AS 'Wait Type', latest(sqlserver.wait_resource) AS 'Wait Resource', latest(user.name) AS 'User', latest(sqlserver.blocking_session_id) AS 'Blocked By', latest(sqlserver.wait_time) AS 'Wait (s)', latest(sqlserver.open_transaction_count) AS 'Open Txns', latest(sqlserver.query_hash) AS 'query_hash', latest(sqlserver.query_start) AS 'Start Time', latest(db.query.text) AS 'Query' WHERE entity.guid IN ({{entity}}) AND event.name = 'db.server.query_sample' AND sqlserver.wait_time > 0 FACET sqlserver.session_id, sqlserver.blocking_session_id SINCE 5 minutes ago LIMIT MAX"
+                "accountIds": [],
+                "query": "FROM Log SELECT latest(sqlserver.wait_type) AS 'Wait Type', latest(sqlserver.wait_resource) AS 'Wait Resource', latest(user.name) AS 'User', latest(sqlserver.blocking_session_id) AS 'Blocked By', latest(sqlserver.wait_time) AS 'Wait (s)', latest(sqlserver.open_transaction_count) AS 'Open Txns', latest(sqlserver.query_hash) AS 'query_hash', latest(sqlserver.query_start) AS 'Start Time', latest(db.query.full_text) AS 'Query' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' AND sqlserver.wait_time > 0 FACET sqlserver.session_id, sqlserver.blocking_session_id LIMIT MAX"
               }
             ]
           }
@@ -418,8 +418,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "FROM Log SELECT uniqueCount(sqlserver.session_id) WHERE entity.guid IN ({{entity}}) AND event.name = 'db.server.query_sample' AND sqlserver.session_status = 'running' FACET db.namespace SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "FROM Log SELECT uniqueCount(sqlserver.session_id) WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' AND sqlserver.session_status = 'running' FACET db.namespace"
               }
             ]
           }
@@ -439,8 +439,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "FROM Log SELECT uniqueCount(sqlserver.session_id) AS 'Blocked Sessions' WHERE entity.guid IN ({{entity}}) AND event.name = 'db.server.query_sample' AND numeric(sqlserver.blocking_session_id) > 0 TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "FROM Log SELECT uniqueCount(sqlserver.session_id) AS 'Blocked Sessions' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' AND numeric(sqlserver.blocking_session_id) > 0 TIMESERIES"
               }
             ]
           }
@@ -452,7 +452,7 @@
       "description": "Query execution plans with drill-down by normalized hash",
       "widgets": [
         {
-          "title": null,
+          "title": "",
           "layout": {
             "column": 1,
             "row": 1,
@@ -486,7 +486,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Log SELECT latest(sqlserver.query_hash) AS 'query_hash', latest(sqlserver.query_plan_hash) AS 'plan_hash', latest(sqlserver.query_plan) AS 'Execution Plan XML' WHERE entity.guid IN ({{entity}}) AND event.name = 'db.server.top_query' AND sqlserver.query_plan != '' FACET  sqlserver.query_plan_hash SINCE 30 minutes ago LIMIT 20"
+                "query": "FROM Log SELECT latest(sqlserver.query_hash) AS 'query_hash', latest(sqlserver.query_plan_hash) AS 'plan_hash', latest(sqlserver.query_plan) AS 'Execution Plan XML' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' AND sqlserver.query_plan != '' FACET  sqlserver.query_plan_hash LIMIT 20"
               }
             ],
             "platformOptions": {
@@ -509,8 +509,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "FROM Log SELECT uniqueCount(sqlserver.query_plan_hash) AS 'Plan Count', latest(db.query.text) AS 'Query', latest(db.namespace) AS 'Database' WHERE entity.guid IN ({{entity}}) AND event.name = 'db.server.top_query' AND sqlserver.query_plan IS NOT NULL FACET sqlserver.query_hash SINCE 1 hour ago LIMIT 20"
+                "accountIds": [],
+                "query": "FROM Log SELECT uniqueCount(sqlserver.query_plan_hash) AS 'Plan Count', latest(db.query.full_text) AS 'Query', latest(db.namespace) AS 'Database' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' AND sqlserver.query_plan IS NOT NULL FACET sqlserver.query_hash LIMIT 20"
               }
             ]
           }
@@ -552,8 +552,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.batch.sql_compilation.rate) AS 'Compilations/sec' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.batch.sql_compilation.rate' TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.batch.sql_compilation.rate) AS 'Compilations/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.batch.sql_compilation.rate' TIMESERIES"
               }
             ]
           }
@@ -573,8 +573,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.batch.sql_recompilation.rate) AS 'Recompilations/sec' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.batch.sql_recompilation.rate' TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.batch.sql_recompilation.rate) AS 'Recompilations/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.batch.sql_recompilation.rate' TIMESERIES"
               }
             ]
           }
@@ -594,8 +594,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.recompilation.ratio) AS 'Recompile %' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.recompilation.ratio' SINCE 5 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.recompilation.ratio) AS 'Recompile %' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.recompilation.ratio'"
               }
             ],
             "thresholds": [
@@ -621,8 +621,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.batch.compilation.utilization) AS 'Compilations/Batch' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.batch.compilation.utilization' SINCE 5 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.batch.compilation.utilization) AS 'Compilations/Batch' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.batch.compilation.utilization'"
               }
             ],
             "thresholds": [
@@ -648,8 +648,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.batch.page_split.utilization) AS 'Page Splits/Batch' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.batch.page_split.utilization' SINCE 5 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.batch.page_split.utilization) AS 'Page Splits/Batch' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.batch.page_split.utilization'"
               }
             ]
           }
@@ -669,8 +669,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.parameterization.rate) FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.parameterization.rate' FACET `sqlserver.parameterization.result` TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.parameterization.rate) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.parameterization.rate' FACET `sqlserver.parameterization.result` TIMESERIES"
               }
             ]
           }
@@ -690,8 +690,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.database.full_scan.rate) AS 'Full Scans/sec' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.database.full_scan.rate' TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.database.full_scan.rate) AS 'Full Scans/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.database.full_scan.rate' TIMESERIES"
               }
             ]
           }
@@ -711,8 +711,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.index.search.rate) AS 'Index Searches/sec' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.index.search.rate' TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.index.search.rate) AS 'Index Searches/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.index.search.rate' TIMESERIES"
               }
             ]
           }
@@ -740,11 +740,11 @@
           }
         },
         {
-          "title": "Memory Target (GB)",
+          "title": "OS Memory Utilization %",
           "layout": {
             "column": 1,
             "row": 3,
-            "width": 3,
+            "width": 4,
             "height": 3
           },
           "linkedEntityGuids": null,
@@ -754,29 +754,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.memory.target) / 1073741824 AS 'Target (GB)' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.memory.target' SINCE 5 minutes ago"
-              }
-            ]
-          }
-        },
-        {
-          "title": "OS Memory Utilization %",
-          "layout": {
-            "column": 4,
-            "row": 3,
-            "width": 3,
-            "height": 3
-          },
-          "linkedEntityGuids": null,
-          "visualization": {
-            "id": "viz.billboard"
-          },
-          "rawConfiguration": {
-            "nrqlQueries": [
-              {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.os.memory.utilization) * 100 AS 'Mem Util %' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.os.memory.utilization' SINCE 5 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.os.memory.utilization) * 100 AS 'Mem Util %' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.os.memory.utilization'"
               }
             ],
             "thresholds": [
@@ -794,9 +773,9 @@
         {
           "title": "OS Disk Size (GB)",
           "layout": {
-            "column": 7,
+            "column": 5,
             "row": 3,
-            "width": 3,
+            "width": 4,
             "height": 3
           },
           "linkedEntityGuids": null,
@@ -806,8 +785,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.os.disk.size) / 1073741824 AS 'Disk (GB)' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.os.disk.size' SINCE 5 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.os.disk.size) / 1073741824 AS 'Disk (GB)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.os.disk.size'"
               }
             ]
           }
@@ -815,9 +794,9 @@
         {
           "title": "Memory Grants Pending",
           "layout": {
-            "column": 10,
+            "column": 9,
             "row": 3,
-            "width": 3,
+            "width": 4,
             "height": 3
           },
           "linkedEntityGuids": null,
@@ -827,8 +806,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.memory.grants.pending.count) AS 'Pending' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.memory.grants.pending.count' SINCE 5 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.memory.grants.pending.count) AS 'Pending' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.memory.grants.pending.count'"
               }
             ],
             "thresholds": [
@@ -858,8 +837,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.memory.area) / 1048576 AS 'MB' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.memory.area' FACET `memory.pool` SINCE 5 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.memory.area) / 1048576 AS 'MB' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.memory.area' FACET `memory.pool`"
               }
             ]
           }
@@ -879,8 +858,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.memory.page.count) FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.memory.page.count' FACET `page.pool` SINCE 5 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.memory.page.count) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.memory.page.count' FACET `page.pool`"
               }
             ]
           }
@@ -900,8 +879,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.os.memory.usage) / 1073741824 AS 'GB' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.os.memory.usage' FACET `memory.state` SINCE 5 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.os.memory.usage) / 1073741824 AS 'GB' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.os.memory.usage' FACET `memory.state`"
               }
             ]
           }
@@ -921,8 +900,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.memory.cache.object.count) FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.memory.cache.object.count' FACET `cache.state` SINCE 5 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.memory.cache.object.count) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.memory.cache.object.count' FACET `cache.state`"
               }
             ]
           }
@@ -964,8 +943,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.database.file.size) / 1048576 AS 'MB' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.database.file.size' FACET `db.namespace`, `file_type` SINCE 5 minutes ago LIMIT 20"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.database.file.size) / 1048576 AS 'MB' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.database.file.size' FACET `db.namespace`, `file_type` LIMIT 20"
               }
             ]
           }
@@ -985,8 +964,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.database.page_file.size) / 1048576 AS 'MB' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.database.page_file.size' FACET `db.namespace`, `page_file.state` SINCE 5 minutes ago LIMIT 20"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.database.page_file.size) / 1048576 AS 'MB' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.database.page_file.size' FACET `db.namespace`, `page_file.state` LIMIT 20"
               }
             ]
           }
@@ -1006,8 +985,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.database.io) FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.database.io' FACET `direction`, `file_type` TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.database.io) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.database.io' FACET `direction`, `file_type` TIMESERIES"
               }
             ]
           }
@@ -1027,8 +1006,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.database.latency) FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.database.latency' FACET `direction`, `file_type` TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.database.latency) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.database.latency' FACET `direction`, `file_type` TIMESERIES"
               }
             ]
           }
@@ -1070,8 +1049,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT max(sqlserver.os.wait.duration) AS 'Wait (s)' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.os.wait.duration' FACET `wait.category` SINCE 30 minutes ago LIMIT 15"
+                "accountIds": [],
+                "query": "SELECT max(sqlserver.os.wait.duration) AS 'Wait (s)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.os.wait.duration' FACET `wait.category` LIMIT 15"
               }
             ]
           }
@@ -1091,8 +1070,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT max(sqlserver.os.wait.tasks.count) FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.os.wait.tasks.count' FACET `wait.category` SINCE 30 minutes ago LIMIT 15"
+                "accountIds": [],
+                "query": "SELECT max(sqlserver.os.wait.tasks.count) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.os.wait.tasks.count' FACET `wait.category` LIMIT 15"
               }
             ]
           }
@@ -1112,8 +1091,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.os.wait.duration) FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.os.wait.duration' FACET `wait.category` TIMESERIES SINCE 30 minutes ago LIMIT 5"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.os.wait.duration) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.os.wait.duration' FACET `wait.category` TIMESERIES LIMIT 5"
               }
             ]
           }
@@ -1155,8 +1134,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.lock.wait.rate) AS 'Lock Waits/sec' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.lock.wait.rate' TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.lock.wait.rate) AS 'Lock Waits/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.lock.wait.rate' TIMESERIES"
               }
             ]
           }
@@ -1176,50 +1155,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.lock.timeout.rate) AS 'Timeouts/sec' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.lock.timeout.rate' TIMESERIES SINCE 30 minutes ago"
-              }
-            ]
-          }
-        },
-        {
-          "title": "Active Locks by Mode",
-          "layout": {
-            "column": 1,
-            "row": 6,
-            "width": 6,
-            "height": 3
-          },
-          "linkedEntityGuids": null,
-          "visualization": {
-            "id": "viz.bar"
-          },
-          "rawConfiguration": {
-            "nrqlQueries": [
-              {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.lock.by_mode.count) FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.lock.by_mode.count' FACET `lock.mode` SINCE 5 minutes ago"
-              }
-            ]
-          }
-        },
-        {
-          "title": "Active Locks by Resource Type",
-          "layout": {
-            "column": 7,
-            "row": 6,
-            "width": 6,
-            "height": 3
-          },
-          "linkedEntityGuids": null,
-          "visualization": {
-            "id": "viz.bar"
-          },
-          "rawConfiguration": {
-            "nrqlQueries": [
-              {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.lock.by_resource.count) FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.lock.by_resource.count' FACET `lock.resource` SINCE 5 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.lock.timeout.rate) AS 'Timeouts/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.lock.timeout.rate' TIMESERIES"
               }
             ]
           }
@@ -1228,7 +1165,7 @@
           "title": "Lock Wait Count (Workload Group)",
           "layout": {
             "column": 1,
-            "row": 9,
+            "row": 6,
             "width": 12,
             "height": 3
           },
@@ -1239,8 +1176,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.lock.wait.count) FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.lock.wait.count' FACET `workload_group.name` TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.lock.wait.count) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.lock.wait.count' FACET `workload_group.name` TIMESERIES"
               }
             ]
           }
@@ -1282,8 +1219,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.database.transactions.active) FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.database.transactions.active' FACET `db.namespace` SINCE 5 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.database.transactions.active) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.database.transactions.active' FACET `db.namespace`"
               }
             ]
           }
@@ -1303,8 +1240,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.transaction.longest_running_time) AS 'Longest (s)' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.transaction.longest_running_time' TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.transaction.longest_running_time) AS 'Longest (s)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.transaction.longest_running_time' TIMESERIES"
               }
             ],
             "thresholds": [
@@ -1334,8 +1271,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.transaction.delay) AS 'Delay (ms)' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.transaction.delay' TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.transaction.delay) AS 'Delay (ms)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.transaction.delay' TIMESERIES"
               }
             ]
           }
@@ -1355,8 +1292,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.transaction.version_cleanup.rate) AS 'Cleanup', latest(sqlserver.transaction.version_generation.rate) AS 'Generation' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName IN ('sqlserver.transaction.version_cleanup.rate', 'sqlserver.transaction.version_generation.rate') TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.transaction.version_cleanup.rate) AS 'Cleanup', latest(sqlserver.transaction.version_generation.rate) AS 'Generation' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName IN ('sqlserver.transaction.version_cleanup.rate', 'sqlserver.transaction.version_generation.rate') TIMESERIES"
               }
             ]
           }
@@ -1398,8 +1335,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.latch.wait.rate) AS 'Latch Waits/sec' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.latch.wait.rate' TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.latch.wait.rate) AS 'Latch Waits/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.latch.wait.rate' TIMESERIES"
               }
             ]
           }
@@ -1419,8 +1356,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.latch.wait_time.avg) AS 'Avg (s)' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.latch.wait_time.avg' TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.latch.wait_time.avg) AS 'Avg (s)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.latch.wait_time.avg' TIMESERIES"
               }
             ]
           }
@@ -1440,8 +1377,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.latch.wait_time.total) AS 'Total (s)' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.latch.wait_time.total' TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.latch.wait_time.total) AS 'Total (s)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.latch.wait_time.total' TIMESERIES"
               }
             ]
           }
@@ -1461,8 +1398,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.latch.superlatch.count) AS 'Active Superlatches' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.latch.superlatch.count' SINCE 5 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.latch.superlatch.count) AS 'Active Superlatches' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.latch.superlatch.count'"
               }
             ]
           }
@@ -1482,8 +1419,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.latch.superlatch.transition.rate) FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.latch.superlatch.transition.rate' FACET `transition.direction` TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.latch.superlatch.transition.rate) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.latch.superlatch.transition.rate' FACET `transition.direction` TIMESERIES"
               }
             ]
           }
@@ -1525,8 +1462,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.thread_pool.workers.count) FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.thread_pool.workers.count' FACET `worker.state` TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.thread_pool.workers.count) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.thread_pool.workers.count' FACET `worker.state` TIMESERIES"
               }
             ]
           }
@@ -1546,8 +1483,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.thread_pool.workers.utilization) * 100 AS 'Util %' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.thread_pool.workers.utilization' SINCE 5 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.thread_pool.workers.utilization) * 100 AS 'Util %' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.thread_pool.workers.utilization'"
               }
             ],
             "thresholds": [
@@ -1577,8 +1514,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.thread_pool.tasks.count) FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.thread_pool.tasks.count' FACET `task.state` TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.thread_pool.tasks.count) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.thread_pool.tasks.count' FACET `task.state` TIMESERIES"
               }
             ]
           }
@@ -1598,8 +1535,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.tempdb.space.usage) / 1048576 AS 'MB' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.tempdb.space.usage' FACET `tempdb.space_kind` SINCE 5 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.tempdb.space.usage) / 1048576 AS 'MB' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.tempdb.space.usage' FACET `tempdb.space_kind`"
               }
             ]
           }
@@ -1619,8 +1556,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.tempdb.file.size) / 1048576 AS 'MB' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.tempdb.file.size' FACET `file_type`, `tempdb.file.id` SINCE 5 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.tempdb.file.size) / 1048576 AS 'MB' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.tempdb.file.size' FACET `file_type`, `tempdb.file.id`"
               }
             ]
           }
@@ -1640,8 +1577,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.tempdb.contention.waiters.count) AS 'Contention Waiters', latest(sqlserver.tempdb.data_files.count) AS 'Data Files' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName IN ('sqlserver.tempdb.contention.waiters.count', 'sqlserver.tempdb.data_files.count') SINCE 5 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.tempdb.contention.waiters.count) AS 'Contention Waiters', latest(sqlserver.tempdb.data_files.count) AS 'Data Files' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName IN ('sqlserver.tempdb.contention.waiters.count', 'sqlserver.tempdb.data_files.count')"
               }
             ]
           }
@@ -1661,177 +1598,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.tempdb.allocation.wait_time.total) FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.tempdb.allocation.wait_time.total' FACET `allocation.page_type` SINCE 5 minutes ago"
-              }
-            ]
-          }
-        }
-      ]
-    },
-    {
-      "name": "Security & Principals",
-      "description": "Database security principals, roles, and risk levels",
-      "widgets": [
-        {
-          "title": "",
-          "layout": {
-            "column": 1,
-            "row": 1,
-            "width": 12,
-            "height": 2
-          },
-          "linkedEntityGuids": null,
-          "visualization": {
-            "id": "viz.markdown"
-          },
-          "rawConfiguration": {
-            "text": "### Security & Principals\n\nDatabase security posture: how many principals exist per database, their types, role risk levels (4=highest for db_owner), orphaned users that should be cleaned up, and recently created accounts."
-          }
-        },
-        {
-          "title": "Server Security Principals",
-          "layout": {
-            "column": 1,
-            "row": 3,
-            "width": 4,
-            "height": 3
-          },
-          "linkedEntityGuids": null,
-          "visualization": {
-            "id": "viz.billboard"
-          },
-          "rawConfiguration": {
-            "nrqlQueries": [
-              {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.server.security.principal.count) AS 'Server Principals' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.server.security.principal.count' SINCE 5 minutes ago"
-              }
-            ]
-          }
-        },
-        {
-          "title": "Server Role Members",
-          "layout": {
-            "column": 5,
-            "row": 3,
-            "width": 8,
-            "height": 3
-          },
-          "linkedEntityGuids": null,
-          "visualization": {
-            "id": "viz.bar"
-          },
-          "rawConfiguration": {
-            "nrqlQueries": [
-              {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.server.security.role_membership.count) FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.server.security.role_membership.count' FACET `role` SINCE 5 minutes ago"
-              }
-            ]
-          }
-        },
-        {
-          "title": "Database Principals by Type & DB",
-          "layout": {
-            "column": 1,
-            "row": 6,
-            "width": 6,
-            "height": 3
-          },
-          "linkedEntityGuids": null,
-          "visualization": {
-            "id": "viz.bar"
-          },
-          "rawConfiguration": {
-            "nrqlQueries": [
-              {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.database.principals.count) FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.database.principals.count' FACET `db.namespace`, `principal.type` SINCE 5 minutes ago LIMIT 20"
-              }
-            ]
-          }
-        },
-        {
-          "title": "Role Risk Level (1=low, 4=high)",
-          "layout": {
-            "column": 7,
-            "row": 6,
-            "width": 6,
-            "height": 3
-          },
-          "linkedEntityGuids": null,
-          "visualization": {
-            "id": "viz.bar"
-          },
-          "rawConfiguration": {
-            "nrqlQueries": [
-              {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.database.role.permission.risk_level) FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.database.role.permission.risk_level' FACET `db.namespace`, `role` SINCE 5 minutes ago LIMIT 20"
-              }
-            ]
-          }
-        },
-        {
-          "title": "Orphaned Users by Database",
-          "layout": {
-            "column": 1,
-            "row": 9,
-            "width": 4,
-            "height": 3
-          },
-          "linkedEntityGuids": null,
-          "visualization": {
-            "id": "viz.bar"
-          },
-          "rawConfiguration": {
-            "nrqlQueries": [
-              {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.database.principals.orphaned_users) FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.database.principals.orphaned_users' FACET `db.namespace` SINCE 5 minutes ago"
-              }
-            ]
-          }
-        },
-        {
-          "title": "Recently Created Principals (30d)",
-          "layout": {
-            "column": 5,
-            "row": 9,
-            "width": 4,
-            "height": 3
-          },
-          "linkedEntityGuids": null,
-          "visualization": {
-            "id": "viz.bar"
-          },
-          "rawConfiguration": {
-            "nrqlQueries": [
-              {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.database.principals.recently_created) FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.database.principals.recently_created' FACET `db.namespace` SINCE 5 minutes ago"
-              }
-            ]
-          }
-        },
-        {
-          "title": "Role Memberships by Kind",
-          "layout": {
-            "column": 9,
-            "row": 9,
-            "width": 4,
-            "height": 3
-          },
-          "linkedEntityGuids": null,
-          "visualization": {
-            "id": "viz.bar"
-          },
-          "rawConfiguration": {
-            "nrqlQueries": [
-              {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.database.role.memberships.count) FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.database.role.memberships.count' FACET `db.namespace`, `membership.kind` SINCE 5 minutes ago LIMIT 20"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.tempdb.allocation.wait_time.total) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.tempdb.allocation.wait_time.total' FACET `allocation.page_type`"
               }
             ]
           }
@@ -1873,8 +1641,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.failover_cluster.replica.flow_control_time) AS 'Flow Control (ms)' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.failover_cluster.replica.flow_control_time' TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.failover_cluster.replica.flow_control_time) AS 'Flow Control (ms)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.failover_cluster.replica.flow_control_time' TIMESERIES"
               }
             ]
           }
@@ -1894,8 +1662,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.replica.data.rate) FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.replica.data.rate' FACET `replica.direction` TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.replica.data.rate) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.replica.data.rate' FACET `replica.direction` TIMESERIES"
               }
             ]
           }
@@ -1915,8 +1683,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.failover_cluster.replica.database.queue_size) FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.failover_cluster.replica.database.queue_size' FACET `replica.queue_kind` TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.failover_cluster.replica.database.queue_size) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.failover_cluster.replica.database.queue_size' FACET `replica.queue_kind` TIMESERIES"
               }
             ]
           }
@@ -1936,8 +1704,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.failover_cluster.replica.database.redo.rate) AS 'Redo Rate' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.failover_cluster.replica.database.redo.rate' TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.failover_cluster.replica.database.redo.rate) AS 'Redo Rate' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.failover_cluster.replica.database.redo.rate' TIMESERIES"
               }
             ]
           }
@@ -1955,7 +1723,7 @@
             "id": "viz.markdown"
           },
           "rawConfiguration": {
-            "text": "## Note\n\nAlways-On metrics only populate when SQL Server has Availability Groups configured. If no AG is configured, these charts will be empty — this is expected behavior."
+            "text": "## Note\n\nAlways-On metrics only populate when SQL Server has Availability Groups configured. If no AG is configured, these charts will be empty \u2014 this is expected behavior."
           }
         }
       ]
@@ -1977,7 +1745,7 @@
             "id": "viz.markdown"
           },
           "rawConfiguration": {
-            "text": "### Resource Governor\n\nResource pool disk operations and throttling, plus login/logout churn rates and kill connection errors. Useful for identifying resource contention in multi-tenant environments."
+            "text": "### Resource Governor\n\nResource pool disk operations and throttling, plus login/logout churn rates and attention events. Useful for identifying resource contention in multi-tenant environments."
           }
         },
         {
@@ -1995,8 +1763,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.resource_pool.disk.operations) FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.resource_pool.disk.operations' FACET `direction` TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.resource_pool.disk.operations) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.resource_pool.disk.operations' FACET `direction` TIMESERIES"
               }
             ]
           }
@@ -2016,8 +1784,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.resource_pool.disk.throttled.read.rate) AS 'Read Throttled/sec' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.resource_pool.disk.throttled.read.rate' TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.resource_pool.disk.throttled.read.rate) AS 'Read Throttled/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.resource_pool.disk.throttled.read.rate' TIMESERIES"
               }
             ]
           }
@@ -2037,8 +1805,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.resource_pool.disk.throttled.write.rate) AS 'Write Throttled/sec' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName = 'sqlserver.resource_pool.disk.throttled.write.rate' TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.resource_pool.disk.throttled.write.rate) AS 'Write Throttled/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.resource_pool.disk.throttled.write.rate' TIMESERIES"
               }
             ]
           }
@@ -2058,14 +1826,14 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.login.rate) AS 'Logins/sec', latest(sqlserver.logout.rate) AS 'Logouts/sec' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName IN ('sqlserver.login.rate', 'sqlserver.logout.rate') TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.login.rate) AS 'Logins/sec', latest(sqlserver.logout.rate) AS 'Logouts/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName IN ('sqlserver.login.rate', 'sqlserver.logout.rate') TIMESERIES"
               }
             ]
           }
         },
         {
-          "title": "Kill Connection Errors & Attention Rate",
+          "title": "Attention Rate",
           "layout": {
             "column": 7,
             "row": 6,
@@ -2079,8 +1847,8 @@
           "rawConfiguration": {
             "nrqlQueries": [
               {
-                "accountId": 0,
-                "query": "SELECT latest(sqlserver.kill_connection.error.rate) AS 'Kill Errors/sec', latest(sqlserver.attention.rate) AS 'Attentions/sec' FROM Metric WHERE entity.guid IN ({{entity}}) AND metricName IN ('sqlserver.kill_connection.error.rate', 'sqlserver.attention.rate') TIMESERIES SINCE 30 minutes ago"
+                "accountIds": [],
+                "query": "SELECT latest(sqlserver.attention.rate) AS 'Attentions/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.attention.rate' TIMESERIES"
               }
             ]
           }
@@ -2090,8 +1858,8 @@
   ],
   "variables": [
     {
-      "name": "entity",
-      "items": null,
+      "name": "instance",
+      "items": [],
       "defaultValues": [
         {
           "value": {
@@ -2101,7 +1869,7 @@
       ],
       "nrqlQuery": {
         "accountIds": [],
-        "query": "FROM Metric SELECT uniques(entity.guid) WHERE metricName = 'sqlserver.user.connection.count' SINCE 1 hour ago LIMIT 100"
+        "query": "FROM Metric SELECT uniques(service.instance.id) WHERE metricName = 'sqlserver.user.connection.count' "
       },
       "options": {
         "hiddenOnVariablesBar": false,

--- a/dashboards/mssql-otel/mssql-otel.json
+++ b/dashboards/mssql-otel/mssql-otel.json
@@ -38,7 +38,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.user.connection.count) AS 'Connections' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.user.connection.count' TIMESERIES"
+                "query": "SELECT latest(sqlserver.user.connection.count) AS 'Connections' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.user.connection.count' FACET service.instance.id TIMESERIES"
               }
             ]
           }
@@ -59,7 +59,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.page.buffer_cache.hit_ratio) AS 'Hit %' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.page.buffer_cache.hit_ratio'"
+                "query": "SELECT latest(sqlserver.page.buffer_cache.hit_ratio) AS 'Hit %' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.page.buffer_cache.hit_ratio' FACET service.instance.id"
               }
             ],
             "thresholds": [
@@ -90,7 +90,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.batch.request.rate) AS 'Batch Requests/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.batch.request.rate' TIMESERIES"
+                "query": "SELECT latest(sqlserver.batch.request.rate) AS 'Batch Requests/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.batch.request.rate' FACET service.instance.id TIMESERIES"
               }
             ]
           }
@@ -111,7 +111,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.process.count) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.process.count' FACET `process.status` TIMESERIES"
+                "query": "SELECT latest(sqlserver.process.count) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.process.count' FACET service.instance.id, `process.status` TIMESERIES"
               }
             ]
           }
@@ -132,7 +132,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.deadlock.rate) AS 'Deadlocks/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.deadlock.rate' TIMESERIES"
+                "query": "SELECT latest(sqlserver.deadlock.rate) AS 'Deadlocks/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.deadlock.rate' FACET service.instance.id TIMESERIES"
               }
             ]
           }
@@ -153,7 +153,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.processes.blocked) AS 'Blocked' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.processes.blocked' TIMESERIES"
+                "query": "SELECT latest(sqlserver.processes.blocked) AS 'Blocked' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.processes.blocked' FACET service.instance.id TIMESERIES"
               }
             ]
           }
@@ -174,7 +174,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.page.life_expectancy) AS 'PLE (s)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.page.life_expectancy' TIMESERIES"
+                "query": "SELECT latest(sqlserver.page.life_expectancy) AS 'PLE (s)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.page.life_expectancy' FACET service.instance.id TIMESERIES"
               }
             ]
           }
@@ -195,7 +195,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.cpu.count) AS 'CPUs', latest(sqlserver.computer.uptime) / 86400 AS 'Uptime (days)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName IN ('sqlserver.cpu.count', 'sqlserver.computer.uptime')"
+                "query": "SELECT latest(sqlserver.cpu.count) AS 'CPUs', latest(sqlserver.computer.uptime) / 86400 AS 'Uptime (days)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName IN ('sqlserver.cpu.count', 'sqlserver.computer.uptime') FACET service.instance.id"
               }
             ]
           }
@@ -241,7 +241,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Log SELECT latest(db.query.full_text) AS 'Query', latest(sqlserver.query_hash) AS 'query_hash', latest(db.namespace) AS 'Database', sum(sqlserver.execution_count) AS 'Executions', sum(sqlserver.total_elapsed_time)/sum(sqlserver.execution_count) AS 'Avg Duration (s)', sum(sqlserver.total_worker_time)/sum(sqlserver.execution_count) AS 'Avg CPU (s)', sum(sqlserver.total_logical_reads) AS 'Logical Reads' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' FACET sqlserver.query_hash LIMIT MAX"
+                "query": "FROM Log SELECT latest(service.instance.id) AS 'Instance', latest(service.instance.id) AS 'Instance', latest(db.query.full_text) AS 'Query', latest(sqlserver.query_hash) AS 'query_hash', latest(db.namespace) AS 'Database', sum(sqlserver.execution_count) AS 'Executions', sum(sqlserver.total_elapsed_time)/sum(sqlserver.execution_count) AS 'Avg Duration (s)', sum(sqlserver.total_worker_time)/sum(sqlserver.execution_count) AS 'Avg CPU (s)', sum(sqlserver.total_logical_reads) AS 'Logical Reads' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' FACET sqlserver.query_hash LIMIT MAX"
               }
             ],
             "platformOptions": {
@@ -265,7 +265,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT sum(sqlserver.execution_count) FROM Log WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' FACET db.namespace TIMESERIES LIMIT MAX"
+                "query": "SELECT sum(sqlserver.execution_count) FROM Log WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' FACET service.instance.id, db.namespace TIMESERIES LIMIT MAX"
               }
             ]
           }
@@ -286,7 +286,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT sum(sqlserver.total_worker_time)/sum(sqlserver.execution_count) AS 'Avg CPU (s)' FROM Log WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' FACET db.namespace TIMESERIES LIMIT MAX"
+                "query": "SELECT sum(sqlserver.total_worker_time)/sum(sqlserver.execution_count) AS 'Avg CPU (s)' FROM Log WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' FACET service.instance.id, db.namespace TIMESERIES LIMIT MAX"
               }
             ]
           }
@@ -332,7 +332,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Log SELECT latest(sqlserver.query_start) AS 'Start Time', latest(sqlserver.query_hash) AS 'query_hash',  latest(db.namespace) AS 'Database', latest(sqlserver.total_elapsed_time) AS 'Duration (s)', latest(db.query.full_text) AS 'Query', latest(user.name) AS 'User', latest(client.address) AS 'Host', latest(sqlserver.wait_type) AS 'Wait Type', latest(sqlserver.wait_time) AS 'Wait (s)', latest(sqlserver.blocking_session_id) AS 'Blocked By'  WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' FACET sqlserver.query_start, sqlserver.session_id LIMIT MAX"
+                "query": "FROM Log SELECT latest(service.instance.id) AS 'Instance', latest(service.instance.id) AS 'Instance', latest(sqlserver.query_start) AS 'Start Time', latest(sqlserver.query_hash) AS 'query_hash',  latest(db.namespace) AS 'Database', latest(sqlserver.total_elapsed_time) AS 'Duration (s)', latest(db.query.full_text) AS 'Query', latest(user.name) AS 'User', latest(client.address) AS 'Host', latest(sqlserver.wait_type) AS 'Wait Type', latest(sqlserver.wait_time) AS 'Wait (s)', latest(sqlserver.blocking_session_id) AS 'Blocked By'  WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' FACET sqlserver.query_start, sqlserver.session_id LIMIT MAX"
               }
             ],
             "platformOptions": {
@@ -356,7 +356,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Log SELECT latest(sqlserver.wait_time) AS 'Wait (s)' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' AND sqlserver.wait_type != '' FACET sqlserver.wait_type TIMESERIES AUTO LIMIT MAX"
+                "query": "FROM Log SELECT latest(sqlserver.wait_time) AS 'Wait (s)' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' AND sqlserver.wait_type != '' FACET service.instance.id, sqlserver.wait_type TIMESERIES AUTO LIMIT MAX"
               }
             ]
           }
@@ -377,7 +377,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Log SELECT uniqueCount(sqlserver.session_id) WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' FACET sqlserver.session_status TIMESERIES"
+                "query": "FROM Log SELECT uniqueCount(sqlserver.session_id) WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' FACET service.instance.id, sqlserver.session_status TIMESERIES"
               }
             ]
           }
@@ -398,7 +398,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Log SELECT latest(sqlserver.wait_type) AS 'Wait Type', latest(sqlserver.wait_resource) AS 'Wait Resource', latest(user.name) AS 'User', latest(sqlserver.blocking_session_id) AS 'Blocked By', latest(sqlserver.wait_time) AS 'Wait (s)', latest(sqlserver.open_transaction_count) AS 'Open Txns', latest(sqlserver.query_hash) AS 'query_hash', latest(sqlserver.query_start) AS 'Start Time', latest(db.query.full_text) AS 'Query' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' AND sqlserver.wait_time > 0 FACET sqlserver.session_id, sqlserver.blocking_session_id LIMIT MAX"
+                "query": "FROM Log SELECT latest(service.instance.id) AS 'Instance', latest(service.instance.id) AS 'Instance', latest(sqlserver.wait_type) AS 'Wait Type', latest(sqlserver.wait_resource) AS 'Wait Resource', latest(user.name) AS 'User', latest(sqlserver.blocking_session_id) AS 'Blocked By', latest(sqlserver.wait_time) AS 'Wait (s)', latest(sqlserver.open_transaction_count) AS 'Open Txns', latest(sqlserver.query_hash) AS 'query_hash', latest(sqlserver.query_start) AS 'Start Time', latest(db.query.full_text) AS 'Query' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' AND sqlserver.wait_time > 0 FACET sqlserver.session_id, sqlserver.blocking_session_id LIMIT MAX"
               }
             ]
           }
@@ -419,7 +419,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Log SELECT uniqueCount(sqlserver.session_id) WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' AND sqlserver.session_status = 'running' FACET db.namespace LIMIT MAX"
+                "query": "FROM Log SELECT uniqueCount(sqlserver.session_id) WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' AND sqlserver.session_status = 'running' FACET service.instance.id, db.namespace LIMIT MAX"
               }
             ]
           }
@@ -440,7 +440,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Log SELECT uniqueCount(sqlserver.session_id) AS 'Blocked Sessions' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' AND numeric(sqlserver.blocking_session_id) > 0 TIMESERIES"
+                "query": "FROM Log SELECT uniqueCount(sqlserver.session_id) AS 'Blocked Sessions' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' AND numeric(sqlserver.blocking_session_id) > 0 FACET service.instance.id TIMESERIES"
               }
             ]
           }
@@ -486,7 +486,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Log SELECT latest(sqlserver.query_hash) AS 'query_hash', latest(sqlserver.query_plan_hash) AS 'plan_hash', latest(sqlserver.query_plan) AS 'Execution Plan XML' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' AND sqlserver.query_plan != '' FACET  sqlserver.query_plan_hash LIMIT 20"
+                "query": "FROM Log SELECT latest(service.instance.id) AS 'Instance', latest(service.instance.id) AS 'Instance', latest(sqlserver.query_hash) AS 'query_hash', latest(sqlserver.query_plan_hash) AS 'plan_hash', latest(sqlserver.query_plan) AS 'Execution Plan XML' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' AND sqlserver.query_plan != '' FACET  sqlserver.query_plan_hash LIMIT 20"
               }
             ],
             "platformOptions": {
@@ -510,7 +510,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Log SELECT uniqueCount(sqlserver.query_plan_hash) AS 'Plan Count', latest(db.query.full_text) AS 'Query', latest(db.namespace) AS 'Database' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' AND sqlserver.query_plan IS NOT NULL FACET sqlserver.query_hash LIMIT 20"
+                "query": "FROM Log SELECT latest(service.instance.id) AS 'Instance', latest(service.instance.id) AS 'Instance', uniqueCount(sqlserver.query_plan_hash) AS 'Plan Count', latest(db.query.full_text) AS 'Query', latest(db.namespace) AS 'Database' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' AND sqlserver.query_plan IS NOT NULL FACET sqlserver.query_hash LIMIT 20"
               }
             ]
           }
@@ -553,7 +553,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.batch.sql_compilation.rate) AS 'Compilations/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.batch.sql_compilation.rate' TIMESERIES"
+                "query": "SELECT latest(sqlserver.batch.sql_compilation.rate) AS 'Compilations/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.batch.sql_compilation.rate' FACET service.instance.id TIMESERIES"
               }
             ]
           }
@@ -574,7 +574,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.batch.sql_recompilation.rate) AS 'Recompilations/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.batch.sql_recompilation.rate' TIMESERIES"
+                "query": "SELECT latest(sqlserver.batch.sql_recompilation.rate) AS 'Recompilations/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.batch.sql_recompilation.rate' FACET service.instance.id TIMESERIES"
               }
             ]
           }
@@ -595,7 +595,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.recompilation.ratio) AS 'Recompile %' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.recompilation.ratio'"
+                "query": "SELECT latest(sqlserver.recompilation.ratio) AS 'Recompile %' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.recompilation.ratio' FACET service.instance.id"
               }
             ],
             "thresholds": [
@@ -622,7 +622,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.batch.compilation.utilization) AS 'Compilations/Batch' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.batch.compilation.utilization'"
+                "query": "SELECT latest(sqlserver.batch.compilation.utilization) AS 'Compilations/Batch' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.batch.compilation.utilization' FACET service.instance.id"
               }
             ],
             "thresholds": [
@@ -649,7 +649,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.batch.page_split.utilization) AS 'Page Splits/Batch' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.batch.page_split.utilization'"
+                "query": "SELECT latest(sqlserver.batch.page_split.utilization) AS 'Page Splits/Batch' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.batch.page_split.utilization' FACET service.instance.id"
               }
             ]
           }
@@ -670,7 +670,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.parameterization.rate) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.parameterization.rate' FACET `sqlserver.parameterization.result` TIMESERIES"
+                "query": "SELECT latest(sqlserver.parameterization.rate) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.parameterization.rate' FACET service.instance.id, `sqlserver.parameterization.result` TIMESERIES"
               }
             ]
           }
@@ -691,7 +691,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.database.full_scan.rate) AS 'Full Scans/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.database.full_scan.rate' TIMESERIES"
+                "query": "SELECT latest(sqlserver.database.full_scan.rate) AS 'Full Scans/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.database.full_scan.rate' FACET service.instance.id TIMESERIES"
               }
             ]
           }
@@ -712,7 +712,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.index.search.rate) AS 'Index Searches/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.index.search.rate' TIMESERIES"
+                "query": "SELECT latest(sqlserver.index.search.rate) AS 'Index Searches/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.index.search.rate' FACET service.instance.id TIMESERIES"
               }
             ]
           }
@@ -755,7 +755,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.os.memory.utilization) * 100 AS 'Mem Util %' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.os.memory.utilization'"
+                "query": "SELECT latest(sqlserver.os.memory.utilization) * 100 AS 'Mem Util %' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.os.memory.utilization' FACET service.instance.id"
               }
             ],
             "thresholds": [
@@ -786,7 +786,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.os.disk.size) / 1073741824 AS 'Disk (GB)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.os.disk.size'"
+                "query": "SELECT latest(sqlserver.os.disk.size) / 1073741824 AS 'Disk (GB)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.os.disk.size' FACET service.instance.id"
               }
             ]
           }
@@ -807,7 +807,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.memory.grants.pending.count) AS 'Pending' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.memory.grants.pending.count'"
+                "query": "SELECT latest(sqlserver.memory.grants.pending.count) AS 'Pending' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.memory.grants.pending.count' FACET service.instance.id"
               }
             ],
             "thresholds": [
@@ -838,7 +838,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.memory.area) / 1048576 AS 'MB' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.memory.area' FACET `memory.pool`"
+                "query": "SELECT latest(sqlserver.memory.area) / 1048576 AS 'MB' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.memory.area' FACET service.instance.id, `memory.pool`"
               }
             ]
           }
@@ -859,7 +859,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.memory.page.count) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.memory.page.count' FACET `page.pool`"
+                "query": "SELECT latest(sqlserver.memory.page.count) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.memory.page.count' FACET service.instance.id, `page.pool`"
               }
             ]
           }
@@ -880,7 +880,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.os.memory.usage) / 1073741824 AS 'GB' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.os.memory.usage' FACET `memory.state`"
+                "query": "SELECT latest(sqlserver.os.memory.usage) / 1073741824 AS 'GB' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.os.memory.usage' FACET service.instance.id, `memory.state`"
               }
             ]
           }
@@ -901,7 +901,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.memory.cache.object.count) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.memory.cache.object.count' FACET `cache.state`"
+                "query": "SELECT latest(sqlserver.memory.cache.object.count) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.memory.cache.object.count' FACET service.instance.id, `cache.state`"
               }
             ]
           }
@@ -944,7 +944,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.database.file.size) / 1048576 AS 'MB' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.database.file.size' FACET `db.namespace`, `file_type` LIMIT 20"
+                "query": "SELECT latest(sqlserver.database.file.size) / 1048576 AS 'MB' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.database.file.size' FACET service.instance.id, `db.namespace`, `file_type` LIMIT 20"
               }
             ]
           }
@@ -965,7 +965,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.database.page_file.size) / 1048576 AS 'MB' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.database.page_file.size' FACET `db.namespace`, `page_file.state` LIMIT 20"
+                "query": "SELECT latest(sqlserver.database.page_file.size) / 1048576 AS 'MB' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.database.page_file.size' FACET service.instance.id, `db.namespace`, `page_file.state` LIMIT 20"
               }
             ]
           }
@@ -986,7 +986,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.database.io) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.database.io' FACET `direction`, `file_type` TIMESERIES"
+                "query": "SELECT latest(sqlserver.database.io) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.database.io' FACET service.instance.id, `direction`, `file_type` TIMESERIES"
               }
             ]
           }
@@ -1007,7 +1007,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.database.latency) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.database.latency' FACET `direction`, `file_type` TIMESERIES"
+                "query": "SELECT latest(sqlserver.database.latency) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.database.latency' FACET service.instance.id, `direction`, `file_type` TIMESERIES"
               }
             ]
           }
@@ -1050,7 +1050,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT max(sqlserver.os.wait.duration) AS 'Wait (s)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.os.wait.duration' FACET `wait.category` LIMIT 15"
+                "query": "SELECT max(sqlserver.os.wait.duration) AS 'Wait (s)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.os.wait.duration' FACET service.instance.id, `wait.category` LIMIT 15"
               }
             ]
           }
@@ -1071,7 +1071,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT max(sqlserver.os.wait.tasks.count) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.os.wait.tasks.count' FACET `wait.category` LIMIT 15"
+                "query": "SELECT max(sqlserver.os.wait.tasks.count) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.os.wait.tasks.count' FACET service.instance.id, `wait.category` LIMIT 15"
               }
             ]
           }
@@ -1092,7 +1092,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.os.wait.duration) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.os.wait.duration' FACET `wait.category` TIMESERIES LIMIT 5"
+                "query": "SELECT latest(sqlserver.os.wait.duration) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.os.wait.duration' FACET service.instance.id, `wait.category` TIMESERIES LIMIT 5"
               }
             ]
           }
@@ -1135,7 +1135,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.lock.wait.rate) AS 'Lock Waits/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.lock.wait.rate' TIMESERIES"
+                "query": "SELECT latest(sqlserver.lock.wait.rate) AS 'Lock Waits/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.lock.wait.rate' FACET service.instance.id TIMESERIES"
               }
             ]
           }
@@ -1156,7 +1156,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.lock.timeout.rate) AS 'Timeouts/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.lock.timeout.rate' TIMESERIES"
+                "query": "SELECT latest(sqlserver.lock.timeout.rate) AS 'Timeouts/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.lock.timeout.rate' FACET service.instance.id TIMESERIES"
               }
             ]
           }
@@ -1177,7 +1177,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.lock.wait.count) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.lock.wait.count' FACET `workload_group.name` TIMESERIES LIMIT MAX"
+                "query": "SELECT latest(sqlserver.lock.wait.count) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.lock.wait.count' FACET service.instance.id, `workload_group.name` TIMESERIES LIMIT MAX"
               }
             ]
           }
@@ -1220,7 +1220,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.database.transactions.active) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.database.transactions.active' FACET `db.namespace` LIMIT MAX"
+                "query": "SELECT latest(sqlserver.database.transactions.active) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.database.transactions.active' FACET service.instance.id, `db.namespace` LIMIT MAX"
               }
             ]
           }
@@ -1241,7 +1241,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.transaction.longest_running_time) AS 'Longest (s)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.transaction.longest_running_time' TIMESERIES"
+                "query": "SELECT latest(sqlserver.transaction.longest_running_time) AS 'Longest (s)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.transaction.longest_running_time' FACET service.instance.id TIMESERIES"
               }
             ],
             "thresholds": [
@@ -1272,7 +1272,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.transaction.delay) AS 'Delay (ms)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.transaction.delay' TIMESERIES"
+                "query": "SELECT latest(sqlserver.transaction.delay) AS 'Delay (ms)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.transaction.delay' FACET service.instance.id TIMESERIES"
               }
             ]
           }
@@ -1293,7 +1293,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.transaction.version_cleanup.rate) AS 'Cleanup', latest(sqlserver.transaction.version_generation.rate) AS 'Generation' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName IN ('sqlserver.transaction.version_cleanup.rate', 'sqlserver.transaction.version_generation.rate') TIMESERIES"
+                "query": "SELECT latest(sqlserver.transaction.version_cleanup.rate) AS 'Cleanup', latest(sqlserver.transaction.version_generation.rate) AS 'Generation' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName IN ('sqlserver.transaction.version_cleanup.rate', 'sqlserver.transaction.version_generation.rate') FACET service.instance.id TIMESERIES"
               }
             ]
           }
@@ -1336,7 +1336,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.latch.wait.rate) AS 'Latch Waits/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.latch.wait.rate' TIMESERIES"
+                "query": "SELECT latest(sqlserver.latch.wait.rate) AS 'Latch Waits/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.latch.wait.rate' FACET service.instance.id TIMESERIES"
               }
             ]
           }
@@ -1357,7 +1357,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.latch.wait_time.avg) AS 'Avg (s)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.latch.wait_time.avg' TIMESERIES"
+                "query": "SELECT latest(sqlserver.latch.wait_time.avg) AS 'Avg (s)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.latch.wait_time.avg' FACET service.instance.id TIMESERIES"
               }
             ]
           }
@@ -1378,7 +1378,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.latch.wait_time.total) AS 'Total (s)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.latch.wait_time.total' TIMESERIES"
+                "query": "SELECT latest(sqlserver.latch.wait_time.total) AS 'Total (s)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.latch.wait_time.total' FACET service.instance.id TIMESERIES"
               }
             ]
           }
@@ -1399,7 +1399,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.latch.superlatch.count) AS 'Active Superlatches' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.latch.superlatch.count'"
+                "query": "SELECT latest(sqlserver.latch.superlatch.count) AS 'Active Superlatches' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.latch.superlatch.count' FACET service.instance.id"
               }
             ]
           }
@@ -1420,7 +1420,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.latch.superlatch.transition.rate) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.latch.superlatch.transition.rate' FACET `transition.direction` TIMESERIES"
+                "query": "SELECT latest(sqlserver.latch.superlatch.transition.rate) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.latch.superlatch.transition.rate' FACET service.instance.id, `transition.direction` TIMESERIES"
               }
             ]
           }
@@ -1463,7 +1463,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.thread_pool.workers.count) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.thread_pool.workers.count' FACET `worker.state` TIMESERIES"
+                "query": "SELECT latest(sqlserver.thread_pool.workers.count) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.thread_pool.workers.count' FACET service.instance.id, `worker.state` TIMESERIES"
               }
             ]
           }
@@ -1484,7 +1484,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.thread_pool.workers.utilization) * 100 AS 'Util %' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.thread_pool.workers.utilization'"
+                "query": "SELECT latest(sqlserver.thread_pool.workers.utilization) * 100 AS 'Util %' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.thread_pool.workers.utilization' FACET service.instance.id"
               }
             ],
             "thresholds": [
@@ -1515,7 +1515,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.thread_pool.tasks.count) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.thread_pool.tasks.count' FACET `task.state` TIMESERIES"
+                "query": "SELECT latest(sqlserver.thread_pool.tasks.count) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.thread_pool.tasks.count' FACET service.instance.id, `task.state` TIMESERIES"
               }
             ]
           }
@@ -1536,7 +1536,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.tempdb.space.usage) / 1048576 AS 'MB' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.tempdb.space.usage' FACET `tempdb.space_kind`"
+                "query": "SELECT latest(sqlserver.tempdb.space.usage) / 1048576 AS 'MB' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.tempdb.space.usage' FACET service.instance.id, `tempdb.space_kind`"
               }
             ]
           }
@@ -1557,7 +1557,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.tempdb.file.size) / 1048576 AS 'MB' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.tempdb.file.size' FACET `file_type`, `tempdb.file.id` LIMIT MAX"
+                "query": "SELECT latest(sqlserver.tempdb.file.size) / 1048576 AS 'MB' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.tempdb.file.size' FACET service.instance.id, `file_type`, `tempdb.file.id` LIMIT MAX"
               }
             ]
           }
@@ -1578,7 +1578,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.tempdb.contention.waiters.count) AS 'Contention Waiters', latest(sqlserver.tempdb.data_files.count) AS 'Data Files' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName IN ('sqlserver.tempdb.contention.waiters.count', 'sqlserver.tempdb.data_files.count')"
+                "query": "SELECT latest(sqlserver.tempdb.contention.waiters.count) AS 'Contention Waiters', latest(sqlserver.tempdb.data_files.count) AS 'Data Files' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName IN ('sqlserver.tempdb.contention.waiters.count', 'sqlserver.tempdb.data_files.count') FACET service.instance.id"
               }
             ]
           }
@@ -1599,7 +1599,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.tempdb.allocation.wait_time.total) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.tempdb.allocation.wait_time.total' FACET `allocation.page_type`"
+                "query": "SELECT latest(sqlserver.tempdb.allocation.wait_time.total) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.tempdb.allocation.wait_time.total' FACET service.instance.id, `allocation.page_type`"
               }
             ]
           }
@@ -1642,7 +1642,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.failover_cluster.replica.flow_control_time) AS 'Flow Control (ms)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.failover_cluster.replica.flow_control_time' TIMESERIES"
+                "query": "SELECT latest(sqlserver.failover_cluster.replica.flow_control_time) AS 'Flow Control (ms)' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.failover_cluster.replica.flow_control_time' FACET service.instance.id TIMESERIES"
               }
             ]
           }
@@ -1663,7 +1663,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.replica.data.rate) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.replica.data.rate' FACET `replica.direction` TIMESERIES"
+                "query": "SELECT latest(sqlserver.replica.data.rate) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.replica.data.rate' FACET service.instance.id, `replica.direction` TIMESERIES"
               }
             ]
           }
@@ -1684,7 +1684,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.failover_cluster.replica.database.queue_size) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.failover_cluster.replica.database.queue_size' FACET `replica.queue_kind` TIMESERIES"
+                "query": "SELECT latest(sqlserver.failover_cluster.replica.database.queue_size) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.failover_cluster.replica.database.queue_size' FACET service.instance.id, `replica.queue_kind` TIMESERIES"
               }
             ]
           }
@@ -1705,7 +1705,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.failover_cluster.replica.database.redo.rate) AS 'Redo Rate' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.failover_cluster.replica.database.redo.rate' TIMESERIES"
+                "query": "SELECT latest(sqlserver.failover_cluster.replica.database.redo.rate) AS 'Redo Rate' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.failover_cluster.replica.database.redo.rate' FACET service.instance.id TIMESERIES"
               }
             ]
           }
@@ -1764,7 +1764,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.resource_pool.disk.operations) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.resource_pool.disk.operations' FACET `direction` TIMESERIES"
+                "query": "SELECT latest(sqlserver.resource_pool.disk.operations) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.resource_pool.disk.operations' FACET service.instance.id, `direction` TIMESERIES"
               }
             ]
           }
@@ -1785,7 +1785,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.resource_pool.disk.throttled.read.rate) AS 'Read Throttled/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.resource_pool.disk.throttled.read.rate' TIMESERIES"
+                "query": "SELECT latest(sqlserver.resource_pool.disk.throttled.read.rate) AS 'Read Throttled/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.resource_pool.disk.throttled.read.rate' FACET service.instance.id TIMESERIES"
               }
             ]
           }
@@ -1806,7 +1806,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.resource_pool.disk.throttled.write.rate) AS 'Write Throttled/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.resource_pool.disk.throttled.write.rate' TIMESERIES"
+                "query": "SELECT latest(sqlserver.resource_pool.disk.throttled.write.rate) AS 'Write Throttled/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.resource_pool.disk.throttled.write.rate' FACET service.instance.id TIMESERIES"
               }
             ]
           }
@@ -1827,7 +1827,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.login.rate) AS 'Logins/sec', latest(sqlserver.logout.rate) AS 'Logouts/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName IN ('sqlserver.login.rate', 'sqlserver.logout.rate') TIMESERIES"
+                "query": "SELECT latest(sqlserver.login.rate) AS 'Logins/sec', latest(sqlserver.logout.rate) AS 'Logouts/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName IN ('sqlserver.login.rate', 'sqlserver.logout.rate') FACET service.instance.id TIMESERIES"
               }
             ]
           }
@@ -1848,7 +1848,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.attention.rate) AS 'Attentions/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.attention.rate' TIMESERIES"
+                "query": "SELECT latest(sqlserver.attention.rate) AS 'Attentions/sec' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.attention.rate' FACET service.instance.id TIMESERIES"
               }
             ]
           }

--- a/dashboards/mssql-otel/mssql-otel.json
+++ b/dashboards/mssql-otel/mssql-otel.json
@@ -265,7 +265,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT sum(sqlserver.execution_count) FROM Log WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' FACET db.namespace TIMESERIES"
+                "query": "SELECT sum(sqlserver.execution_count) FROM Log WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' FACET db.namespace TIMESERIES LIMIT MAX"
               }
             ]
           }
@@ -286,7 +286,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT sum(sqlserver.total_worker_time)/sum(sqlserver.execution_count) AS 'Avg CPU (s)' FROM Log WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' FACET db.namespace TIMESERIES"
+                "query": "SELECT sum(sqlserver.total_worker_time)/sum(sqlserver.execution_count) AS 'Avg CPU (s)' FROM Log WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' FACET db.namespace TIMESERIES LIMIT MAX"
               }
             ]
           }
@@ -356,7 +356,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Log SELECT latest(sqlserver.wait_time) AS 'Wait (s)' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' AND sqlserver.wait_type != '' FACET sqlserver.wait_type TIMESERIES AUTO"
+                "query": "FROM Log SELECT latest(sqlserver.wait_time) AS 'Wait (s)' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' AND sqlserver.wait_type != '' FACET sqlserver.wait_type TIMESERIES AUTO LIMIT MAX"
               }
             ]
           }
@@ -419,7 +419,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Log SELECT uniqueCount(sqlserver.session_id) WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' AND sqlserver.session_status = 'running' FACET db.namespace"
+                "query": "FROM Log SELECT uniqueCount(sqlserver.session_id) WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' AND sqlserver.session_status = 'running' FACET db.namespace LIMIT MAX"
               }
             ]
           }
@@ -1177,7 +1177,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.lock.wait.count) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.lock.wait.count' FACET `workload_group.name` TIMESERIES"
+                "query": "SELECT latest(sqlserver.lock.wait.count) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.lock.wait.count' FACET `workload_group.name` TIMESERIES LIMIT MAX"
               }
             ]
           }
@@ -1220,7 +1220,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.database.transactions.active) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.database.transactions.active' FACET `db.namespace`"
+                "query": "SELECT latest(sqlserver.database.transactions.active) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.database.transactions.active' FACET `db.namespace` LIMIT MAX"
               }
             ]
           }
@@ -1557,7 +1557,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.tempdb.file.size) / 1048576 AS 'MB' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.tempdb.file.size' FACET `file_type`, `tempdb.file.id`"
+                "query": "SELECT latest(sqlserver.tempdb.file.size) / 1048576 AS 'MB' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.tempdb.file.size' FACET `file_type`, `tempdb.file.id` LIMIT MAX"
               }
             ]
           }

--- a/dashboards/mssql-otel/mssql-otel.json
+++ b/dashboards/mssql-otel/mssql-otel.json
@@ -241,7 +241,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Log SELECT latest(service.instance.id) AS 'Instance', latest(service.instance.id) AS 'Instance', latest(db.query.full_text) AS 'Query', latest(sqlserver.query_hash) AS 'query_hash', latest(db.namespace) AS 'Database', sum(sqlserver.execution_count) AS 'Executions', sum(sqlserver.total_elapsed_time)/sum(sqlserver.execution_count) AS 'Avg Duration (s)', sum(sqlserver.total_worker_time)/sum(sqlserver.execution_count) AS 'Avg CPU (s)', sum(sqlserver.total_logical_reads) AS 'Logical Reads' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' FACET sqlserver.query_hash LIMIT MAX"
+                "query": "FROM Log SELECT latest(db.query.full_text) AS 'Query', latest(sqlserver.query_hash) AS 'query_hash', latest(db.namespace) AS 'Database', sum(sqlserver.execution_count) AS 'Executions', sum(sqlserver.total_elapsed_time)/sum(sqlserver.execution_count) AS 'Avg Duration (s)', sum(sqlserver.total_worker_time)/sum(sqlserver.execution_count) AS 'Avg CPU (s)', sum(sqlserver.total_logical_reads) AS 'Logical Reads' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' FACET service.instance.id, sqlserver.query_hash LIMIT MAX"
               }
             ],
             "platformOptions": {
@@ -332,7 +332,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Log SELECT latest(service.instance.id) AS 'Instance', latest(service.instance.id) AS 'Instance', latest(sqlserver.query_start) AS 'Start Time', latest(sqlserver.query_hash) AS 'query_hash',  latest(db.namespace) AS 'Database', latest(sqlserver.total_elapsed_time) AS 'Duration (s)', latest(db.query.full_text) AS 'Query', latest(user.name) AS 'User', latest(client.address) AS 'Host', latest(sqlserver.wait_type) AS 'Wait Type', latest(sqlserver.wait_time) AS 'Wait (s)', latest(sqlserver.blocking_session_id) AS 'Blocked By'  WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' FACET sqlserver.query_start, sqlserver.session_id LIMIT MAX"
+                "query": "FROM Log SELECT latest(sqlserver.query_start) AS 'Start Time', latest(sqlserver.query_hash) AS 'query_hash',  latest(db.namespace) AS 'Database', latest(sqlserver.total_elapsed_time) AS 'Duration (s)', latest(db.query.full_text) AS 'Query', latest(user.name) AS 'User', latest(client.address) AS 'Host', latest(sqlserver.wait_type) AS 'Wait Type', latest(sqlserver.wait_time) AS 'Wait (s)', latest(sqlserver.blocking_session_id) AS 'Blocked By'  WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' FACET service.instance.id, sqlserver.query_start, sqlserver.session_id LIMIT MAX"
               }
             ],
             "platformOptions": {
@@ -398,7 +398,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Log SELECT latest(service.instance.id) AS 'Instance', latest(service.instance.id) AS 'Instance', latest(sqlserver.wait_type) AS 'Wait Type', latest(sqlserver.wait_resource) AS 'Wait Resource', latest(user.name) AS 'User', latest(sqlserver.blocking_session_id) AS 'Blocked By', latest(sqlserver.wait_time) AS 'Wait (s)', latest(sqlserver.open_transaction_count) AS 'Open Txns', latest(sqlserver.query_hash) AS 'query_hash', latest(sqlserver.query_start) AS 'Start Time', latest(db.query.full_text) AS 'Query' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' AND sqlserver.wait_time > 0 FACET sqlserver.session_id, sqlserver.blocking_session_id LIMIT MAX"
+                "query": "FROM Log SELECT latest(sqlserver.wait_type) AS 'Wait Type', latest(sqlserver.wait_resource) AS 'Wait Resource', latest(user.name) AS 'User', latest(sqlserver.blocking_session_id) AS 'Blocked By', latest(sqlserver.wait_time) AS 'Wait (s)', latest(sqlserver.open_transaction_count) AS 'Open Txns', latest(sqlserver.query_hash) AS 'query_hash', latest(sqlserver.query_start) AS 'Start Time', latest(db.query.full_text) AS 'Query' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' AND sqlserver.wait_time > 0 FACET service.instance.id, sqlserver.session_id, sqlserver.blocking_session_id LIMIT MAX"
               }
             ]
           }
@@ -486,7 +486,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Log SELECT latest(service.instance.id) AS 'Instance', latest(service.instance.id) AS 'Instance', latest(sqlserver.query_hash) AS 'query_hash', latest(sqlserver.query_plan_hash) AS 'plan_hash', latest(sqlserver.query_plan) AS 'Execution Plan XML' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' AND sqlserver.query_plan != '' FACET  sqlserver.query_plan_hash LIMIT 20"
+                "query": "FROM Log SELECT latest(sqlserver.query_hash) AS 'query_hash', latest(sqlserver.query_plan_hash) AS 'plan_hash', latest(sqlserver.query_plan) AS 'Execution Plan XML' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' AND sqlserver.query_plan != '' FACET  service.instance.id, sqlserver.query_plan_hash LIMIT 20"
               }
             ],
             "platformOptions": {
@@ -510,7 +510,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Log SELECT latest(service.instance.id) AS 'Instance', latest(service.instance.id) AS 'Instance', uniqueCount(sqlserver.query_plan_hash) AS 'Plan Count', latest(db.query.full_text) AS 'Query', latest(db.namespace) AS 'Database' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' AND sqlserver.query_plan IS NOT NULL FACET sqlserver.query_hash LIMIT 20"
+                "query": "FROM Log SELECT uniqueCount(sqlserver.query_plan_hash) AS 'Plan Count', latest(db.query.full_text) AS 'Query', latest(db.namespace) AS 'Database' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' AND sqlserver.query_plan IS NOT NULL FACET service.instance.id, sqlserver.query_hash LIMIT 20"
               }
             ]
           }


### PR DESCRIPTION
Update mssql-otel dashboard: fixes, metric cleanup, and OTel alignment
- Switch filtering from entity.guid to service.instance.id
- Remove deprecated/duplicate metrics and Security & Principals page which are removed as part of https://github.com/newrelic-forks/opentelemetry-collector-contrib/pull/245
- Fix layout gaps in Memory & Buffer and Locks pages
- Remove all hardcoded SINCE clauses to respect dashboard time picker
- Add LIMIT MAX to Slow Queries and Active Queries tables
- Standardize accountIds to [] across all widget queries
- Fix stale descriptions referencing entity variable and kill_connection errors
- Add facet service.instance.id filter to all NRQL's to support multi entities

imported dashboard link:- https://staging.onenr.io/07jbMLKL3Ry

<!-- DON'T DELETE THIS SECTION BELOW IF SUBMITTING A NEW QUICKSTART -->

## Pre merge checklist

<!-- THIS CHECKLIST MUST BE FULLY COMPLETE OR YOUR PR WILL NOT BE MERGED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you include a Data source and Documentation reference?
- [ ] Are all documentation links publicly accessible?
- [ ] Did you check your descriptive content for [voice and tone](https://docs.newrelic.com/docs/style-guide/writing-strategies/voice-strategies-docs-sound-new-relic/)?
- [ ] Did you check your descriptive content for spelling and grammar errors?
- [ ] Did you review your content with a subject matter expert? (e.g. a Browser agent quickstart is reviewed with a member of the Browser Agent team)

### Dashboards

- [ ] Does the PR contain a screenshot for each of your dashboards?
- [ ] Do your screenshots show data?
- [ ] Has the [sanitization script](https://github.com/newrelic/newrelic-quickstarts/blob/main/CONTRIBUTING.md#dashboards) been run on each dashboard?

### Alerts

- [ ] Did you check that your alerts actually work?
- [ ] Are you trying to create standalone alerts? Standalone alerts are deprecated. They should only be included in quickstarts.
