### PR TITLE
Update otel dashboards

### DIFF
--- a/dashboards/mssql-otel/mssql-otel.json
+++ b/dashboards/mssql-otel/mssql-otel.json
@@ -241,7 +241,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Log SELECT latest(db.query.full_text) AS 'Query', latest(sqlserver.query_hash) AS 'query_hash', latest(db.namespace) AS 'Database', sum(sqlserver.execution_count) AS 'Executions', sum(sqlserver.total_elapsed_time)/sum(sqlserver.execution_count) AS 'Avg Duration (s)', sum(sqlserver.total_worker_time)/sum(sqlserver.execution_count) AS 'Avg CPU (s)', sum(sqlserver.total_logical_reads) AS 'Logical Reads' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' FACET service.instance.id, sqlserver.query_hash LIMIT MAX"
+                "query": "FROM Log SELECT latest(db.query.full_text) AS 'Query', latest(sqlserver.query_hash) AS 'query_hash', latest(db.namespace) AS 'Database', sum(sqlserver.execution_count) AS 'Executions', sum(sqlserver.total_elapsed_time)/sum(sqlserver.execution_count) AS 'Avg Duration (s)', sum(sqlserver.total_worker_time)/sum(sqlserver.execution_count) AS 'Avg CPU (s)', sum(sqlserver.total_logical_reads) AS 'Logical Reads' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' FACET service.instance.id, sqlserver.query_hash  "
               }
             ],
             "platformOptions": {
@@ -265,7 +265,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT sum(sqlserver.execution_count) FROM Log WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' FACET service.instance.id, db.namespace TIMESERIES LIMIT MAX"
+                "query": "SELECT sum(sqlserver.execution_count) FROM Log WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' FACET service.instance.id, db.namespace TIMESERIES"
               }
             ]
           }
@@ -286,7 +286,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT sum(sqlserver.total_worker_time)/sum(sqlserver.execution_count) AS 'Avg CPU (s)' FROM Log WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' FACET service.instance.id, db.namespace TIMESERIES LIMIT MAX"
+                "query": "SELECT sum(sqlserver.total_worker_time)/sum(sqlserver.execution_count) AS 'Avg CPU (s)' FROM Log WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.top_query' FACET service.instance.id, db.namespace TIMESERIES"
               }
             ]
           }
@@ -332,7 +332,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Log SELECT latest(sqlserver.query_start) AS 'Start Time', latest(sqlserver.query_hash) AS 'query_hash',  latest(db.namespace) AS 'Database', latest(sqlserver.total_elapsed_time) AS 'Duration (s)', latest(db.query.full_text) AS 'Query', latest(user.name) AS 'User', latest(client.address) AS 'Host', latest(sqlserver.wait_type) AS 'Wait Type', latest(sqlserver.wait_time) AS 'Wait (s)', latest(sqlserver.blocking_session_id) AS 'Blocked By'  WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' FACET service.instance.id, sqlserver.query_start, sqlserver.session_id LIMIT MAX"
+                "query": "FROM Log SELECT latest(sqlserver.query_start) AS 'Start Time', latest(sqlserver.query_hash) AS 'query_hash',  latest(db.namespace) AS 'Database', latest(sqlserver.total_elapsed_time) AS 'Duration (s)', latest(db.query.full_text) AS 'Query', latest(user.name) AS 'User', latest(client.address) AS 'Host', latest(sqlserver.wait_type) AS 'Wait Type', latest(sqlserver.wait_time) AS 'Wait (s)', latest(sqlserver.blocking_session_id) AS 'Blocked By'  WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' FACET service.instance.id, sqlserver.query_start, sqlserver.session_id"
               }
             ],
             "platformOptions": {
@@ -356,7 +356,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Log SELECT latest(sqlserver.wait_time) AS 'Wait (s)' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' AND sqlserver.wait_type != '' FACET service.instance.id, sqlserver.wait_type TIMESERIES AUTO LIMIT MAX"
+                "query": "FROM Log SELECT latest(sqlserver.wait_time) AS 'Wait (s)' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' AND sqlserver.wait_type != '' FACET service.instance.id, sqlserver.wait_type TIMESERIES AUTO"
               }
             ]
           }
