### PR TITLE
fix: normalize YAML block scalar style in linkerd-otel alert policies

### DIFF
--- a/alert-policies/linkerd-otel/ExcessTCPConnections.yml
+++ b/alert-policies/linkerd-otel/ExcessTCPConnections.yml
@@ -2,7 +2,7 @@
 name: Linkerd Excess TCP Connections
 
 # Description and details
-description: |+
+description: |
   This alert is triggered when the total number of open TCP connections across all meshed pods
   exceeds 1000 for 5 minutes, which may indicate a connection leak or traffic surge.
 

--- a/alert-policies/linkerd-otel/HighErrorRate.yml
+++ b/alert-policies/linkerd-otel/HighErrorRate.yml
@@ -2,7 +2,7 @@
 name: Linkerd High HTTP Error Rate
 
 # Description and details
-description: |+
+description: |
   This alert is triggered when the inbound HTTP 5xx error rate exceeds 5% for 5 minutes,
   indicating service errors being observed by the Linkerd proxy.
 

--- a/alert-policies/linkerd-otel/HighInboundLatency.yml
+++ b/alert-policies/linkerd-otel/HighInboundLatency.yml
@@ -2,7 +2,7 @@
 name: Linkerd High Inbound Request Latency
 
 # Description and details
-description: |+
+description: |
   This alert is triggered when the p99 inbound HTTP request latency exceeds 500ms for 5 minutes,
   indicating a slow or overloaded service behind the Linkerd proxy.
 


### PR DESCRIPTION
Minor cleanup: normalizes `description: |+` to `description: |` in the three Linkerd OTel alert policy files. The `|+` keep-chomping indicator is non-standard here since no trailing newlines are intentionally preserved.