@@ -398,7 +398,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Log SELECT latest(sqlserver.wait_type) AS 'Wait Type', latest(sqlserver.wait_resource) AS 'Wait Resource', latest(user.name) AS 'User', latest(sqlserver.blocking_session_id) AS 'Blocked By', latest(sqlserver.wait_time) AS 'Wait (s)', latest(sqlserver.open_transaction_count) AS 'Open Txns', latest(sqlserver.query_hash) AS 'query_hash', latest(sqlserver.query_start) AS 'Start Time', latest(db.query.full_text) AS 'Query' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' AND sqlserver.wait_time > 0 FACET service.instance.id, sqlserver.session_id, sqlserver.blocking_session_id LIMIT MAX"
+                "query": "FROM Log SELECT latest(sqlserver.wait_type) AS 'Wait Type', latest(sqlserver.wait_resource) AS 'Wait Resource', latest(user.name) AS 'User', latest(sqlserver.blocking_session_id) AS 'Blocked By', latest(sqlserver.wait_time) AS 'Wait (s)', latest(sqlserver.open_transaction_count) AS 'Open Txns', latest(sqlserver.query_hash) AS 'query_hash', latest(sqlserver.query_start) AS 'Start Time', latest(db.query.full_text) AS 'Query' WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' AND sqlserver.wait_time > 0 FACET service.instance.id, sqlserver.session_id, sqlserver.blocking_session_id  "
               }
             ]
           }
@@ -419,7 +419,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Log SELECT uniqueCount(sqlserver.session_id) WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' AND sqlserver.session_status = 'running' FACET service.instance.id, db.namespace LIMIT MAX"
+                "query": "FROM Log SELECT uniqueCount(sqlserver.session_id) WHERE service.instance.id IN ({{instance}}) AND event.name = 'db.server.query_sample' AND sqlserver.session_status = 'running' FACET service.instance.id, db.namespace  "
               }
             ]
           }
@@ -1177,7 +1177,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.lock.wait.count) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.lock.wait.count' FACET service.instance.id, `workload_group.name` TIMESERIES LIMIT MAX"
+                "query": "SELECT latest(sqlserver.lock.wait.count) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.lock.wait.count' FACET service.instance.id, `workload_group.name` TIMESERIES  "
               }
             ]
           }
@@ -1220,7 +1220,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.database.transactions.active) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.database.transactions.active' FACET service.instance.id, `db.namespace` LIMIT MAX"
+                "query": "SELECT latest(sqlserver.database.transactions.active) FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.database.transactions.active' FACET service.instance.id, `db.namespace`  "
               }
             ]
           }
@@ -1557,7 +1557,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "SELECT latest(sqlserver.tempdb.file.size) / 1048576 AS 'MB' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.tempdb.file.size' FACET service.instance.id, `file_type`, `tempdb.file.id` LIMIT MAX"
+                "query": "SELECT latest(sqlserver.tempdb.file.size) / 1048576 AS 'MB' FROM Metric WHERE service.instance.id IN ({{instance}}) AND metricName = 'sqlserver.tempdb.file.size' FACET service.instance.id, `file_type`, `tempdb.file.id`  "
               }
             ]
           }

--- a/dashboards/oracle-otel/oracle-otel.json
+++ b/dashboards/oracle-otel/oracle-otel.json
@@ -23,7 +23,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.cpu_time`), 1 SECOND) WHERE metricName = 'oracledb.cpu_time' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.cpu_time`), 1 SECOND) WHERE metricName = 'oracledb.cpu_time' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -48,7 +48,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT average(`oracledb.database.cpu.utilization`) WHERE metricName = 'oracledb.database.cpu.utilization' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT average(`oracledb.database.cpu.utilization`) WHERE metricName = 'oracledb.database.cpu.utilization' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -73,7 +73,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT average(`oracledb.host.cpu.utilization`) WHERE metricName = 'oracledb.host.cpu.utilization' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT average(`oracledb.host.cpu.utilization`) WHERE metricName = 'oracledb.host.cpu.utilization' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -98,7 +98,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT average(`oracledb.system.cpu.load`) WHERE metricName = 'oracledb.system.cpu.load' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} TIMESERIES"
+                "query": "FROM Metric SELECT average(`oracledb.system.cpu.load`) WHERE metricName = 'oracledb.system.cpu.load' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -129,7 +129,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.executions`), 1 SECOND) WHERE metricName = 'oracledb.executions' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.executions`), 1 SECOND) WHERE metricName = 'oracledb.executions' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -154,7 +154,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT average(`oracledb.execution.utilization`) WHERE metricName = 'oracledb.execution.utilization' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT average(`oracledb.execution.utilization`) WHERE metricName = 'oracledb.execution.utilization' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -179,7 +179,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.parse_calls`), 1 SECOND) WHERE metricName = 'oracledb.parse_calls' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.parse_calls`), 1 SECOND) WHERE metricName = 'oracledb.parse_calls' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -204,7 +204,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT average(`oracledb.parse.rate`) WHERE metricName = 'oracledb.parse.rate' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb, oracledb.parse.result TIMESERIES"
+                "query": "FROM Metric SELECT average(`oracledb.parse.rate`) WHERE metricName = 'oracledb.parse.rate' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb, oracledb.parse.result TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -229,7 +229,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT average(`oracledb.parse.utilization`) WHERE metricName = 'oracledb.parse.utilization' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT average(`oracledb.parse.utilization`) WHERE metricName = 'oracledb.parse.utilization' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -254,7 +254,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.hard_parses`), 1 SECOND) WHERE metricName = 'oracledb.hard_parses' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.hard_parses`), 1 SECOND) WHERE metricName = 'oracledb.hard_parses' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -285,7 +285,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.logical_reads`), 1 SECOND) WHERE metricName = 'oracledb.logical_reads' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.logical_reads`), 1 SECOND) WHERE metricName = 'oracledb.logical_reads' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -310,7 +310,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.physical_reads`), 1 SECOND) WHERE metricName = 'oracledb.physical_reads' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.physical_reads`), 1 SECOND) WHERE metricName = 'oracledb.physical_reads' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -335,7 +335,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.physical_reads_direct`), 1 SECOND) WHERE metricName = 'oracledb.physical_reads_direct' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.physical_reads_direct`), 1 SECOND) WHERE metricName = 'oracledb.physical_reads_direct' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -360,7 +360,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.physical_writes`), 1 SECOND) WHERE metricName = 'oracledb.physical_writes' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.physical_writes`), 1 SECOND) WHERE metricName = 'oracledb.physical_writes' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -385,7 +385,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.physical_writes_direct`), 1 SECOND) WHERE metricName = 'oracledb.physical_writes_direct' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.physical_writes_direct`), 1 SECOND) WHERE metricName = 'oracledb.physical_writes_direct' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -410,7 +410,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.physical_read_io_requests`), 1 SECOND) WHERE metricName = 'oracledb.physical_read_io_requests' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.physical_read_io_requests`), 1 SECOND) WHERE metricName = 'oracledb.physical_read_io_requests' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -435,7 +435,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.physical_write_io_requests`), 1 SECOND) WHERE metricName = 'oracledb.physical_write_io_requests' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.physical_write_io_requests`), 1 SECOND) WHERE metricName = 'oracledb.physical_write_io_requests' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -466,7 +466,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.physical_io.cache_writes`), 1 SECOND) WHERE metricName = 'oracledb.physical_io.cache_writes' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.physical_io.cache_writes`), 1 SECOND) WHERE metricName = 'oracledb.physical_io.cache_writes' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -491,7 +491,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.physical_io.requests`), 1 SECOND) WHERE metricName = 'oracledb.physical_io.requests' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.physical_io.requests`), 1 SECOND) WHERE metricName = 'oracledb.physical_io.requests' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -516,7 +516,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.physical_io.transferred`), 1 SECOND) WHERE metricName = 'oracledb.physical_io.transferred' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.physical_io.transferred`), 1 SECOND) WHERE metricName = 'oracledb.physical_io.transferred' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -547,7 +547,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.sqlnet.io.transferred`), 1 SECOND) WHERE metricName = 'oracledb.sqlnet.io.transferred' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.sqlnet.io.transferred`), 1 SECOND) WHERE metricName = 'oracledb.sqlnet.io.transferred' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -578,7 +578,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.consistent_gets`), 1 SECOND) WHERE metricName = 'oracledb.consistent_gets' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.consistent_gets`), 1 SECOND) WHERE metricName = 'oracledb.consistent_gets' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -603,7 +603,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.db_block_gets`), 1 SECOND) WHERE metricName = 'oracledb.db_block_gets' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.db_block_gets`), 1 SECOND) WHERE metricName = 'oracledb.db_block_gets' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -628,7 +628,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT average(`oracledb.buffer_cache.utilization`) WHERE metricName = 'oracledb.buffer_cache.utilization' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT average(`oracledb.buffer_cache.utilization`) WHERE metricName = 'oracledb.buffer_cache.utilization' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -653,7 +653,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT average(`oracledb.library_cache.utilization`) WHERE metricName = 'oracledb.library_cache.utilization' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT average(`oracledb.library_cache.utilization`) WHERE metricName = 'oracledb.library_cache.utilization' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -678,7 +678,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT average(`oracledb.data_dictionary.hit_ratio`) WHERE metricName = 'oracledb.data_dictionary.hit_ratio' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} TIMESERIES"
+                "query": "FROM Metric SELECT average(`oracledb.data_dictionary.hit_ratio`) WHERE metricName = 'oracledb.data_dictionary.hit_ratio' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -703,7 +703,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT average(`oracledb.shared_pool.utilization`) WHERE metricName = 'oracledb.shared_pool.utilization' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT average(`oracledb.shared_pool.utilization`) WHERE metricName = 'oracledb.shared_pool.utilization' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -734,7 +734,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT average(`oracledb.pga_memory`) WHERE metricName = 'oracledb.pga_memory' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT average(`oracledb.pga_memory`) WHERE metricName = 'oracledb.pga_memory' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -759,7 +759,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT latest(`oracledb.sga.limit`) WHERE metricName = 'oracledb.sga.limit' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}}"
+                "query": "FROM Metric SELECT latest(`oracledb.sga.limit`) WHERE metricName = 'oracledb.sga.limit' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name"
               }
             ],
             "platformOptions": {
@@ -784,7 +784,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT latest(`oracledb.sga.usage`) WHERE metricName = 'oracledb.sga.usage' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracledb.sga.component.name"
+                "query": "FROM Metric SELECT latest(`oracledb.sga.usage`) WHERE metricName = 'oracledb.sga.usage' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracledb.sga.component.name"
               }
             ],
             "platformOptions": {
@@ -815,7 +815,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT average(`oracledb.database.wait.utilization`) WHERE metricName = 'oracledb.database.wait.utilization' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT average(`oracledb.database.wait.utilization`) WHERE metricName = 'oracledb.database.wait.utilization' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -846,7 +846,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT average(`oracledb.enqueue_locks.usage`) WHERE metricName = 'oracledb.enqueue_locks.usage' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} TIMESERIES"
+                "query": "FROM Metric SELECT average(`oracledb.enqueue_locks.usage`) WHERE metricName = 'oracledb.enqueue_locks.usage' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -871,7 +871,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT average(`oracledb.dml_locks.usage`) WHERE metricName = 'oracledb.dml_locks.usage' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} TIMESERIES"
+                "query": "FROM Metric SELECT average(`oracledb.dml_locks.usage`) WHERE metricName = 'oracledb.dml_locks.usage' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -896,7 +896,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT latest(`oracledb.enqueue_locks.limit`) WHERE metricName = 'oracledb.enqueue_locks.limit' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}}"
+                "query": "FROM Metric SELECT latest(`oracledb.enqueue_locks.limit`) WHERE metricName = 'oracledb.enqueue_locks.limit' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name"
               }
             ],
             "platformOptions": {
@@ -921,7 +921,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.enqueue_deadlocks`), 1 SECOND) WHERE metricName = 'oracledb.enqueue_deadlocks' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.enqueue_deadlocks`), 1 SECOND) WHERE metricName = 'oracledb.enqueue_deadlocks' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -946,7 +946,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT latest(`oracledb.enqueue_resources.limit`) WHERE metricName = 'oracledb.enqueue_resources.limit' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}}"
+                "query": "FROM Metric SELECT latest(`oracledb.enqueue_resources.limit`) WHERE metricName = 'oracledb.enqueue_resources.limit' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name"
               }
             ],
             "platformOptions": {
@@ -971,7 +971,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT average(`oracledb.enqueue_resources.usage`) WHERE metricName = 'oracledb.enqueue_resources.usage' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} TIMESERIES"
+                "query": "FROM Metric SELECT average(`oracledb.enqueue_resources.usage`) WHERE metricName = 'oracledb.enqueue_resources.usage' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -996,7 +996,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.exchange_deadlocks`), 1 SECOND) WHERE metricName = 'oracledb.exchange_deadlocks' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.exchange_deadlocks`), 1 SECOND) WHERE metricName = 'oracledb.exchange_deadlocks' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -1021,7 +1021,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT latest(`oracledb.dml_locks.limit`) WHERE metricName = 'oracledb.dml_locks.limit' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}}"
+                "query": "FROM Metric SELECT latest(`oracledb.dml_locks.limit`) WHERE metricName = 'oracledb.dml_locks.limit' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name"
               }
             ],
             "platformOptions": {
@@ -1052,7 +1052,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT latest(`oracledb.processes.limit`) WHERE metricName = 'oracledb.processes.limit' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}}"
+                "query": "FROM Metric SELECT latest(`oracledb.processes.limit`) WHERE metricName = 'oracledb.processes.limit' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name"
               }
             ],
             "platformOptions": {
@@ -1077,7 +1077,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT average(`oracledb.processes.usage`) WHERE metricName = 'oracledb.processes.usage' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} TIMESERIES"
+                "query": "FROM Metric SELECT average(`oracledb.processes.usage`) WHERE metricName = 'oracledb.processes.usage' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -1102,7 +1102,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT latest(`oracledb.sessions.limit`) WHERE metricName = 'oracledb.sessions.limit' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}}"
+                "query": "FROM Metric SELECT latest(`oracledb.sessions.limit`) WHERE metricName = 'oracledb.sessions.limit' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name"
               }
             ],
             "platformOptions": {
@@ -1127,7 +1127,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT sum(`oracledb.sessions.usage`) WHERE metricName = 'oracledb.sessions.usage' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb, session_status TIMESERIES"
+                "query": "FROM Metric SELECT sum(`oracledb.sessions.usage`) WHERE metricName = 'oracledb.sessions.usage' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb, session_status TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -1152,7 +1152,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.logons`), 1 SECOND) WHERE metricName = 'oracledb.logons' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.logons`), 1 SECOND) WHERE metricName = 'oracledb.logons' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -1183,7 +1183,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT latest(`oracledb.transactions.limit`) WHERE metricName = 'oracledb.transactions.limit' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}}"
+                "query": "FROM Metric SELECT latest(`oracledb.transactions.limit`) WHERE metricName = 'oracledb.transactions.limit' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name"
               }
             ],
             "platformOptions": {
@@ -1208,7 +1208,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT average(`oracledb.transactions.usage`) WHERE metricName = 'oracledb.transactions.usage' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} TIMESERIES"
+                "query": "FROM Metric SELECT average(`oracledb.transactions.usage`) WHERE metricName = 'oracledb.transactions.usage' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -1233,7 +1233,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.user_commits`), 1 SECOND) WHERE metricName = 'oracledb.user_commits' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.user_commits`), 1 SECOND) WHERE metricName = 'oracledb.user_commits' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -1258,7 +1258,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.user_rollbacks`), 1 SECOND) WHERE metricName = 'oracledb.user_rollbacks' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.user_rollbacks`), 1 SECOND) WHERE metricName = 'oracledb.user_rollbacks' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -1289,7 +1289,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT latest(`oracledb.tablespace_size.limit`) WHERE metricName = 'oracledb.tablespace_size.limit' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb, tablespace_name"
+                "query": "FROM Metric SELECT latest(`oracledb.tablespace_size.limit`) WHERE metricName = 'oracledb.tablespace_size.limit' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb, tablespace_name"
               }
             ],
             "platformOptions": {
@@ -1314,7 +1314,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT latest(`oracledb.tablespace_size.usage`) WHERE metricName = 'oracledb.tablespace_size.usage' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb, tablespace_name"
+                "query": "FROM Metric SELECT latest(`oracledb.tablespace_size.usage`) WHERE metricName = 'oracledb.tablespace_size.usage' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb, tablespace_name"
               }
             ],
             "platformOptions": {
@@ -1345,7 +1345,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT average(`oracledb.storage.usage`) WHERE metricName = 'oracledb.storage.usage' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} TIMESERIES"
+                "query": "FROM Metric SELECT average(`oracledb.storage.usage`) WHERE metricName = 'oracledb.storage.usage' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -1370,7 +1370,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT average(`oracledb.storage.utilization`) WHERE metricName = 'oracledb.storage.utilization' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} TIMESERIES"
+                "query": "FROM Metric SELECT average(`oracledb.storage.utilization`) WHERE metricName = 'oracledb.storage.utilization' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -1395,7 +1395,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT latest(`oracledb.recycle_bin.limit`) WHERE metricName = 'oracledb.recycle_bin.limit' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}}"
+                "query": "FROM Metric SELECT latest(`oracledb.recycle_bin.limit`) WHERE metricName = 'oracledb.recycle_bin.limit' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name"
               }
             ],
             "platformOptions": {
@@ -1426,7 +1426,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.queries_parallelized`), 1 SECOND) WHERE metricName = 'oracledb.queries_parallelized' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.queries_parallelized`), 1 SECOND) WHERE metricName = 'oracledb.queries_parallelized' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -1451,7 +1451,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.ddl_statements_parallelized`), 1 SECOND) WHERE metricName = 'oracledb.ddl_statements_parallelized' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.ddl_statements_parallelized`), 1 SECOND) WHERE metricName = 'oracledb.ddl_statements_parallelized' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -1476,7 +1476,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.dml_statements_parallelized`), 1 SECOND) WHERE metricName = 'oracledb.dml_statements_parallelized' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.dml_statements_parallelized`), 1 SECOND) WHERE metricName = 'oracledb.dml_statements_parallelized' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -1501,7 +1501,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.parallel_operations_not_downgraded`), 1 SECOND) WHERE metricName = 'oracledb.parallel_operations_not_downgraded' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.parallel_operations_not_downgraded`), 1 SECOND) WHERE metricName = 'oracledb.parallel_operations_not_downgraded' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -1526,7 +1526,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.parallel_operations_downgraded_1_to_25_pct`), 1 SECOND) WHERE metricName = 'oracledb.parallel_operations_downgraded_1_to_25_pct' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.parallel_operations_downgraded_1_to_25_pct`), 1 SECOND) WHERE metricName = 'oracledb.parallel_operations_downgraded_1_to_25_pct' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -1551,7 +1551,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.parallel_operations_downgraded_25_to_50_pct`), 1 SECOND) WHERE metricName = 'oracledb.parallel_operations_downgraded_25_to_50_pct' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.parallel_operations_downgraded_25_to_50_pct`), 1 SECOND) WHERE metricName = 'oracledb.parallel_operations_downgraded_25_to_50_pct' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -1576,7 +1576,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.parallel_operations_downgraded_50_to_75_pct`), 1 SECOND) WHERE metricName = 'oracledb.parallel_operations_downgraded_50_to_75_pct' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.parallel_operations_downgraded_50_to_75_pct`), 1 SECOND) WHERE metricName = 'oracledb.parallel_operations_downgraded_50_to_75_pct' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -1601,7 +1601,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.parallel_operations_downgraded_75_to_99_pct`), 1 SECOND) WHERE metricName = 'oracledb.parallel_operations_downgraded_75_to_99_pct' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.parallel_operations_downgraded_75_to_99_pct`), 1 SECOND) WHERE metricName = 'oracledb.parallel_operations_downgraded_75_to_99_pct' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -1626,7 +1626,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT rate(sum(`oracledb.parallel_operations_downgraded_to_serial`), 1 SECOND) WHERE metricName = 'oracledb.parallel_operations_downgraded_to_serial' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT rate(sum(`oracledb.parallel_operations_downgraded_to_serial`), 1 SECOND) WHERE metricName = 'oracledb.parallel_operations_downgraded_to_serial' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -1657,7 +1657,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT average(`oracledb.redo_allocation.utilization`) WHERE metricName = 'oracledb.redo_allocation.utilization' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT average(`oracledb.redo_allocation.utilization`) WHERE metricName = 'oracledb.redo_allocation.utilization' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -1682,7 +1682,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT average(`oracledb.sort.ratio`) WHERE metricName = 'oracledb.sort.ratio' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT average(`oracledb.sort.ratio`) WHERE metricName = 'oracledb.sort.ratio' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -1713,7 +1713,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT average(`oracledb.sql_service.response.duration`) WHERE metricName = 'oracledb.sql_service.response.duration' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} FACET oracle.db.pdb TIMESERIES"
+                "query": "FROM Metric SELECT average(`oracledb.sql_service.response.duration`) WHERE metricName = 'oracledb.sql_service.response.duration' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name, oracle.db.pdb TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -1744,7 +1744,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT average(`system.cpu.physical.count`) WHERE metricName = 'system.cpu.physical.count' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}} TIMESERIES"
+                "query": "FROM Metric SELECT average(`system.cpu.physical.count`) WHERE metricName = 'system.cpu.physical.count' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name TIMESERIES"
               }
             ],
             "platformOptions": {
@@ -1769,7 +1769,7 @@
             "nrqlQueries": [
               {
                 "accountIds": [],
-                "query": "FROM Metric SELECT latest(`system.memory.limit`) WHERE metricName = 'system.memory.limit' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name = {{host_name}}"
+                "query": "FROM Metric SELECT latest(`system.memory.limit`) WHERE metricName = 'system.memory.limit' AND otel.library.name = 'github.com/newrelic-forks/opentelemetry-collector-contrib/receiver/nroracledbreceiver' AND host.name IN ({{host_name}}) FACET host.name"
               }
             ],
             "platformOptions": {


### PR DESCRIPTION
# Summary
                                                                                                                                           
  ### Oracle DB OTel Dashboard                                                                                                           
  - Replaced `host.name = {{host_name}}` with `host.name IN ({{host_name}})` across all 67 queries to enable proper multi-host filtering   
  - Added `FACET host.name` to all queries so charts segment by host when multiple instances are selected 

staging entity link:- https://staging.onenr.io/0qwyDM0VGQn                               
                                                                                                                                           
  ### SQL Server OTel Dashboard 
- Removed LIMIT MAX from the nrql queries                               

## Pre merge checklist

<!-- THIS CHECKLIST MUST BE FULLY COMPLETE OR YOUR PR WILL NOT BE MERGED -->

- [ ] Did you check you NRQL syntax? - Does it work?
- [ ] Did you include a Data source and Documentation reference?
- [ ] Are all documentation links publicly accessible?
- [ ] Did you check your descriptive content for [voice and tone](https://docs.newrelic.com/docs/style-guide/writing-strategies/voice-strategies-docs-sound-new-relic/)?
- [ ] Did you check your descriptive content for spelling and grammar errors?
- [ ] Did you review your content with a subject matter expert? (e.g. a Browser agent quickstart is reviewed with a member of the Browser Agent team)

### Dashboards

- [ ] Does the PR contain a screenshot for each of your dashboards?
- [ ] Do your screenshots show data?
- [ ] Has the [sanitization script](https://github.com/newrelic/newrelic-quickstarts/blob/main/CONTRIBUTING.md#dashboards) been run on each dashboard?

### Alerts

- [ ] Did you check that your alerts actually work?
- [ ] Are you trying to create standalone alerts? Standalone alerts are deprecated. They should only be included in quickstarts.
